### PR TITLE
Fixed annotations for message id parameter

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -654,7 +654,7 @@ Returns True on success.
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the message recipient |
-| messageId | <code>String</code> | Identifier of a message to pin |
+| messageId | <code>Number</code> | Identifier of a message to pin |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+unpinChatMessage"></a>
@@ -1118,7 +1118,7 @@ Use this method to delete a message.
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier of the target chat |
-| messageId | <code>String</code> | Unique identifier of the target message |
+| messageId | <code>Number</code> | Unique identifier of the target message |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+sendInvoice"></a>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1080,7 +1080,7 @@ class TelegramBot extends EventEmitter {
    * Returns True on success.
    *
    * @param  {Number|String} chatId  Unique identifier for the message recipient
-   * @param  {String} messageId Identifier of a message to pin
+   * @param  {Number} messageId Identifier of a message to pin
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#pinchatmessage
@@ -1614,7 +1614,7 @@ class TelegramBot extends EventEmitter {
   /**
    * Use this method to delete a message.
    * @param  {Number|String} chatId  Unique identifier of the target chat
-   * @param  {String} messageId  Unique identifier of the target message
+   * @param  {Number} messageId  Unique identifier of the target message
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#deletemessage


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

Fixed annotation mistake described in issue https://github.com/yagop/node-telegram-bot-api/issues/490

### References

<!--
Telegream bot API https://core.telegram.org/bots/api#updating-messages
-->
