### PR TITLE
Add getStickerSet

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -75,6 +75,7 @@ TelegramBot
         * [.sendInvoice(chatId, title, description, payload, providerToken, startParameter, currency, prices, [options])](#TelegramBot+sendInvoice) ⇒ <code>Promise</code>
         * [.answerShippingQuery(shippingQueryId, ok, [options])](#TelegramBot+answerShippingQuery) ⇒ <code>Promise</code>
         * [.answerPreCheckoutQuery(preCheckoutQueryId, ok, [options])](#TelegramBot+answerPreCheckoutQuery) ⇒ <code>Promise</code>
+        * [.getStickerSet(name, [options])](#TelegramBot+getStickerSet) ⇒ <code>Promise</code>
     * _static_
         * [.Promise](#TelegramBot.Promise)
 
@@ -975,6 +976,19 @@ Use this method to confirm shipping of a product.
 | --- | --- | --- |
 | preCheckoutQueryId | <code>String</code> | Unique identifier for the query to be answered |
 | ok | <code>Boolean</code> | Specify if every order details are ok |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+getStickerSet"></a>
+
+### telegramBot.getStickerSet(name, [options]) ⇒ <code>Promise</code>
+Use this method to get a sticker set. On success, a [StickerSet](https://core.telegram.org/bots/api#stickerset) object is returned.
+
+**Kind**: instance method of <code>[TelegramBot](#TelegramBot)</code>  
+**See**: https://core.telegram.org/bots/api#getstickerset  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>String</code> | Name of the sticker set |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot.Promise"></a>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1501,12 +1501,12 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
-   * Use this method to get the sticker set given the name of the set.
-   * Returns a [StickerSet](https://core.telegram.org/bots/api#stickerset) object.
+   * Use this method to get a sticker set. On success, a [StickerSet](https://core.telegram.org/bots/api#stickerset) object is returned.
    *
-   * @param {String} name Name of the sticker set
-   * @param {Object} [options] Additional Telegram query options
-   * @returns {Promise}
+   * @param  {String} name Name of the sticker set
+   * @param  {Object} [options] Additional Telegram query options
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#getstickerset
    */
   getStickerSet(name, form = {}) {
     form.name = name;

--- a/test/README.md
+++ b/test/README.md
@@ -10,8 +10,13 @@ export TEST_USER_ID=<USER_ID>
 # Group Id which to use in some of the tests, e.g. for TelegramBot#getChat()
 export TEST_GROUP_ID=<GROUP_ID>
 
-# Game short name which to use in some of the tests, e.g. TelegramBot#sendGame()
+# Game short name to use in some tests, e.g. TelegramBot#sendGame()
+# Defaults to "medusalab_test".
 export TEST_GAME_SHORT_NAME=<GAME_SHORT_NAME>
+
+# Sticker set name to use in some tests, e.g. TelegramBot#getStickerSet()
+# Defaults to "pusheen".
+export TEST_STICKER_SET_NAME=<STICKER_SET_NAME>
 
 # Payment provider token to be used
 export TEST_PROVIDER_TOKEN=<YOUR_PROVIDER_TOKEN>

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -26,7 +26,7 @@ if (!PROVIDER_TOKEN && !isCI) { // If is not running in Travis / Appveyor
 const USERID = process.env.TEST_USER_ID || 777000;
 const GROUPID = process.env.TEST_GROUP_ID || -1001075450562;
 const GAME_SHORT_NAME = process.env.TEST_GAME_SHORT_NAME || 'medusalab_test';
-const STICKER_SET_NAME = process.env.STICKER_SET || 'pusheen';
+const STICKER_SET_NAME = process.env.TEST_STICKER_SET_NAME || 'pusheen';
 const timeout = 60 * 1000;
 let portindex = 8091;
 const staticPort = portindex++;


### PR DESCRIPTION
- [ ] All tests pass
- [x] I have run `npm run gen-doc`

### Description

Implements `getStickerSet` (part of the Bot API 3.2: #407).

### References

The original PR was #389. Seeing that it was abandoned, I fixed it.