### PR TITLE
Automatically JSON.stringify keyboard markup

### DIFF
--- a/examples/polling.js
+++ b/examples/polling.js
@@ -39,11 +39,11 @@ bot.onText(/\/love/, function (msg) {
   var chatId = msg.chat.id;
   var opts = {
       reply_to_message_id: msg.message_id,
-      reply_markup: JSON.stringify({
+      reply_markup: {
         keyboard: [
           ['Yes, you are the bot of my life ❤'],
           ['No, sorry there is another one...']]
-      })
+      }
     };
     bot.sendMessage(chatId, 'Do you love me?', opts);
 });

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -200,6 +200,9 @@ TelegramBot.prototype.getUpdates = function (timeout, limit, offset) {
  */
 TelegramBot.prototype.sendMessage = function (chatId, text, options) {
   var form = options || {};
+  if (form.reply_markup instanceof Object) {
+    form.reply_markup = JSON.stringify(form.reply_markup);
+  }
   form.chat_id = chatId;
   form.text = text;
   return this._request('sendMessage', {form: form});


### PR DESCRIPTION
I noticed that you currently have to manually call JSON.stringify on your keyboard markup when you need one.
This automatically calls JSON.stringify on the keyboard_markup option if it specified and was not already stringified