### PR TITLE
New Update Fields From API v2.3

### DIFF
--- a/README.hbs
+++ b/README.hbs
@@ -43,8 +43,8 @@ There are some other examples on [examples](https://github.com/yagop/node-telegr
 ### Events
 Every time TelegramBot receives a message, it emits a `message`. Depending on which  [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. Its much better to listen a specific event rather than a `message` in order to stay safe from the content.
 TelegramBot emits `callback_query` when receives a [Callback Query](https://core.telegram.org/bots/api#callbackquery).
-TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode)
-TelegramBot emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type of message was edited.
+TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode).
+TelegramBot emits `channel_post` on a new incoming channel post of any kind and also `channel_post_edited` when a channel post text or caption is edited. TelegramBot emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type of message was edited.
 * * *
 
 ### WebHooks

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are some other examples on [examples](https://github.com/yagop/node-telegr
 Every time TelegramBot receives a message, it emits a `message`. Depending on which  [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. Its much better to listen a specific event rather than a `message` in order to stay safe from the content.
 TelegramBot emits `callback_query` when receives a [Callback Query](https://core.telegram.org/bots/api#callbackquery).
 TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode)
-TelegramBot emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type of message was edited.
+TelegramBot emits `channel_post` on a new incoming channel post of any kind and also `channel_post_edited` when a channel post text or caption is edited. TelegramBot emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type of message was edited.
 * * *
 
 ### WebHooks

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are some other examples on [examples](https://github.com/yagop/node-telegr
 ### Events
 Every time TelegramBot receives a message, it emits a `message`. Depending on which  [message](https://core.telegram.org/bots/api#message) was received, emits an event from this ones: `text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `contact`, `location`, `new_chat_participant`, `left_chat_participant`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`. Its much better to listen a specific event rather than a `message` in order to stay safe from the content.
 TelegramBot emits `callback_query` when receives a [Callback Query](https://core.telegram.org/bots/api#callbackquery).
-TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode)
+TelegramBot emits `inline_query` when receives an [Inline Query](https://core.telegram.org/bots/api#inlinequery) and `chosen_inline_result` when receives a [ChosenInlineResult](https://core.telegram.org/bots/api#choseninlineresult). Bot must be enabled on [inline mode](https://core.telegram.org/bots/api#inline-mode).
 TelegramBot emits `channel_post` on a new incoming channel post of any kind and also `channel_post_edited` when a channel post text or caption is edited. TelegramBot emits `edited_message` when a message is edited, and also `edited_message_text` or `edited_message_caption` depending on which type of message was edited.
 * * *
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -86,6 +86,8 @@ class TelegramBot extends EventEmitter {
     debug('Process Update %j', update);
     const message = update.message;
     const editedMessage = update.edited_message;
+    const channelPost = update.channel_post;
+    const editedChannelPost = update.edited_channel_post;
     const inlineQuery = update.inline_query;
     const chosenInlineResult = update.chosen_inline_result;
     const callbackQuery = update.callback_query;
@@ -135,6 +137,18 @@ class TelegramBot extends EventEmitter {
       if (editedMessage.caption) {
         this.emit('edited_message_caption', editedMessage);
       }
+    } else if (channelPost) {
+      debug('Process Update channel_post %j', channelPost);
+      this.emit('channel_post', channelPost);   
+    } else if (editedChannelPost) {
+      debug('Process Update edited_channel_post %j', editedChannelPost);
+      this.emit('edited_channel_post', editedChannelPost);
+      if (editedChannelPost.text) {
+        this.emit('edited_channel_post_text', editedChannelPost);
+      }
+      if (editedChannelPost.caption) {
+        this.emit('edited_channel_post_caption', editedChannelPost);
+      }         
     } else if (inlineQuery) {
       debug('Process Update inline_query %j', inlineQuery);
       this.emit('inline_query', inlineQuery);


### PR DESCRIPTION
bot will now get updates about posts in channels. Added new fields channel_post and edited_channel_post to Update.

[v2.3 Update](https://core.telegram.org/bots/api/#update)

Example:

```js
bot.on('channel_post', function (msg) {
  var chatId = msg.chat.id;
  console.log(msg.text)
  bot.sendMessage(chatId, 'New Channel Post Detected');
});

bot.on('edited_channel_post', function (msg) {
  var chatId = msg.chat.id;
  bot.sendMessage(chatId, 'Channel Post Has Been Edited');
});
```