### PR TITLE
Added downloadFile sugar method

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,4 +264,19 @@ See: https://core.telegram.org/bots/api#sendlocation
 
 * **Promise**
 
+## getFile(fileId)
+
+Get file.
+Use this method to get basic info about a file and prepare it for downloading.
+Attention: link will be valid for 1 hour.
+
+See: https://core.telegram.org/bots/api#getfile
+
+### Params:
+* **String** *fileId* File identifier to get info about
+
+### Return:
+
+* **Promise**
+
 <!-- End src/telegram.js -->

--- a/README.md
+++ b/README.md
@@ -279,4 +279,21 @@ See: https://core.telegram.org/bots/api#getfile
 
 * **Promise**
 
+## getFileLink(fileId)
+
+Get link for file.
+Use this method to get link for file for subsequent use.
+Attention: link will be valid for 1 hour.
+
+This method is a sugar extension of the (getFile)[#getfilefileid] method, which returns just path to file on remote server (you will have to manually build full uri after that).
+
+See: https://core.telegram.org/bots/api#getfile
+
+### Params:
+* **String** *fileId* File identifier to get info about
+
+### Return:
+
+* **Promise** *promise* Promise which will have *fileURI* in resolve callback
+
 <!-- End src/telegram.js -->

--- a/README.md
+++ b/README.md
@@ -296,4 +296,17 @@ See: https://core.telegram.org/bots/api#getfile
 
 * **Promise** *promise* Promise which will have *fileURI* in resolve callback
 
+## downloadFile(fileId, downloadDir)
+
+Downloads file in the specified folder.
+This is just a sugar for (getFile)[#getfilefiled] method
+
+### Params:
+* **String** *fileId* File identifier to get info about
+* **String** *downloadDir* Absolute path to the folder in which file will be saved
+
+### Return:
+
+* **Promise** *promise* Promise, which will have *filePath* of downloaded file in resolve callback
+
 <!-- End src/telegram.js -->

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
+    "del": "^2.0.2",
     "istanbul": "^0.3.17",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "0.0.2",

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -380,4 +380,20 @@ TelegramBot.prototype.sendLocation = function (chatId, latitude, longitude, opti
   return this._request('sendLocation', {qs: query});
 };
 
+/**
+ * Get file.
+ * Use this method to get basic info about a file and prepare it for downloading.
+ * Attention: link will be valid for 1 hour.
+ *
+ * @param  {String} fileId  File identifier to get info about
+ * @return {Promise}
+ * @see https://core.telegram.org/bots/api#getfile
+ */
+TelegramBot.prototype.getFile = function(fileId) {
+
+	var query = { file_id: fileId };
+
+	return this._request('getFile', {qs: query});
+};
+
 module.exports = TelegramBot;

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -73,11 +73,7 @@ TelegramBot.prototype._request = function (path, options) {
     throw new Error('Telegram Bot Token not provided!');
   }
   options = options || {};
-  options.url = URL.format({
-    protocol: 'https',
-    host: 'api.telegram.org',
-    pathname: '/bot'+this.token+'/'+path
-  });
+  options.url = this._buildURL(path);
   debug('HTTP request: %j', options);
   return requestPromise(options)
     .then(function (resp) {
@@ -92,6 +88,20 @@ TelegramBot.prototype._request = function (path, options) {
       }
     });
 };
+
+/**
+ * Generates url with bot token and provided path/method you want to be got/executed by bot
+ * @return {String} url
+ * @param {String} path
+ * @see https://core.telegram.org/bots/api#making-requests
+ */
+TelegramBot.prototype._buildURL = function(path) {
+	return URL.format({
+    protocol: 'https',
+    host: 'api.telegram.org',
+    pathname: '/bot' + this.token + '/' + path
+  });
+}
 
 /**
  * Returns basic information about the bot in form of a `User` object.
@@ -394,6 +404,34 @@ TelegramBot.prototype.getFile = function(fileId) {
 	var query = { file_id: fileId };
 
 	return this._request('getFile', {qs: query});
+};
+
+/**
+ * Get link for file.
+ * Use this method to get link for file for subsequent use.
+ * Attention: link will be valid for 1 hour.
+ *
+ * This method is a sugar extension of the (getFile)[#getfilefileid] method, which returns just path to file on remote server (you will have to manually build full uri after that).
+ *
+ * @param  {String} fileId  File identifier to get info about
+ * @return {Promise} promise Promise which will have *fileURI* in resolve callback
+ * @see https://core.telegram.org/bots/api#getfile
+ */
+TelegramBot.prototype.getFileLink = function(fileId) {
+
+	var bot = this;
+
+	return new Promise(function(resolve) {
+		bot.getFile(fileId).then(function(resp) {
+			var fileURI = URL.format({
+				protocol: 'https',
+				host: 'api.telegram.org',
+				pathname: '/file/bot' + bot.token + '/' + resp.file_path
+			});
+
+			resolve(fileURI);
+		})
+	});
 };
 
 module.exports = TelegramBot;

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -434,4 +434,33 @@ TelegramBot.prototype.getFileLink = function(fileId) {
 	});
 };
 
