### PR TITLE
URL-decoded filename when sending file from stream

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -277,7 +277,7 @@ TelegramBot.prototype._formatSendData = function (type, data) {
     formData[type] = {
       value: data,
       options: {
-        filename: fileName,
+        filename: decodeURIComponent(fileName),
         contentType: mime.lookup(fileName)
       }
     };

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -7,6 +7,7 @@ var EventEmitter = require('events').EventEmitter;
 var fileType = require('file-type');
 var Promise = require('bluebird');
 var request = require('request');
+var qs = require('querystring');
 var stream = require('stream');
 var util = require('util');
 var mime = require('mime');

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -277,7 +277,7 @@ TelegramBot.prototype._formatSendData = function (type, data) {
     formData[type] = {
       value: data,
       options: {
-        filename: decodeURIComponent(fileName),
+        filename: qs.unescape(fileName),
         contentType: mime.lookup(fileName)
       }
     };


### PR DESCRIPTION
This sends the file as "My File.ext" instead of "My%20File.ext".