### PR TITLE
Add filename parsing

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -98,6 +98,13 @@ TelegramBot.prototype._request = function (path, options) {
   options = options || {};
   options.url = this._buildURL(path);
   debug('HTTP request: %j', options);
+  // Parse filename from stream for photo and document
+  if ( options.formData && ( options.formData.photo || options.formData.document  )) {
+    var obj = (options.formData.photo) ? options.formData.photo : options.formData.document;
+    var fileName = obj.value.req.path.split('/').pop();
+
+    obj.options.filename = fileName;
+  }
   return requestPromise(options)
     .then(function (resp) {
       if (resp[0].statusCode !== 200) {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -98,13 +98,6 @@ TelegramBot.prototype._request = function (path, options) {
   options = options || {};
   options.url = this._buildURL(path);
   debug('HTTP request: %j', options);
-  // Parse filename from stream for photo and document
-  if ( options.formData && ( options.formData.photo || options.formData.document  )) {
-    var obj = (options.formData.photo) ? options.formData.photo : options.formData.document;
-    var fileName = obj.value.req.path.split('/').pop();
-
-    obj.options.filename = fileName;
-  }
   return requestPromise(options)
     .then(function (resp) {
       if (resp[0].statusCode !== 200) {
@@ -228,6 +221,9 @@ TelegramBot.prototype._formatSendData = function (type, data) {
   var fileId;
   if (data instanceof stream.Stream) {
     fileName = URL.parse(path.basename(data.path)).pathname;
+    if (fileName == 'undefined') {
+      fileName = path.basename(data.req.path);
+    }
     formData = {};
     formData[type] = {
       value: data,


### PR DESCRIPTION
Parsing filename from remote files stream let show right name in message. For example 'cat.gif' instead 'undefined', and telegram show preview for img in case if we read stream by url.
