### PR TITLE
Webhook health check endpoint

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -80,6 +80,7 @@ Emits `message` when a message arrives.
 | [options.webHook.pfx] | <code>String</code> |  | Path to file with PFX private key and certificate chain for webHook server.  The file is read **synchronously**! |
 | [options.webHook.autoOpen] | <code>Boolean</code> | <code>true</code> | Open webHook immediately |
 | [options.webHook.https] | <code>Object</code> |  | Options to be passed to `https.createServer()`.  Note that `options.webHook.key`, `options.webHook.cert` and `options.webHook.pfx`, if provided, will be  used to override `key`, `cert` and `pfx` in this object, respectively.  See https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener for more information. |
+| [options.webHook.healthEndpoint] | <code>String</code> | <code>/healthz</code> | An endpoint for health checks that always responds with 200 OK |
 | [options.onlyFirstMatch] | <code>Boolean</code> | <code>false</code> | Set to true to stop after first match. Otherwise, all regexps are executed |
 | [options.request] | <code>Object</code> |  | Options which will be added for all requests to telegram api.  See https://github.com/request/request#requestoptions-callback for more information. |
 | [options.baseApiUrl] | <code>String</code> | <code>https://api.telegram.org</code> | API Base URl; useful for proxying and testing |

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -59,6 +59,7 @@ class TelegramBot extends EventEmitter {
    *  Note that `options.webHook.key`, `options.webHook.cert` and `options.webHook.pfx`, if provided, will be
    *  used to override `key`, `cert` and `pfx` in this object, respectively.
    *  See https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener for more information.
+   * @param {String} [options.webHook.healthEndpoint=/healthz] An endpoint for health checks that always responds with 200 OK
    * @param {Boolean} [options.onlyFirstMatch=false] Set to true to stop after first match. Otherwise, all regexps are executed
    * @param {Object} [options.request] Options which will be added for all requests to telegram api.
    *  See https://github.com/request/request#requestoptions-callback for more information.

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -133,6 +133,12 @@ describe('TelegramBot', function telegramSuite() {
   });
 
   describe('WebHook', function webHookSuite() {
+    it('returns OK for healthz endpoint', function test(done) {
+      utils.sendWebHookRequest(webHookPort2, '/healthz', { json: false }).then(resp => {
+        assert.equal(resp, 'OK');
+        return done();
+      });
+    });
     it('returns 401 error if token is wrong', function test(done) {
       utils.sendWebHookMessage(webHookPort2, 'wrong-token').catch(resp => {
         assert.equal(resp.statusCode, 401);

--- a/test/utils.js
+++ b/test/utils.js
@@ -31,6 +31,17 @@ exports = module.exports = {
    */
   isPollingMockServer,
   /**
+   * Send a message to the webhook at the specified port and path.
+   * @param  {Number} port
+   * @param  {String} path
+   * @param  {Object} [options]
+   * @param  {String} [options.method=POST] Method to use
+   * @param  {Object} [options.message] Message to send. Default to a generic text message
+   * @param  {Boolean} [options.https=false] Use https
+   * @return {Promise}
+   */
+  sendWebHookRequest,
+  /**
    * Send a message to the webhook at the specified port.
    * @param  {Number} port
    * @param  {String} token
@@ -134,11 +145,11 @@ function hasOpenWebHook(port, reverse) {
 }
 
 
-function sendWebHookMessage(port, token, options = {}) {
+function sendWebHookRequest(port, path, options = {}) {
   assert.ok(port);
-  assert.ok(token);
+  assert.ok(path);
   const protocol = options.https ? 'https' : 'http';
-  const url = `${protocol}://127.0.0.1:${port}/bot${token}`;
+  const url = `${protocol}://127.0.0.1:${port}${path}`;
   return request({
     url,
     method: options.method || 'POST',
@@ -146,8 +157,16 @@ function sendWebHookMessage(port, token, options = {}) {
       update_id: 1,
       message: options.message || { text: 'test' }
     },
-    json: true,
+    json: options.json || true,
   });
+}
+
+
+function sendWebHookMessage(port, token, options = {}) {
+  assert.ok(port);
+  assert.ok(token);
+  const path = `/bot${token}`;
+  return sendWebHookRequest(port, path, options);
 }
 
 


### PR DESCRIPTION
Docker-ized environments usually expose an HTTP endpoint for health checks.

For example, in order to use a bot built with this lib in a kubernetes cluster, we have to give it an HTTP endpoint that responds 200 OK.

Refs:
https://github.com/kubernetes/contrib/tree/master/ingress/controllers/gce#health-checks
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#defining-a-liveness-http-request