### PR TITLE
sendMessage: pass valid parameters to API

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -672,10 +672,10 @@ class TelegramBot extends EventEmitter {
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#sendmessage
    */
-  sendMessage(chatId, text, form = {}) {
-    form.chat_id = chatId;
-    form.text = text;
-    return this._request('sendMessage', { form });
+  sendMessage(chatId, text, options = {}) {
+    options.chat_id = chatId;
+    options.text = text;
+    return this._request('sendMessage', { qs: options });
   }
 
   /**


### PR DESCRIPTION
perhaps after 13.02.2018 API update there are only errors like "**400: message are empty**" when we are trying to send a message via `sendMessage` method

this fix the issue.

<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
