### PR TITLE
Allow deferring fetching updates

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -10,6 +10,7 @@ TelegramBot
 
 * [TelegramBot](#TelegramBot)
     * [new TelegramBot(token, [options])](#new_TelegramBot_new)
+    * [.waitFor(promise)](#TelegramBot+waitFor)
     * [.startPolling([options])](#TelegramBot+startPolling) ⇒ <code>Promise</code>
     * ~~[.initPolling([options])](#TelegramBot+initPolling) ⇒ <code>Promise</code>~~
     * [.stopPolling()](#TelegramBot+stopPolling) ⇒ <code>Promise</code>
@@ -84,6 +85,19 @@ Emits `message` when a message arrives.
 | [options.request] | <code>Object</code> |  | Options which will be added for all requests to telegram api.  See https://github.com/request/request#requestoptions-callback for more information. |
 | [options.baseApiUrl] | <code>String</code> | <code>https://api.telegram.org</code> | API Base URl; useful for proxying and testing |
 | [options.filepath] | <code>Boolean</code> | <code>true</code> | Allow passing file-paths as arguments when sending files,  such as photos using `TelegramBot#sendPhoto()`. See [usage information][usage-sending-files-performance]  for more information on this option and its consequences. |
+
+<a name="TelegramBot+waitFor"></a>
+
+### telegramBot.waitFor(promise)
+Wait with fetching updates until promise resolves.
+Must be called synchronously after creating instance of TelegramBot.
+No effect if already started fetching updates.
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+
+| Param | Type |
+| --- | --- |
+| promise | <code>Promise</code> | 
 
 <a name="TelegramBot+startPolling"></a>
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -80,7 +80,15 @@ class TelegramBot extends EventEmitter {
     this._onReplyToMessages = [];
     this._polling = null;
     this._webHook = null;
+    this._promisesToWaitFor = [];
 
+    process.nextTick(() => {
+      Promise.all(this._promisesToWaitFor).done(() => this._listen());
+    });
+  }
+
+  _listen() {
+    const options = this.options;
     if (options.polling) {
       const autoStart = options.polling.autoStart;
       if (typeof autoStart === 'undefined' || autoStart === true) {
@@ -94,6 +102,16 @@ class TelegramBot extends EventEmitter {
         this.openWebHook();
       }
     }
+  }
+
+  /**
+   * Wait with fetching updates until promise resolves.
+   * Must be called synchronously after creating instance of TelegramBot.
+   * No effect if already started fetching updates.
+   * @param {Promise} promise
+   */
+  waitFor(promise) {
+    this._promisesToWaitFor.push(promise);
   }
 
   /**


### PR DESCRIPTION
Why? https://github.com/GochoMugo/tgfancy/issues/8

Tl;dr: we wanna create `onCommand` in Tgfancy, but we need username obtained from `getMe` to tell if the command is directed to the bot before we can process any message.

In this PR I added `waitFor(promise)` method making a bot wait for `promise` resolving before starting fetching updates. I also restructured constructor a little to make it possible.