### PR TITLE
Replaced bound functions with functions in prototype

### DIFF
--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -45,7 +45,7 @@ class TelegramBotWebHook {
   }
 
   // pipe+parse body
-  _parseBody = (err, body) => {
+  _parseBody(err, body) {
     if (err) {
       return debug(err);
     }
@@ -58,8 +58,7 @@ class TelegramBotWebHook {
     return null;
   }
 
-  // bound req listener
-  _requestListener = (req, res) => {
+  _requestListener(req, res) {
     debug('WebHook request URL: %s', req.url);
     debug('WebHook request headers: %j', req.headers);
 


### PR DESCRIPTION
That enables the library to be used without transpiling on Node 6.9 (current LTS).

I'm pretty sure that the only difference in behavior is that when you do `const foo = webHookInstance._requestListener`, it currently gives you bound function, and after this change, it gives you unbound one; that shouldn't break anything I believe, but I haven't tested.