### PR TITLE
allow 0ms for polling interval

### DIFF
--- a/src/telegramPolling.js
+++ b/src/telegramPolling.js
@@ -17,7 +17,7 @@ var TelegramBotPolling = function (token, options, callback) {
   this.token = token;
   this.callback = callback;
   this.timeout = options.timeout || 0;
-  this.interval = options.interval || 2000;
+  this.interval = (typeof options.interval === 'number') ? options.interval : 2000;
   this.lastUpdate = 0;
   this.lastRequest = null;
   this.abort = false;


### PR DESCRIPTION
fixes #20. thanks!!

by the way, i'm seeing a lot of tests fail locally due to `PEER_ID_INVALID`. it looks like i should probably set a `TEST_USER_ID`, but i'm not sure where to get that value from. thanks again