### PR TITLE
Proxy extra request options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "eventemitter3": "^1.2.0",
+    "extend": "^3.0.0",
     "file-type": "^3.8.0",
     "mime": "^1.3.4",
     "pump": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "eventemitter3": "^1.2.0",
-    "extend": "^3.0.0",
     "file-type": "^3.8.0",
     "mime": "^1.3.4",
     "pump": "^1.0.1",

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -13,6 +13,7 @@ const path = require('path');
 const URL = require('url');
 const fs = require('fs');
 const pump = require('pump');
+const extend = require('extend');
 
 const _messageTypes = [
   'text', 'audio', 'document', 'photo', 'sticker', 'video', 'voice', 'contact',
@@ -42,6 +43,7 @@ class TelegramBot extends EventEmitter {
    * @param {String} [options.webHook.key] PEM private key to webHook server.
    * @param {String} [options.webHook.cert] PEM certificate (public) to webHook server.
    * @param {Boolean} [options.onlyFirstMatch=false] Set to true to stop after first match. Otherwise, all regexps are executed
+   * @param {Object} [options.request] Options which will be added for all requests to telegram api.
    * @see https://core.telegram.org/bots/api
    */
   constructor(token, options = {}) {
@@ -166,6 +168,10 @@ class TelegramBot extends EventEmitter {
   _request(_path, options = {}) {
     if (!this.token) {
       throw new Error('Telegram Bot Token not provided!');
+    }
+
+    if (this.options.request) {
+      extend(true, options, this.options.request);
     }
 
     if (options.form) {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -13,7 +13,6 @@ const path = require('path');
 const URL = require('url');
 const fs = require('fs');
 const pump = require('pump');
-const extend = require('extend');
 
 const _messageTypes = [
   'text', 'audio', 'document', 'photo', 'sticker', 'video', 'voice', 'contact',
@@ -171,7 +170,7 @@ class TelegramBot extends EventEmitter {
     }
 
     if (this.options.request) {
-      extend(true, options, this.options.request);
+      Object.assign(options, this.options.request);
     }
 
     if (options.form) {


### PR DESCRIPTION
I have a server which has only ipv6 access to api.telegram.org. So, I must pass `family: 6` option for each request to telegram api.

It would be great to add an extra option to TelegramBot constructor which makes it possible.

@yagop what do you think?
