### PR TITLE
add the sendVenue method

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -490,6 +490,28 @@ class TelegramBot extends EventEmitter {
     form.longitude = longitude;
     return this._request('sendLocation', { form });
   }
+  
+  /**
+   * Send venue.
+   * Use this method to send information about a venue.
+   *
+   * @param  {Number|String} chatId  Unique identifier for the message recipient
+   * @param  {Float} latitude Latitude of location
+   * @param  {Float} longitude Longitude of location
+   * @param  {String} title Name of the venue
+   * @param  {String} address Address of the venue
+   * @param  {Object} [options] Additional Telegram query options
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#sendvenue
+   */
+  sendVenue(chatId, latitude, longitude, title, address, form = {}) {
+    form.chat_id = chatId;
+    form.latitude = latitude;
+    form.longitude = longitude;
+    form.title = title;
+    form.address = address;
+    return this._request('sendVenue', { form });
+  }
 
   /**
    * Get file.

--- a/test/index.js
+++ b/test/index.js
@@ -394,6 +394,24 @@ describe('Telegram', function telegramSuite() {
       });
     });
   });
+  
+  describe('#sendVenue', function sendVenueSuite() {
+    it('should send a venue', function test() {
+      const bot = new Telegram(TOKEN);
+      const lat = 47.5351072;
+      const long = -52.7508537;
+      const title = `The Village Shopping Centre`;
+      const address = `430 Topsail Rd,St. John's, NL A1E 4N1, Canada`;
+      return bot.sendVenue(USERID, lat, long, title, address).then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.object(resp.location));
+        assert.ok(is.number(resp.location.latitude));
+        assert.ok(is.number(resp.location.longitude));
+        assert.ok(is.string(resp.title));
+        assert.ok(is.string(resp.address));
+      });
+    });
+  });
 
   describe('#getFile', function getFileSuite() {
     let fileId;


### PR DESCRIPTION
This pull request adds the method and test for sendVenue. This method was added to the Telegram Bot API on April 9, 2016 in the Bot API 2.0 update. See https://core.telegram.org/bots/api#sendvenue for more info.

I did this blindly in GitHub because the change seems simple enough. I did briefly test it live in my Telegram bot and it sent the venue correctly.

I attached a screenshot of how the venue looks in the iOS client:
![img_0885](https://cloud.githubusercontent.com/assets/11628889/15082189/1f2d2622-13cf-11e6-8892-d92ba4c02102.png)
