### PR TITLE
Fixes stream end event never being called

### DIFF
--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -71,7 +71,7 @@ class TelegramBotWebHook {
     } else if (req.method === 'POST') {
       req
         .pipe(bl(this._parseBody))
-        .on('end', () => res.end('OK'));
+        .on('finish', () => res.end('OK'));
     } else {
       // Authorized but not a POST
       debug('WebHook request isn\'t a POST');


### PR DESCRIPTION
For [writable streams](https://nodejs.org/api/stream.html#stream_class_stream_writable), like [http.ClientRequest](https://nodejs.org/api/http.html#http_class_http_clientrequest), there is no `end` event, only `finish`. Thus, `req.end` is never called and never sending a response.

This results in a nasty bug for WebHook users that basically renders the library useless because if Telegram doesn't receive a response from the bot server, it will continue to queue and send requests until it does, or until 24 hours have passed. This means, if you are responding to a message, your bot will send the response over and over and over until you either kill it or the 24 hours are up.