### PR TITLE
Add edited_message event

### DIFF
--- a/README.hbs
+++ b/README.hbs
@@ -32,8 +32,8 @@ bot.on('message', function (msg) {
 There are some other examples on [examples](https://github.com/yagop/node-telegram-bot-api/tree/master/examples).
 
 ### Events
-Every time TelegramBot receives a message, it emits a `message`. Depending on which  [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. Its much better to listen a specific event rather than a `message` in order to stay safe from the content.
-TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode)
+Every time TelegramBot receives a message, it emits a `message`. Depending on which [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. It's much better to listen a specific event rather than a `message` in order to stay safe from the content.
+TelegramBot also emits `edited_message` when a message is edited, `inline_query` when it receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when it receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode).
 * * *
 
 ### WebHooks

--- a/README.hbs
+++ b/README.hbs
@@ -33,7 +33,10 @@ There are some other examples on [examples](https://github.com/yagop/node-telegr
 
 ### Events
 Every time TelegramBot receives a message, it emits a `message`. Depending on which [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. It's much better to listen a specific event rather than a `message` in order to stay safe from the content.
-TelegramBot also emits `edited_message` when a message is edited, `inline_query` when it receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when it receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode).
+TelegramBot also emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type 
+of message was edited. 
+If [inline mode](https://core.telegram.org/bots/api#inline-mode) is enabled, it will emit `inline_query` when it receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when it receives a 
+[ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult).
 * * *
 
 ### WebHooks

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ bot.on('message', function (msg) {
 There are some other examples on [examples](https://github.com/yagop/node-telegram-bot-api/tree/master/examples).
 
 ### Events
-Every time TelegramBot receives a message, it emits a `message`. Depending on which  [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. Its much better to listen a specific event rather than a `message` in order to stay safe from the content.
-TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode)
+Every time TelegramBot receives a message, it emits a `message`. Depending on which [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. It's much better to listen a specific event rather than a `message` in order to stay safe from the content.
+TelegramBot also emits `edited_message` when a message is edited, `inline_query` when it receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when it receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode).
 * * *
 
 ### WebHooks

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ There are some other examples on [examples](https://github.com/yagop/node-telegr
 
 ### Events
 Every time TelegramBot receives a message, it emits a `message`. Depending on which [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. It's much better to listen a specific event rather than a `message` in order to stay safe from the content.
-TelegramBot also emits `edited_message` when a message is edited, `inline_query` when it receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when it receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode).
+TelegramBot also emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type 
+of message was edited. 
+If [inline mode](https://core.telegram.org/bots/api#inline-mode) is enabled, it will emit `inline_query` when it receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when it receives a 
+[ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult).
 * * *
 
 ### WebHooks

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -124,6 +124,12 @@ class TelegramBot extends EventEmitter {
     } else if (editedMessage) {
       debug('Process Update edited_message %j', editedMessage);
       this.emit('edited_message', editedMessage);
+      if (editedMessage.text) {
+        this.emit('edited_message_text', editedMessage);
+      }
+      if (editedMessage.caption) {
+        this.emit('edited_message_caption', editedMessage);
+      }
     } else if (inlineQuery) {
       debug('Process Update inline_query %j', inlineQuery);
       this.emit('inline_query', inlineQuery);

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -82,6 +82,7 @@ class TelegramBot extends EventEmitter {
   processUpdate(update) {
     debug('Process Update %j', update);
     const message = update.message;
+    const editedMessage = update.edited_message;
     const inlineQuery = update.inline_query;
     const chosenInlineResult = update.chosen_inline_result;
     const callbackQuery = update.callback_query;
@@ -120,6 +121,9 @@ class TelegramBot extends EventEmitter {
           }
         });
       }
+    } else if (editedMessage) {
+      debug('Process Update edited_message %j', editedMessage);
+      this.emit('edited_message', editedMessage);
     } else if (inlineQuery) {
       debug('Process Update inline_query %j', inlineQuery);
       this.emit('inline_query', inlineQuery);


### PR DESCRIPTION
Adds support for the `edited_message` parameter in Updates.
Emits an `edited_message` event when a message is edited, and also two specific events, `edited_message_text` and `edited_message_caption`, depending on the type of the message.