### PR TITLE
[API v4.0] Publish new methods and message types

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -35,6 +35,7 @@ TelegramBot
         * [.sendDocument(chatId, doc, [options], [fileOptions])](#TelegramBot+sendDocument) ⇒ <code>Promise</code>
         * [.sendSticker(chatId, sticker, [options], [fileOptions])](#TelegramBot+sendSticker) ⇒ <code>Promise</code>
         * [.sendVideo(chatId, video, [options], [fileOptions])](#TelegramBot+sendVideo) ⇒ <code>Promise</code>
+        * [.sendAnimation(chatId, animation, [options], [fileOptions])](#TelegramBot+sendAnimation) ⇒ <code>Promise</code>
         * [.sendVideoNote(chatId, videoNote, [options], [fileOptions])](#TelegramBot+sendVideoNote) ⇒ <code>Promise</code>
         * [.sendVoice(chatId, voice, [options], [fileOptions])](#TelegramBot+sendVoice) ⇒ <code>Promise</code>
         * [.sendChatAction(chatId, action, [options])](#TelegramBot+sendChatAction) ⇒ <code>Promise</code>
@@ -52,6 +53,7 @@ TelegramBot
         * [.answerCallbackQuery(callbackQueryId, [options])](#TelegramBot+answerCallbackQuery) ⇒ <code>Promise</code>
         * [.editMessageText(text, [options])](#TelegramBot+editMessageText) ⇒ <code>Promise</code>
         * [.editMessageCaption(caption, [options])](#TelegramBot+editMessageCaption) ⇒ <code>Promise</code>
+        * [.editMessageMedia(media, [options])](#TelegramBot+editMessageMedia) ⇒ <code>Promise</code>
         * [.editMessageReplyMarkup(replyMarkup, [options])](#TelegramBot+editMessageReplyMarkup) ⇒ <code>Promise</code>
         * [.getUserProfilePhotos(userId, [options])](#TelegramBot+getUserProfilePhotos) ⇒ <code>Promise</code>
         * [.sendLocation(chatId, latitude, longitude, [options])](#TelegramBot+sendLocation) ⇒ <code>Promise</code>
@@ -436,6 +438,25 @@ Use this method to send video files, Telegram clients support mp4 videos (other 
 | [options] | <code>Object</code> | Additional Telegram query options |
 | [fileOptions] | <code>Object</code> | Optional file related meta-data |
 
+<a name="TelegramBot+sendAnimation"></a>
+
+### telegramBot.sendAnimation(chatId, animation, [options], [fileOptions]) ⇒ <code>Promise</code>
+Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**
+
+- https://core.telegram.org/bots/api#sendanimation
+- https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the message recipient |
+| animation | <code>String</code> \| <code>stream.Stream</code> \| <code>Buffer</code> | A file path, Stream or Buffer. Can also be a `file_id` previously uploaded. |
+| [options] | <code>Object</code> | Additional Telegram query options |
+| [fileOptions] | <code>Object</code> | Optional file related meta-data |
+
 <a name="TelegramBot+sendVideoNote"></a>
 
 ### telegramBot.sendVideoNote(chatId, videoNote, [options], [fileOptions]) ⇒ <code>Promise</code>
@@ -725,6 +746,26 @@ inline_message_id in your request.
 | Param | Type | Description |
 | --- | --- | --- |
 | caption | <code>String</code> | New caption of the message |
+| [options] | <code>Object</code> | Additional Telegram query options (provide either one of chat_id, message_id, or inline_message_id here) |
+
+<a name="TelegramBot+editMessageMedia"></a>
+
+### telegramBot.editMessageMedia(media, [options]) ⇒ <code>Promise</code>
+Use this method to edit audio, document, photo, or video messages.
+If a message is a part of a message album, then it can be edited only to a photo or a video.
+Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded.
+Use previously uploaded file via its file_id or specify a URL.
+On success, the edited Message is returned.
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**: https://core.telegram.org/bots/api#editmessagemedia  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| media | <code>Object</code> | A JSON-serialized object for a new media content of the message |
 | [options] | <code>Object</code> | Additional Telegram query options (provide either one of chat_id, message_id, or inline_message_id here) |
 
 <a name="TelegramBot+editMessageReplyMarkup"></a>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -842,7 +842,7 @@ class TelegramBot extends EventEmitter {
   /**
    * Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
    * @param  {Number|String} chatId  Unique identifier for the message recipient
-   * @param  {String|stream.Stream|Buffer} doc A file path, Stream or Buffer.
+   * @param  {String|stream.Stream|Buffer} animation A file path, Stream or Buffer.
    * Can also be a `file_id` previously uploaded.
    * @param  {Object} [options] Additional Telegram query options
    * @param  {Object} [fileOptions] Optional file related meta-data

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -37,6 +37,7 @@ const _messageTypes = [
   'new_chat_members',
   'new_chat_photo',
   'new_chat_title',
+  'passport_data',
   'photo',
   'pinned_message',
   'sticker',

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1185,6 +1185,26 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Use this method to edit audio, document, photo, or video messages.
+   * If a message is a part of a message album, then it can be edited only to a photo or a video.
+   * Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded.
+   * Use previously uploaded file via its file_id or specify a URL.
+   * On success, the edited Message is returned.
+   *
+   * Note that you must provide one of chat_id, message_id, or
+   * inline_message_id in your request.
+   *
+   * @param  {Object} media  A JSON-serialized object for a new media content of the message
+   * @param  {Object} [options] Additional Telegram query options (provide either one of chat_id, message_id, or inline_message_id here)
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#editmessagemedia
+   */
+  editMessageMedia(media, form = {}) {
+    form.media = media;
+    return this._request('editMessageMedia', { form });
+  }  
+
+  /**
    * Use this method to edit only the reply markup of messages
    * sent by the bot or via the bot (for inline bots).
    * On success, the edited Message is returned.

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -21,6 +21,7 @@ let Promise = require('bluebird');
 
 const _messageTypes = [
   'text',
+  'animation',
   'audio',
   'channel_chat_created',
   'contact',

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -839,6 +839,32 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
+   * @param  {Number|String} chatId  Unique identifier for the message recipient
+   * @param  {String|stream.Stream|Buffer} doc A file path, Stream or Buffer.
+   * Can also be a `file_id` previously uploaded.
+   * @param  {Object} [options] Additional Telegram query options
+   * @param  {Object} [fileOptions] Optional file related meta-data
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#sendanimation
+   * @see https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files
+   */
+  sendAnimation(chatId, animation, options = {}, fileOptions = {}) {
+    const opts = {
+      qs: options
+    };
+    opts.qs.chat_id = chatId;
+    try {
+      const sendData = this._formatSendData('animation', animation, fileOptions);
+      opts.formData = sendData[0];
+      opts.qs.document = sendData[1];
+    } catch (ex) {
+      return Promise.reject(ex);
+    }
+    return this._request('sendAnimation', opts);
+  }  
+
+  /**
    * Use this method to send rounded square videos of upto 1 minute long.
    * @param  {Number|String} chatId  Unique identifier for the message recipient
    * @param  {String|stream.Stream|Buffer} videoNote A file path or Stream.


### PR DESCRIPTION
- [ ] All tests pass
- [x] I have run `npm run doc`

### Description
Update the library with minor changes from the latest bot API update (v4.0 released on 26/07/2018).

Add new methods:
- **editMessageMedia**
- **sendAnimation**

Add new message types:

- **passport_data**
- **animation**

### References

- #624
- [Update release notes from Telegram](https://core.telegram.org/bots/api#july-26-2018)
