### PR TITLE
Implement webHook endpoint

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -59,6 +59,7 @@ $ openssl genrsa -out key.pem 2048
 # Our public certificate will be crt.pem
 $ openssl req -new -sha256 -key key.pem -out crt.pem
 ```
+**Note:** Domain, specified in CN section during creation should be equal to your real domain address
 
 Once they are generated, the `crt.pem` should be uploaded, when setting up
 your webhook. For example,

--- a/examples/webhook/https.js
+++ b/examples/webhook/https.js
@@ -8,9 +8,10 @@ const TOKEN = process.env.TELEGRAM_TOKEN || 'YOUR_TELEGRAM_BOT_TOKEN';
 const TelegramBot = require('../..');
 const options = {
   webHook: {
-    port: 443,
-    key: `${__dirname}/../ssl/key.pem`, // Path to file with PEM private key
-    cert: `${__dirname}/../ssl/crt.pem` // Path to file with PEM certificate
+    port: 443,                           // Defaults to 8443
+    key: `${__dirname}/../ssl/key.pem`,  // Path to file with PEM private key
+    cert: `${__dirname}/../ssl/crt.pem`, // Path to file with PEM certificate
+    endpoint: '/webHookEndpoint'         // Secret path to the webhook endpoint. Optional
   }
 };
 // This URL must route to the port set above (i.e. 443)

--- a/test/utils.js
+++ b/test/utils.js
@@ -50,18 +50,6 @@ exports = module.exports = {
    */
   sendWebHookRequest,
   /**
-   * Send a message to the webhook at the specified port.
-   * @param  {Number} port
-   * @param  {String} token
-   * @param  {Object} [options]
-   * @param  {String} [options.method=POST] Method to use
-   * @param  {Object} [options.update] Update object to send.
-   * @param  {Object} [options.message] Message to send. Default to a generic text message
-   * @param  {Boolean} [options.https=false] Use https
-   * @return {Promise}
-   */
-  sendWebHookMessage,
-  /**
    * Start a mock server at the specified port.
    * @param  {Number} port
    * @param  {Object} [options]
@@ -174,14 +162,6 @@ function sendWebHookRequest(port, path, options = {}) {
     },
     json: (typeof options.json === 'undefined') ? true : options.json,
   });
-}
-
-
-function sendWebHookMessage(port, token, options = {}) {
-  assert.ok(port);
-  assert.ok(token);
-  const path = `/bot${token}`;
-  return sendWebHookRequest(port, path, options);
 }
 
 


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description
`TOKEN` webHook endpoint is now optional.

You can specify `secret path` in options
```
new TelegramBot(TOKEN,{
  webHook: {
    endpoint: 'your_secret_path' //Defaults to index path
  }
});
```
### References
https://github.com/yagop/node-telegram-bot-api/issues/585
<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
