### PR TITLE
Added `removeReplyListener` as the counterpart for `onReplyToMessage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,4 +354,16 @@ Register a reply to wait for a message response.
 | messageId | <code>Number</code> &#124; <code>String</code> | The message id to be replied. |
 | callback | <code>function</code> | Callback will be called with the reply  message. |
 
+
+<a name="TelegramBot+removeReplyListener"></a>
+### telegramBot.removeReplyListener(chatId, messageId)
+Removes a callback for a message reply previously registered using <code>[onReplyToMessage](#TelegramBot+onReplyToMessage)</code>.
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> &#124; <code>String</code> | The chat id the callback was registered for. |
+| messageId | <code>Number</code> &#124; <code>String</code> | The message id that the callback was registered for. |
+
 * * *

--- a/README.md
+++ b/README.md
@@ -356,14 +356,13 @@ Register a reply to wait for a message response.
 
 
 <a name="TelegramBot+removeReplyListener"></a>
-### telegramBot.removeReplyListener(chatId, messageId)
+### telegramBot.removeReplyListener(replyToMessageId)
 Removes a callback for a message reply previously registered using <code>[onReplyToMessage](#TelegramBot+onReplyToMessage)</code>.
 
 **Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| chatId | <code>Number</code> &#124; <code>String</code> | The chat id the callback was registered for. |
-| messageId | <code>Number</code> &#124; <code>String</code> | The message id that the callback was registered for. |
+| replyToMessageId | <code>Number</code> &#124; <code>String</code> | The id of the registered onReplyToMessages instance. This id is returned by onReplyToMessage. |
 
 * * *

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -107,7 +107,7 @@ TelegramBot.prototype._processUpdate = function (update) {
           // Responding to that message
           if (reply.messageId === message.reply_to_message.message_id) {
             // Resolve the promise
-            reply.callback(reply.id);
+            reply.callback(message);
           }
         }
       });
@@ -573,17 +573,19 @@ TelegramBot.prototype.onText = function (regexp, callback) {
  * Register a reply to wait for a message response.
  * @param  {Number|String}   chatId       The chat id where the message cames from.
  * @param  {Number|String}   messageId    The message id to be replied.
- * @param  {Function} callback     Callback will be called with the reply 
+ * @param  {Function} callback      Callback will be called with the reply 
+ * @return {Number} newId           The id of the onReplyToMessages object.
  * message.
  */
 TelegramBot.prototype.onReplyToMessage = function (chatId, messageId, callback) {
-  var newId = newReplyId();
+  var newId = this.newReplyId();
   this.onReplyToMessages.push({
     id: newId,
     chatId: chatId,
     messageId: messageId,
     callback: callback
   });
+  return newId;
 };
 
 /**
@@ -605,7 +607,7 @@ TelegramBot.prototype.removeReplyListener = function (replyId) {
   if (index === -1) {
     return null;
   }
-  var removedListener = this.onReplyToMessages.splice(index);
+  var removedListener = this.onReplyToMessages.splice(index, 1);
   return removedListener;
 }
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -570,16 +570,6 @@ TelegramBot.prototype.onText = function (regexp, callback) {
 };
 
 /**
- * Id generator for use in TelegramBot.onReplyToMessage() and
- * .removeReplyListener().
- * NOT a member of TelegramBot.
- */
-var i=0;
-function newId() {
-  return i++;
-}
-
-/**
  * Register a reply to wait for a message response.
  * @param  {Number|String}   chatId       The chat id where the message cames from.
  * @param  {Number|String}   messageId    The message id to be replied.

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -588,6 +588,7 @@ TelegramBot.prototype.onReplyToMessage = function (chatId, messageId, callback) 
 TelegramBot.prototype.removeReplyListener = function (chatId, messageId) {
   var index = -1;
   for (var i=0; i<this.onReplyToMessages.length; ++i) {
+    var reply = this.onReplyToMessages[i];
     if ((reply.chatId === chatId) && (reply.messageId === messageId)) {
       index = i;
       break;

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -578,4 +578,26 @@ TelegramBot.prototype.onReplyToMessage = function (chatId, messageId, callback) 
   });
 };
 
+/**
+ * Removes a reply that has been prev. registered for a message response.
+ * @param   {Number|String}   chatId      The chat id that the reply is awaited from
+ * @param   {Number|String}   messageId   The message_id of the msg to which a reply waited for
+ * @return  {Object}    deletedListener   Returns the deleted listener if one
+ * matched the params, otherwise returns null
+ */
+TelegramBot.prototype.removeReplyListener = function (chatId, messageId) {
+  var index = -1;
+  for (var i=0; i<this.onReplyToMessages.length; ++i) {
+    if ((reply.chatId === chatId) && (reply.messageId === messageId)) {
+      index = i;
+      break;
+    }
+  }
+  if (index === -1) {
+    return null;
+  }
+  var removedListener = this.onReplyToMessages.splice(index);
+  return removedListener;
+}
+
 module.exports = TelegramBot;


### PR DESCRIPTION
Adds the function `removeReplyListener` to `TelegramBot`, which removes a previously registered callback (created using `onReplyToMessage`).
This way the developer can make sure his application does not retain unnecessary callback functions in the `onReplyToMessages` array in his `TelegramBot` instance.
Also, if so desired, this can be used to easily ensure, that only on response to a message will be processed, as shown in the following short code snippet:

```
// bot is an instance of TelegramBot
bot.sendMessage(someChatId, someMessage, someOpts)
  .then(function(sentMsg) {
    bot.onReplyToMessage(sentMsg.chat.id, sentMsg.message_id, function(reply) {
      if (isValidReply(reply) {
        // do something ... and:
        removeReplyListener(sentMsg.chat.id, sentMsg.message_id);
      }
    });
  });
```
