### PR TITLE
fixed download file path on windows

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1050,7 +1050,7 @@ class TelegramBot extends EventEmitter {
       .then(fileURI => {
         const fileName = fileURI.slice(fileURI.lastIndexOf('/') + 1);
         // TODO: Ensure fileName doesn't contains slashes
-        const filePath = `${downloadDir}/${fileName}`;
+        const filePath = path.join(downloadDir, fileName);
 
         // properly handles errors and closes all streams
         return Promise


### PR DESCRIPTION
### Description

Return valid path on Windows OS. 

### References
closes #363

P.S. I didn't manage to run your tests because I have no idea how to get TEST_PROVIDER_TOKEN / TEST_GAME_SHORT_NAME / TEST_GROUP_ID
It would be nice to have a description how to get these in your docs :)