### PR TITLE
[API] v3 SendVideoNote method

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -33,6 +33,7 @@ TelegramBot
     * [.sendDocument(chatId, doc, [options], [fileOpts])](#TelegramBot+sendDocument) ⇒ <code>Promise</code>
     * [.sendSticker(chatId, sticker, [options])](#TelegramBot+sendSticker) ⇒ <code>Promise</code>
     * [.sendVideo(chatId, video, [options])](#TelegramBot+sendVideo) ⇒ <code>Promise</code>
+    * [.sendVideoNote(chatId, videoNote, length, [options])](#TelegramBot+sendVideoNote) ⇒ <code>Promise</code>
     * [.sendVoice(chatId, voice, [options])](#TelegramBot+sendVoice) ⇒ <code>Promise</code>
     * [.sendChatAction(chatId, action)](#TelegramBot+sendChatAction) ⇒ <code>Promise</code>
     * [.kickChatMember(chatId, userId)](#TelegramBot+kickChatMember) ⇒ <code>Promise</code>
@@ -336,6 +337,21 @@ Use this method to send video files, Telegram clients support mp4 videos (other 
 | --- | --- | --- |
 | chatId | <code>Number</code> &#124; <code>String</code> | Unique identifier for the message recipient |
 | video | <code>String</code> &#124; <code>stream.Stream</code> &#124; <code>Buffer</code> | A file path or Stream. Can also be a `file_id` previously uploaded. |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+sendVideoNote"></a>
+
+### telegramBot.sendVideoNote(chatId, videoNote, length, [options]) ⇒ <code>Promise</code>
+Use this method to send rounded square videos of upto 1 minute long.
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**See**: https://core.telegram.org/bots/api#sendvideonote  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> &#124; <code>String</code> | Unique identifier for the message recipient |
+| videoNote | <code>String</code> &#124; <code>stream.Stream</code> &#124; <code>Buffer</code> | A file path or Stream. Can also be a `file_id` previously uploaded. |
+| length | <code>Number</code> | Video width and height |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+sendVoice"></a>

--- a/doc/api.md
+++ b/doc/api.md
@@ -33,7 +33,7 @@ TelegramBot
     * [.sendDocument(chatId, doc, [options], [fileOpts])](#TelegramBot+sendDocument) ⇒ <code>Promise</code>
     * [.sendSticker(chatId, sticker, [options])](#TelegramBot+sendSticker) ⇒ <code>Promise</code>
     * [.sendVideo(chatId, video, [options])](#TelegramBot+sendVideo) ⇒ <code>Promise</code>
-    * [.sendVideoNote(chatId, videoNote, length, [options])](#TelegramBot+sendVideoNote) ⇒ <code>Promise</code>
+    * [.sendVideoNote(chatId, videoNote, [options])](#TelegramBot+sendVideoNote) ⇒ <code>Promise</code>
     * [.sendVoice(chatId, voice, [options])](#TelegramBot+sendVoice) ⇒ <code>Promise</code>
     * [.sendChatAction(chatId, action)](#TelegramBot+sendChatAction) ⇒ <code>Promise</code>
     * [.kickChatMember(chatId, userId)](#TelegramBot+kickChatMember) ⇒ <code>Promise</code>
@@ -341,17 +341,17 @@ Use this method to send video files, Telegram clients support mp4 videos (other 
 
 <a name="TelegramBot+sendVideoNote"></a>
 
-### telegramBot.sendVideoNote(chatId, videoNote, length, [options]) ⇒ <code>Promise</code>
+### telegramBot.sendVideoNote(chatId, videoNote, [options]) ⇒ <code>Promise</code>
 Use this method to send rounded square videos of upto 1 minute long.
 
 **Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
 **See**: https://core.telegram.org/bots/api#sendvideonote  
+**Note**: The length parameter is optional, but **required** untill Telegram patches it.
 
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | <code>Number</code> &#124; <code>String</code> | Unique identifier for the message recipient |
 | videoNote | <code>String</code> &#124; <code>stream.Stream</code> &#124; <code>Buffer</code> | A file path or Stream. Can also be a `file_id` previously uploaded. |
-| length | <code>Number</code> | Video width and height |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+sendVoice"></a>

--- a/doc/api.md
+++ b/doc/api.md
@@ -344,9 +344,9 @@ Use this method to send video files, Telegram clients support mp4 videos (other 
 ### telegramBot.sendVideoNote(chatId, videoNote, [options]) ⇒ <code>Promise</code>
 Use this method to send rounded square videos of upto 1 minute long.
 
-**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**Info**: The length parameter is actually optional. However, the API (at time of writing) requires you to always provide it until it is fixed.  
 **See**: https://core.telegram.org/bots/api#sendvideonote  
-**Info**: The length parameter is actually optional. However, the API (at time of writing) requires you to always provide it until it is fixed.
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/doc/api.md
+++ b/doc/api.md
@@ -344,9 +344,9 @@ Use this method to send video files, Telegram clients support mp4 videos (other 
 ### telegramBot.sendVideoNote(chatId, videoNote, [options]) ⇒ <code>Promise</code>
 Use this method to send rounded square videos of upto 1 minute long.
 
-**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>
 **See**: https://core.telegram.org/bots/api#sendvideonote  
-**Note**: The length parameter is optional, but **required** untill Telegram patches it.
+**Info**: The length parameter is actually optional. However, the API (at time of writing) requires you to always provide it until it is fixed.
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -696,6 +696,32 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Use this method to send rounded square videos of upto 1 minute long.
+   * @param  {Number|String} chatId  Unique identifier for the message recipient
+   * @param  {String|stream.Stream|Buffer} videoNote A file path or Stream.
+   * @param  {Number} length Video width and height
+   * Can also be a `file_id` previously uploaded.
+   * @param  {Object} [options] Additional Telegram query options
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#sendvideonote
+   */
+  sendVideoNote(chatId, videoNote, length, options = {}) {
+    const opts = {
+      qs: options
+    };
+    opts.qs.chat_id = chatId;
+    opts.qs.length = length;
+    try {
+      const sendData = this._formatSendData('video_note', videoNote);
+      opts.formData = sendData[0];
+      opts.qs.video_note = sendData[1];
+    } catch (ex) {
+      return Promise.reject(ex);
+    }
+    return this._request('sendVideoNote', opts);
+  }  
+
+  /**
    * Send voice
    * @param  {Number|String} chatId  Unique identifier for the message recipient
    * @param  {String|stream.Stream|Buffer} voice A file path, Stream or Buffer.

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -700,17 +700,15 @@ class TelegramBot extends EventEmitter {
    * @param  {Number|String} chatId  Unique identifier for the message recipient
    * @param  {String|stream.Stream|Buffer} videoNote A file path or Stream.
    * Can also be a `file_id` previously uploaded.
-   * @param  {Number} length Video width and height
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#sendvideonote
    */
-  sendVideoNote(chatId, videoNote, length, options = {}) {
+  sendVideoNote(chatId, videoNote, options = {}) {
     const opts = {
       qs: options
     };
     opts.qs.chat_id = chatId;
-    opts.qs.length = length;
     try {
       const sendData = this._formatSendData('video_note', videoNote);
       opts.formData = sendData[0];

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -702,6 +702,7 @@ class TelegramBot extends EventEmitter {
    * Can also be a `file_id` previously uploaded.
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise}
+   * @info The length parameter is actually optional. However, the API (at time of writing) requires you to always provide it until it is fixed.
    * @see https://core.telegram.org/bots/api#sendvideonote
    */
   sendVideoNote(chatId, videoNote, options = {}) {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -699,8 +699,8 @@ class TelegramBot extends EventEmitter {
    * Use this method to send rounded square videos of upto 1 minute long.
    * @param  {Number|String} chatId  Unique identifier for the message recipient
    * @param  {String|stream.Stream|Buffer} videoNote A file path or Stream.
-   * @param  {Number} length Video width and height
    * Can also be a `file_id` previously uploaded.
+   * @param  {Number} length Video width and height
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#sendvideonote
@@ -719,7 +719,7 @@ class TelegramBot extends EventEmitter {
       return Promise.reject(ex);
     }
     return this._request('sendVideoNote', opts);
-  }  
+  }
 
   /**
    * Send voice

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -709,6 +709,43 @@ describe('TelegramBot', function telegramSuite() {
     });
   });
 
+  describe('#sendVideoNote', function sendVideoNoteSuite() {
+    let videoId;
+    this.timeout(timeout);
+    before(function before() {
+      utils.handleRatelimit(bot, 'sendVideoNote', this);
+    });
+    it('should send a video from file', function test() {
+      const video = `${__dirname}/data/video.mp4`;
+      return bot.sendVideoNote(USERID, video, 5).then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.object(resp.video_note));
+        videoId = resp.video_note.file_id;
+      });
+    });
+    it('should send a video from id', function test() {
+      // Send the same videonote as before
+      return bot.sendVideo(USERID, videoId, 5).then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.object(resp.video_note));
+      });
+    });
+    it('should send a video from fs.readStream', function test() {
+      const video = fs.createReadStream(`${__dirname}/data/video.mp4`);
+      return bot.sendVideo(USERID, video, 5).then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.object(resp.video_note));
+      });
+    });
+    it('should send a video from a Buffer', function test() {
+      const video = fs.readFileSync(`${__dirname}/data/video.mp4`);
+      return bot.sendVideo(USERID, video, 5).then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.object(resp.video_note));
+      });
+    });
+  });
+
   describe('#sendVoice', function sendVoiceSuite() {
     let voiceId;
     this.timeout(timeout);

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -710,7 +710,7 @@ describe('TelegramBot', function telegramSuite() {
   });
 
   describe('#sendVideoNote', function sendVideoNoteSuite() {
-    let videoId;
+    let videoNoteId;
     this.timeout(timeout);
     before(function before() {
       utils.handleRatelimit(bot, 'sendVideoNote', this);
@@ -720,26 +720,27 @@ describe('TelegramBot', function telegramSuite() {
       return bot.sendVideoNote(USERID, video, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
-        videoId = resp.video_note.file_id;
+        videoNoteId = resp.video_note.file_id;
       });
     });
     it('should send a video from id', function test() {
       // Send the same videonote as before
-      return bot.sendVideo(USERID, videoId, { length: 5 }).then(resp => {
+      assert.ok(videoNoteId);
+      return bot.sendVideoNote(USERID, videoNoteId, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
       });
     });
     it('should send a video from fs.readStream', function test() {
       const video = fs.createReadStream(`${__dirname}/data/video.mp4`);
-      return bot.sendVideo(USERID, video, { length: 5 }).then(resp => {
+      return bot.sendVideoNote(USERID, video, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
       });
     });
     it('should send a video from a Buffer', function test() {
       const video = fs.readFileSync(`${__dirname}/data/video.mp4`);
-      return bot.sendVideo(USERID, video, { length: 5 }).then(resp => {
+      return bot.sendVideoNote(USERID, video, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
       });

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -717,7 +717,7 @@ describe('TelegramBot', function telegramSuite() {
     });
     it('should send a video from file', function test() {
       const video = `${__dirname}/data/video.mp4`;
-      return bot.sendVideoNote(USERID, video, 5).then(resp => {
+      return bot.sendVideoNote(USERID, video, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
         videoId = resp.video_note.file_id;
@@ -725,21 +725,21 @@ describe('TelegramBot', function telegramSuite() {
     });
     it('should send a video from id', function test() {
       // Send the same videonote as before
-      return bot.sendVideo(USERID, videoId, 5).then(resp => {
+      return bot.sendVideo(USERID, videoId, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
       });
     });
     it('should send a video from fs.readStream', function test() {
       const video = fs.createReadStream(`${__dirname}/data/video.mp4`);
-      return bot.sendVideo(USERID, video, 5).then(resp => {
+      return bot.sendVideo(USERID, video, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
       });
     });
     it('should send a video from a Buffer', function test() {
       const video = fs.readFileSync(`${__dirname}/data/video.mp4`);
-      return bot.sendVideo(USERID, video, 5).then(resp => {
+      return bot.sendVideo(USERID, video, { length: 5 }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.video_note));
       });


### PR DESCRIPTION
## API v3 

**sendVideoNote**

[[source](https://core.telegram.org/bots/api#sendvideonote)]

_There seems to be an issue with Telegrams documentation regarding this method, which doesn't state that length is actually a required parameter._

- [x] Add tests.
- [x] Generate documentation.
- [x] Run tests.

