### PR TITLE
Added getFileLink method

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,4 +264,19 @@ See: https://core.telegram.org/bots/api#sendlocation
 
 * **Promise**
 
+## getFile(fileId)
+
+Get file.
+Use this method to get basic info about a file and prepare it for downloading.
+Attention: link will be valid for 1 hour.
+
+See: https://core.telegram.org/bots/api#getfile
+
+### Params:
+* **String** *fileId* File identifier to get info about
+
+### Return:
+
+* **Promise**
+
 <!-- End src/telegram.js -->

--- a/README.md
+++ b/README.md
@@ -279,4 +279,21 @@ See: https://core.telegram.org/bots/api#getfile
 
 * **Promise**
 
+## getFileLink(fileId)
+
+Get link for file.
+Use this method to get link for file for subsequent use.
+Attention: link will be valid for 1 hour.
+
+This method is a sugar extension of the (getFile)[#getfilefileid] method, which returns just path to file on remote server (you will have to manually build full uri after that).
+
+See: https://core.telegram.org/bots/api#getfile
+
+### Params:
+* **String** *fileId* File identifier to get info about
+
+### Return:
+
+* **Promise** *promise* Promise which will have *fileURI* in resolve callback
+
 <!-- End src/telegram.js -->

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -380,4 +380,20 @@ TelegramBot.prototype.sendLocation = function (chatId, latitude, longitude, opti
   return this._request('sendLocation', {qs: query});
 };
 
+/**
+ * Get file.
+ * Use this method to get basic info about a file and prepare it for downloading.
+ * Attention: link will be valid for 1 hour.
+ *
+ * @param  {String} fileId  File identifier to get info about
+ * @return {Promise}
+ * @see https://core.telegram.org/bots/api#getfile
+ */
+TelegramBot.prototype.getFile = function(fileId) {
+
+	var query = { file_id: fileId };
+
+	return this._request('getFile', {qs: query});
+};
+
 module.exports = TelegramBot;

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -73,11 +73,7 @@ TelegramBot.prototype._request = function (path, options) {
     throw new Error('Telegram Bot Token not provided!');
   }
   options = options || {};
-  options.url = URL.format({
-    protocol: 'https',
-    host: 'api.telegram.org',
-    pathname: '/bot'+this.token+'/'+path
-  });
+  options.url = this._buildURL(path);
   debug('HTTP request: %j', options);
   return requestPromise(options)
     .then(function (resp) {
@@ -92,6 +88,20 @@ TelegramBot.prototype._request = function (path, options) {
       }
     });
 };
+
+/**
+ * Generates url with bot token and provided path/method you want to be got/executed by bot
+ * @return {String} url
+ * @param {String} path
+ * @see https://core.telegram.org/bots/api#making-requests
+ */
+TelegramBot.prototype._buildURL = function(path) {
+	return URL.format({
+    protocol: 'https',
+    host: 'api.telegram.org',
+    pathname: '/bot' + this.token + '/' + path
+  });
+}
 
 /**
  * Returns basic information about the bot in form of a `User` object.
@@ -394,6 +404,34 @@ TelegramBot.prototype.getFile = function(fileId) {
 	var query = { file_id: fileId };
 
 	return this._request('getFile', {qs: query});
+};
+
+/**
+ * Get link for file.
+ * Use this method to get link for file for subsequent use.
+ * Attention: link will be valid for 1 hour.
+ *
+ * This method is a sugar extension of the (getFile)[#getfilefileid] method, which returns just path to file on remote server (you will have to manually build full uri after that).
+ *
+ * @param  {String} fileId  File identifier to get info about
+ * @return {Promise} promise Promise which will have *fileURI* in resolve callback
+ * @see https://core.telegram.org/bots/api#getfile
+ */
+TelegramBot.prototype.getFileLink = function(fileId) {
+
+	var bot = this;
+
+	return new Promise(function(resolve) {
+		bot.getFile(fileId).then(function(resp) {
+			var fileURI = URL.format({
+				protocol: 'https',
+				host: 'api.telegram.org',
+				pathname: '/file/bot' + bot.token + '/' + resp.file_path
+			});
+
+			resolve(fileURI);
+		})
+	});
 };
 
 module.exports = TelegramBot;

--- a/test/index.js
+++ b/test/index.js
@@ -394,6 +394,32 @@ describe('Telegram', function () {
     });
   });
 
+  describe('#getFileLink', function () {
+		var fileId;
+
+		// To get a file we have to send any file first
+    it('should send a photo from file', function (done) {
+      var bot = new Telegram(TOKEN);
+      var photo = __dirname + '/bot.gif';
+      bot.sendPhoto(USERID, photo).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        fileId = resp.photo[0].file_id;
+        done();
+      });
+    });
+
+    it('should get a file link', function (done) {
+
+      var bot = new Telegram(TOKEN);
+
+      bot.getFileLink(fileId).then(function (fileURI) {
+        fileURI.should.be.an.instanceOf(String);
+        fileURI.should.startWith('https');
+        done(); // TODO: validate URL with some library or regexp
+      });
+    });
+  });
+
 }); // End Telegram
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -368,6 +368,32 @@ describe('Telegram', function () {
     });
   });
 
+  describe('#getFile', function () {
+		var fileId;
+
+		// To get a file we have to send any file first
+    it('should send a photo from file', function (done) {
+      var bot = new Telegram(TOKEN);
+      var photo = __dirname + '/bot.gif';
+      bot.sendPhoto(USERID, photo).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        fileId = resp.photo[0].file_id;
+        done();
+      });
+    });
+
+    it('should get a file', function (done) {
+
+      var bot = new Telegram(TOKEN);
+
+      bot.getFile(fileId).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        resp.file_path.should.be.an.instanceOf(String);
+        done();
+      });
+    });
+  });
+
 }); // End Telegram
 
 


### PR DESCRIPTION
```getFile``` method is not sufficient and a little bit useless (it can give you just a part of the file url)
```getFileLink``` should be much more useful

If you'd like to accept this PR, you should accept that PR first: https://github.com/yagop/node-telegram-bot-api/pull/32