### PR TITLE
Add `stopPolling` method

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -67,6 +67,14 @@ class TelegramBot extends EventEmitter {
     this._polling = new TelegramBotPolling(this.token, this.options.polling, this.processUpdate.bind(this));
   }
 
+  stopPolling() {
+    if (this._polling) {
+      this._polling.abort = true;
+      this._polling.lastRequest.cancel('Stop polling');
+    }
+    this._polling = null;
+  }
+
   processUpdate(update) {
     debug('Process Update %j', update);
     const message = update.message;


### PR DESCRIPTION
usage:
```js
var bot = new TelegramBot(token, {});

bot.initPolling(); // polling started

bot.initPolling(); // polling restart

bot.stopPolling(); // new method: polling stoped
```