### PR TITLE
examples: Add webhook example for Zeit/now

### DIFF
--- a/examples/nowWebHook.js
+++ b/examples/nowWebHook.js
@@ -1,0 +1,30 @@
+/**
+ * This example demonstrates setting up webhook with zeit now.
+ * Attention: You have to use webhook with zeit now only, polling doesn't work
+ */
+
+
+const TOKEN = process.env.TELEGRAM_TOKEN || 'YOUR_TELEGRAM_BOT_TOKEN';
+const TelegramBot = require('..');
+const options = {
+  webHook: {
+    // Just use 443 directly
+    port: 443
+  }
+};
+// You can use 'now alias <your deployment url> <custom url>' to assign fixed domain
+// See: https://zeit.co/blog/now-alias
+// Or just use NOW_URL to get deployment url from env
+const url = 'YOUR_DOMAIN_ALIAS' || process.env.NOW_URL
+const bot = new TelegramBot(TOKEN, options);
+
+
+// This informs the Telegram servers of the new webhook.
+// Note: we do not need to pass in the cert, as it already provided
+bot.setWebHook(`${url}/bot${TOKEN}`);
+
+
+// Just to ping!
+bot.on('message', function onMessage(msg) {
+  bot.sendMessage(msg.chat.id, 'I am alive on Heroku!');
+});


### PR DESCRIPTION
Example: Deploy node-telegram-bot-api to [Zeit now](https://zeit.co/now).