### PR TITLE
[Update] Message sub-types

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -14,9 +14,12 @@
   1. Depending on the properties of the [Message][message], one of these
      events will **ALSO** be emitted: `text`, `audio`, `document`, `photo`,
      `sticker`, `video`, `voice`, `contact`, `location`,
-     `new_chat_participant`, `left_chat_participant`, `new_chat_title`,
+     `new_chat_members`, `left_chat_member`, `new_chat_title`,
      `new_chat_photo`, `delete_chat_photo`, `group_chat_created`,
+     `game`, `pinned_message`, `migrate_from_chat_id`, `migrate_to_chat_id`,
+     `channel_chat_created`, `supergroup_chat_created`,
      `successful_payment`, `invoice`
+  1. `new_chat_participant`, `left_chat_participant` are **deprecated**
 1. `callback_query`: Received a new incoming [Callback Query][callback-query]
 1. `inline_query`: Received a new incoming [Inline Query][inline-query]
 1. `chosen_inline_result`: Received result of an inline query i.e. [ChosenInlineResult][chosen-inline-result]

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -21,8 +21,10 @@ const deprecate = require('depd')('node-telegram-bot-api');
 
 const _messageTypes = [
   'text', 'audio', 'document', 'photo', 'sticker', 'video', 'voice', 'contact',
-  'location', 'new_chat_participant', 'left_chat_participant', 'new_chat_title',
-  'new_chat_photo', 'delete_chat_photo', 'group_chat_created', 'successful_payment', 'invoice'
+  'location', 'new_chat_members', 'left_chat_member', 'new_chat_title',
+  'new_chat_photo', 'delete_chat_photo', 'group_chat_created', 'game', 'pinned_message',
+  'migrate_from_chat_id', 'migrate_to_chat_id', 'channel_chat_created', 'supergroup_chat_created',
+  'successful_payment', 'invoice'
 ];
 
 // enable cancellation

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -26,6 +26,9 @@ const _messageTypes = [
   'migrate_from_chat_id', 'migrate_to_chat_id', 'channel_chat_created', 'supergroup_chat_created',
   'successful_payment', 'invoice'
 ];
+const _deprecatedMessageTypes = [
+  'new_chat_participant', 'left_chat_participant'
+];
 
 // enable cancellation
 Promise.config({
@@ -40,6 +43,14 @@ class TelegramBot extends EventEmitter {
 
   static get messageTypes() {
     return _messageTypes;
+  }
+
+  on(event, listener) {
+    if (_deprecatedMessageTypes.indexOf(event) !== -1) {
+      const url = 'https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#events';
+      deprecate(`Events ${_deprecatedMessageTypes.join(',')} are deprecated. See the updated list of events: ${url}`);
+    }
+    super.on(event, listener);
   }
 
   /**


### PR DESCRIPTION
[[source](https://core.telegram.org/bots/api#message)]

Added 6 missing message sub-types: `game`, `pinned_message`, `migrate_from_chat_id`, `migrate_to_chat_id`, `channel_chat_created`, `supergroup_chat_created`

Rename 1 message sub-type: `new_chat_members`