### PR TITLE
Expose message.type to 'message'

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -491,11 +491,13 @@ class TelegramBot extends EventEmitter {
 
     if (message) {
       debug('Process Update message %j', message);
-      this.emit('message', message);
       const processMessageType = messageType => {
         if (message[messageType]) {
           debug('Emitting %s: %j', messageType, message);
           this.emit(messageType, message);
+          this.emit('message', { ...message, type: messageType });
+        } else {
+          this.emit('message', message);
         }
       };
       TelegramBot.messageTypes.forEach(processMessageType);


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [ ] I have run `npm run gen-doc`

(haven't run any as it was a trivial fix directly from the github interface; I'd be highly surprised if things don't work out)

### Description

expose `message.type` to the 'message' event, the checks are being done already either way

### References

Closes #409 