+/**
+ * Downloads file in the specified folder.
+ * This is just a sugar for (getFile)[#getfilefiled] method
+ *
+ * @param  {String} fileId  File identifier to get info about
+ * @param  {String} downloadDir Absolute path to the folder in which file will be saved
+ * @return {Promise} promise Promise, which will have *filePath* of downloaded file in resolve callback
+ */
+TelegramBot.prototype.downloadFile = function(fileId, downloadDir) {
+
+	var bot = this;
+
+	return new Promise(function(resolve, reject) {
+		
+		bot.getFileLink(fileId).then(function(fileURI) {
+			// Apparently, this is not the safest method to get the file name,
+			// but I am pretty sure that Telegram will not include slashes when generating names
+			var fileName = fileURI.slice(fileURI.lastIndexOf('/') + 1);
+			var filePath = downloadDir + '/' + fileName;
+
+			request({uri: fileURI})
+				.pipe(fs.createWriteStream(filePath))
+				.on('close', function() {
+					resolve(filePath);
+				});
+		});		
+	});
+}
+
 module.exports = TelegramBot;

--- a/test/index.js
+++ b/test/index.js
@@ -394,6 +394,32 @@ describe('Telegram', function () {
     });
   });
 
+  describe('#getFileLink', function () {
+		var fileId;
+
+		// To get a file we have to send any file first
+    it('should send a photo from file', function (done) {
+      var bot = new Telegram(TOKEN);
+      var photo = __dirname + '/bot.gif';
+      bot.sendPhoto(USERID, photo).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        fileId = resp.photo[0].file_id;
+        done();
+      });
+    });
+
+    it('should get a file link', function (done) {
+
+      var bot = new Telegram(TOKEN);
+
+      bot.getFileLink(fileId).then(function (fileURI) {
+        fileURI.should.be.an.instanceOf(String);
+        fileURI.should.startWith('https');
+        done(); // TODO: validate URL with some library or regexp
+      });
+    });
+  });
+
 }); // End Telegram
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -368,6 +368,32 @@ describe('Telegram', function () {
     });
   });
 
+  describe('#getFile', function () {
+		var fileId;
+
+		// To get a file we have to send any file first
+    it('should send a photo from file', function (done) {
+      var bot = new Telegram(TOKEN);
+      var photo = __dirname + '/bot.gif';
+      bot.sendPhoto(USERID, photo).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        fileId = resp.photo[0].file_id;
+        done();
+      });
+    });
+
+    it('should get a file', function (done) {
+
+      var bot = new Telegram(TOKEN);
+
+      bot.getFile(fileId).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        resp.file_path.should.be.an.instanceOf(String);
+        done();
+      });
+    });
+  });
+
 }); // End Telegram
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@ var TelegramPolling = require('../src/telegramPolling');
 var Telegram = require('../index');
 var request = require('request');
 var should = require('should');
+var del = require('del');
 var fs = require('fs');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
@@ -419,6 +420,38 @@ describe('Telegram', function () {
       });
     });
   });
+
+  describe('#downloadFile', function () {
+
+  	var fileId;
+  	var downloadPath = __dirname;
+
+  	// To get a file we have to send some file first
+    it('should send a photo from file', function (done) {
+
+      var bot = new Telegram(TOKEN);
+      var photo = __dirname + '/bot.gif';
+
+      bot.sendPhoto(USERID, photo).then(function (resp) {
+        resp.should.be.an.instanceOf(Object);
+        fileId = resp.photo[0].file_id;
+        done();
+      });
+    });
+
+    it('should download a file', function (done) {
+
+      var bot = new Telegram(TOKEN);
+
+      bot.downloadFile(fileId, downloadPath).then(function (filePath) {
+        filePath.should.be.an.instanceOf(String);
+        fs.existsSync(filePath).should.be.true();
+        del(filePath); // Clean folder after test
+        done();
+      });
+    });
+  });
+
 
 }); // End Telegram
 

--- a/test/index.js
+++ b/test/index.js
@@ -370,9 +370,9 @@ describe('Telegram', function () {
   });
 
   describe('#getFile', function () {
-		var fileId;
+	var fileId;
 
-		// To get a file we have to send any file first
+	// To get a file we have to send any file first
     it('should send a photo from file', function (done) {
       var bot = new Telegram(TOKEN);
       var photo = __dirname + '/bot.gif';
@@ -396,9 +396,9 @@ describe('Telegram', function () {
   });
 
   describe('#getFileLink', function () {
-		var fileId;
+	var fileId;
 
-		// To get a file we have to send any file first
+	// To get a file we have to send any file first
     it('should send a photo from file', function (done) {
       var bot = new Telegram(TOKEN);
       var photo = __dirname + '/bot.gif';


### PR DESCRIPTION
I think, this lib should has some sugar methods and downloading file by file_id is just musthave (I can't imagine a lot of other use cases for ```getFile``` api method.

BTW, [python's most popular telegram api lib](https://github.com/leandrotoledo/python-telegram-bot#api)  has such kind of functional

P.S. If you'd like to accept this PR, i think you should accept that PR first: https://github.com/yagop/node-telegram-bot-api/pull/33

~~P.P.S. Aligning has broken on several lines. I will fix it a little bit later, fixing it now is a pain for me, sry.~~ Fixed