### PR TITLE
fix(onText): reset state of global regexp after search

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -473,6 +473,8 @@ class TelegramBot extends EventEmitter {
           if (!result) {
             return false;
           }
+          // reset index so we start at the beginning of the regex each time
+          reg.regexp.lastIndex = 0;
           debug('Matches %s', reg.regexp);
           reg.callback(message, result);
           // returning truthy value exits .some

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -975,6 +975,16 @@ describe('TelegramBot', function telegramSuite() {
         message: { text: '/onText ECHO ALOHA' },
       });
     });
+    it('should reset the global regex state with each message', function test(done) {
+      const regexp = /\/onText (.+)/g;
+      botWebHook.onText(regexp, () => {
+        assert.equal(regexp.lastIndex, 0);
+        return done();
+      });
+      utils.sendWebHookMessage(webHookPort2, TOKEN, {
+        message: { text: '/onText ECHO ALOHA' },
+      });
+    });
   });
 
   describe.skip('#onReplyToMessage', function onReplyToMessageSuite() {});


### PR DESCRIPTION
- [x] All tests pass
- [x] I have run `npm run gen-doc` (no changes)

### Description
Regex matching in `onText`: Resets the search index to start each regex match at the beginning again . 

**Note:** I usually add test cases to code I add/modif, but in this case it seems rather difficult to do that without modifying the `onText `function itself. I want to count the number of times the callback is executed. Any Ideas?

### References
Issue #325


