### PR TITLE
Cancelling polling request when polling is disabled. Fix #455

### DIFF
--- a/src/telegramPolling.js
+++ b/src/telegramPolling.js
@@ -58,15 +58,16 @@ class TelegramBotPolling {
     if (!this._lastRequest) {
       return Promise.resolve();
     }
+    const reason = options.reason || 'Polling stop';
     const lastRequest = this._lastRequest;
     this._lastRequest = null;
     clearTimeout(this._pollingTimeout);
     if (options.cancel) {
-      const reason = options.reason || 'Polling stop';
       lastRequest.cancel(reason);
       return Promise.resolve();
     }
     this._abort = true;
+    lastRequest.cancel(reason);
     return lastRequest.finally(() => {
       this._abort = false;
     });


### PR DESCRIPTION

- [ ] All tests pass
- [x] I have run `npm run gen-doc`

### Description

`stopPolling` cancels all the event listeners installed when polling starts.

### References

* Issue https://github.com/yagop/node-telegram-bot-api/issues/455

### Note

I was unable to run the tests, as they were failing even before my changes.