### PR TITLE
Add option to ignore further regexes after match is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Emits `message` when a message arrives.
 | [options.webHook] | <code>Boolean</code> &#124; <code>Object</code> | <code>false</code> | Set true to enable WebHook or set options |
 | [options.webHook.key] | <code>String</code> |  | PEM private key to webHook server. |
 | [options.webHook.cert] | <code>String</code> |  | PEM certificate (public) to webHook server. |
+| [options.onlyFirstMatch] | <code>Boolean</code> | <code>false</code> | false: try matching all regexps; true: stop after first match |
 
 <a name="TelegramBot+stopPolling"></a>
 
@@ -537,7 +538,7 @@ username of a user, group or channel, etc.).
 
 | Param | Type | Description |
 | --- | --- | --- |
-| chatId | <code>Number</code> &#124; <code>String</code> | Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername) |
+| chatId | <code>Number</code> &#124; <code>String</code> | Unique identifier for the target chat or username of the target supergroup or channel |
 
 <a name="TelegramBot+getChatAdministrators"></a>
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -41,6 +41,7 @@ class TelegramBot extends EventEmitter {
    * @param {Boolean|Object} [options.webHook=false] Set true to enable WebHook or set options
    * @param {String} [options.webHook.key] PEM private key to webHook server.
    * @param {String} [options.webHook.cert] PEM certificate (public) to webHook server.
+   * @param {Boolean} [options.onlyFirstMatch=false] Set to true to stop after first match. Otherwise, all regexps are executed
    * @see https://core.telegram.org/bots/api
    */
   constructor(token, options = {}) {
@@ -99,12 +100,14 @@ class TelegramBot extends EventEmitter {
       TelegramBot.messageTypes.forEach(processMessageType);
       if (message.text) {
         debug('Text message');
-        this.textRegexpCallbacks.forEach(reg => {
+        this.textRegexpCallbacks.some(reg => {
           debug('Matching %s whith', message.text, reg.regexp);
           const result = reg.regexp.exec(message.text);
           if (result) {
             debug('Matches', reg.regexp);
             reg.callback(message, result);
+            // returning truthy value exits .some
+            return this.options.onlyFirstMatch;
           }
         });
       }


### PR DESCRIPTION
By default,  all regexes registered via `onText` are tried and in case of match callbacks are called, even if match is already found, which can cause one message to be processed multiple times.

I added `onlyFirstMatch` option which, as the name suggests, causes the bot to ignore further regexes after match is found.

It also enables people to add `.onText(/(?:)/, ...)` or something like that to handle the messages which were not matched by any regex.

I did not change existing behavior, you need to opt-in.

That's my first pull request, so I appreciate any hints you could give me.
