### PR TITLE
Minor: self-signed certificates are now allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Every time  TelegramBot receives a message, it emits a `message`. Depending on w
 ## TelegramBot
 
 Both request method to obtain messages are implemented. To use standard polling, set `polling: true`
-on `options`. Notice that [webHook](https://core.telegram.org/bots/api#setwebhook) will need a valid (not self signed) SSL certificate.
+on `options`. Notice that [webHook](https://core.telegram.org/bots/api#setwebhook) will need a valid SSL certificate (self-signed certificates are allowed since August 29, 2015).
 Emits `message` when a message arrives.
 
 See: https://core.telegram.org/bots/api


### PR DESCRIPTION
According to Telegram Bot API [recent changes](https://core.telegram.org/bots/api#recent-changes):

```
August 29, 2015
Added support for self-signed certificates: upload your certificate using the
certificate parameter in the setWebhook method.
```