### PR TITLE
Fix handling fs.readStream.path if it's a buffer

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -294,7 +294,7 @@ class TelegramBot extends EventEmitter {
     let fileName;
     let fileId;
     if (data instanceof stream.Stream) {
-      fileName = URL.parse(path.basename(data.path)).pathname;
+      fileName = URL.parse(path.basename(data.path.toString())).pathname;
       formData = {};
       formData[type] = {
         value: data,

--- a/test/index.js
+++ b/test/index.js
@@ -162,6 +162,16 @@ describe('Telegram', function telegramSuite() {
     });
   });
 
+  describe('#_formatSendData', function _formatSendData() {
+    it('should handle buffer path from fs.readStream', function test() {
+      const bot = new Telegram(TOKEN);
+      const photo = fs.createReadStream(Buffer.from(`${__dirname}/bot.gif`));
+      return bot.sendPhoto(USERID, photo).then(resp => {
+        assert.ok(is.object(resp));
+      });
+    });
+  });
+
   describe('#sendPhoto', function sendPhotoSuite() {
     let photoId;
     it('should send a photo from file', function test() {


### PR DESCRIPTION
**Bug:**

The (private) method TelegramBot#_formatSendData(), used by public
  methods, such as TelegramBot#sendPhoto(), throws an error
  if the stream passed (fs.readStream) has the property 'path',
  being an instance of Buffer.

For example,

```js
const stream = fs.createReadStream(Buffer.from('cat.png'));
Buffer.isBuffer(stream.path); // true
bot.sendPhoto(chatId, stream);
```

Would throw an error, like

```txt
TypeError: Path must be a string. Received <Buffer 60 62 63 64>
```

This is because of this line ([src/telegram.js:297](https://github.com/yagop/node-telegram-bot-api/blob/e0e5e9a7b0cbf823e008704b76d614e5da6e2922/src/telegram.js#L297)):

```js
fileName = URL.parse(path.basename(data.path)).pathname;
```

`path.basename()` can not handle buffer (non-string) paths. From the docs, ["A TypeError is thrown if path is not a string..."](https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext).

**Fix:**

Ensure `path.basename()` receives a string, by converting the buffer to string.

**References:**

* fs.ReadStream.path: https://nodejs.org/docs/latest/api/fs.html#fs_class_fs_readstream#fs_readstream_path
* path.basename(): https://nodejs.org/docs/latest/api/path.html#path_path_basename_path_ext