### PR TITLE
Add deleteWebHook, getWebHookInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ TelegramBot
     * [.hasOpenWebHook()](#TelegramBot+hasOpenWebHook) ⇒ <code>Boolean</code>
     * [.getMe()](#TelegramBot+getMe) ⇒ <code>Promise</code>
     * [.setWebHook(url, [options])](#TelegramBot+setWebHook)
+    * [.getWebHookInfo()](#TelegramBot+getWebHookInfo) ⇒ <code>Promise</code>
     * [.getUpdates([options])](#TelegramBot+getUpdates) ⇒ <code>Promise</code>
     * [.processUpdate(update)](#TelegramBot+processUpdate)
     * [.sendMessage(chatId, text, [options])](#TelegramBot+sendMessage) ⇒ <code>Promise</code>
@@ -202,6 +203,16 @@ that is being deprecated.
 | [options] | <code>Object</code> | Additional Telegram query options |
 | [options.certificate] | <code>String</code> &#124; <code>stream.Stream</code> | PEM certificate key (public). |
 
+<a name="TelegramBot+getWebHookInfo"></a>
+
+### telegramBot.getWebHookInfo() ⇒ <code>Promise</code>
+Use this method to get current webhook status.
+On success, returns a [WebhookInfo](https://core.telegram.org/bots/api#webhookinfo) object.
+If the bot is using getUpdates, will return an object with the
+url field empty.
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**See**: https://core.telegram.org/bots/api#getwebhookinfo  
 <a name="TelegramBot+getUpdates"></a>
 
 ### telegramBot.getUpdates([options]) ⇒ <code>Promise</code>

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ TelegramBot
     * [.hasOpenWebHook()](#TelegramBot+hasOpenWebHook) ⇒ <code>Boolean</code>
     * [.getMe()](#TelegramBot+getMe) ⇒ <code>Promise</code>
     * [.setWebHook(url, [options])](#TelegramBot+setWebHook)
+    * [.deleteWebHook()](#TelegramBot+deleteWebHook) ⇒ <code>Promise</code>
     * [.getWebHookInfo()](#TelegramBot+getWebHookInfo) ⇒ <code>Promise</code>
     * [.getUpdates([options])](#TelegramBot+getUpdates) ⇒ <code>Promise</code>
     * [.processUpdate(update)](#TelegramBot+processUpdate)
@@ -203,6 +204,14 @@ that is being deprecated.
 | [options] | <code>Object</code> | Additional Telegram query options |
 | [options.certificate] | <code>String</code> &#124; <code>stream.Stream</code> | PEM certificate key (public). |
 
+<a name="TelegramBot+deleteWebHook"></a>
+
+### telegramBot.deleteWebHook() ⇒ <code>Promise</code>
+Use this method to remove webhook integration if you decide to
+switch back to getUpdates. Returns True on success.
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**See**: https://core.telegram.org/bots/api#deletewebhook  
 <a name="TelegramBot+getWebHookInfo"></a>
 
 ### telegramBot.getWebHookInfo() ⇒ <code>Promise</code>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -335,7 +335,7 @@ class TelegramBot extends EventEmitter {
       });
   }
 
-  /*
+  /**
    * Use this method to remove webhook integration if you decide to
    * switch back to getUpdates. Returns True on success.
    * @return {Promise}

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -335,6 +335,28 @@ class TelegramBot extends EventEmitter {
       });
   }
 
+  /*
+   * Use this method to remove webhook integration if you decide to
+   * switch back to getUpdates. Returns True on success.
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#deletewebhook
+   */
+  deleteWebHook() {
+    return this._request('deleteWebhook');
+  }
+
+  /**
+   * Use this method to get current webhook status.
+   * On success, returns a [WebhookInfo](https://core.telegram.org/bots/api#webhookinfo) object.
+   * If the bot is using getUpdates, will return an object with the
+   * url field empty.
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#getwebhookinfo
+   */
+  getWebHookInfo() {
+    return this._request('getWebhookInfo');
+  }
+
   /**
    * Use this method to receive incoming updates using long polling.
    * This method has an [older, compatible signature][getUpdates-v0.25.0]

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -250,6 +250,30 @@ describe('Telegram', function telegramSuite() {
     });
   });
 
+  describe('#deleteWebHook', function deleteWebHookSuite() {
+    before(function before() {
+      utils.handleRatelimit(bot, 'deleteWebHook', this);
+    });
+    it('should delete webhook', function test() {
+      return bot.deleteWebHook().then(resp => {
+        assert.equal(resp, true);
+      });
+    });
+  });
+
+  describe('#getWebHookInfo', function getWebHookInfoSuite() {
+    before(function before() {
+      utils.handleRatelimit(bot, 'getWebHookInfo', this);
+    });
+    it('should return WebhookInfo', function test() {
+      return bot.getWebHookInfo().then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.boolean(resp.has_custom_certificate));
+        assert.ok(is.number(resp.pending_update_count));
+      });
+    });
+  });
+
   describe('#getUpdates', function getUpdatesSuite() {
     const opts = {
       timeout: 0,
@@ -258,7 +282,7 @@ describe('Telegram', function telegramSuite() {
     before(function before() {
       utils.handleRatelimit(bot, 'setWebHook', this);
       utils.handleRatelimit(bot, 'getUpdates', this);
-      return bot.setWebHook('');
+      return bot.deleteWebHook();
     });
     it('should return an Array', function test() {
       return bot.getUpdates(opts).then(resp => {


### PR DESCRIPTION
See:

* deleteWebhook: https://core.telegram.org/bots/api#deletewebhook
* getWebhookInfo: https://core.telegram.org/bots/api#getwebhookinfo

---

## notes:

Are we using a typo with the word **WebHook**?

|Bot API|Library|
|---|---|
|setWeb**h**ook|setWeb**H**ook|
|deleteWeb**h**ook|deleteWeb**H**ook|
|getWeb**h**ookInfo|getWeb**H**ookInfo|

If so, we should fix this typo by supporting **both**
Web**H**ook and Web**h**ook; thus ensuring backwards-compatibility
and consistency with how we have "taught" our community to
name it as.

On major release, we should consider dropping the Web**H**ook
for Web**h**ook!