### PR TITLE
src: add method to send messages sequentially

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -59,6 +59,7 @@ TelegramBot
     * [.sendGame(chatId, gameShortName, [options])](#TelegramBot+sendGame) ⇒ <code>Promise</code>
     * [.setGameScore(userId, score, [options])](#TelegramBot+setGameScore) ⇒ <code>Promise</code>
     * [.getGameHighScores(userId, [options])](#TelegramBot+getGameHighScores) ⇒ <code>Promise</code>
+    * [.sendSequence(method, chatId, messages, [options], [fileOpts])](#TelegramBot+sendSequence) ⇒ <code>Promise</code>
 
 <a name="new_TelegramBot_new"></a>
 
@@ -728,6 +729,22 @@ Use this method to get data for high score table.
 | --- | --- | --- |
 | userId | <code>String</code> | Unique identifier of the target user |
 | [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+sendSequence"></a>
+
+### telegramBot.sendSequence(method, chatId, messages, [options], [fileOpts]) ⇒ <code>Promise</code>
+Use this method to send messages with correct sequence
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**Returns**: <code>Promise</code> - resolves to an array of responses  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| method | <code>function</code> | Bot method to send messages, i.e. bot.sendMessage |
+| chatId | <code>Number</code> &#124; <code>String</code> | Unique identifier for the message recipient |
+| messages | <code>\*</code> | Messages to be sent.  Two dimentional array should used if API method requires more than one argument |
+| [options] | <code>Object</code> | Additional Telegram query options |
+| [fileOpts] | <code>Object</code> | Optional file related meta-data (for .sendDocument) |
 
 * * *
 

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -1118,4 +1118,37 @@ describe('TelegramBot', function telegramSuite() {
       return bot.sendPhoto(USERID, stream);
     });
   });
+
+  describe('#sendSequence', function sendSequence() {
+    this.timeout(timeout);
+    it('should send array of text messages', function test() {
+      const messages = ['a', 'b', 'c', 'd', 'e'];
+      return bot.sendSequence(bot.sendMessage, USERID, messages).then(resp => {
+        assert.ok(is.array(resp));
+        messages.forEach((message, i) => {
+          assert.ok(is.number(resp[i].message_id));
+          assert.ok(message === resp[i].text);
+        });
+      });
+    });
+    it('should send array of contacts', function test() {
+      const contacts = [
+        ['+1', '1'],
+        ['+2', '2'],
+        ['+3', '3']
+      ];
+      return bot.sendSequence(bot.sendContact, USERID, contacts).then(resp => {
+        assert.ok(is.array(resp));
+        contacts.forEach((contact, i) => {
+          assert.ok(is.object(resp[i].contact));
+          const expectedContact = {
+            phone_number: contact[0],
+            first_name: contact[1]
+          };
+          assert.deepEqual(resp[i].contact, expectedContact);
+        });
+      });
+    });
+  });
 }); // End Telegram
+


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run gen-doc`

### Description
Add a method which allows to send messages one-by-one. Promise returned by this method resolves to array of responses for each message. Sequence is also correct. It should correctly work for all .send* methods. 
I will add more tests to this PR if current implementation looks good enough.
<!-- Explain what you are trying to achieve with this PR -->

### References
Issue #240 
<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
