### PR TITLE
Added documentation for tunneling to local machine and replaced sendDocument with senddocument.

### DIFF
--- a/doc/help.md
+++ b/doc/help.md
@@ -104,7 +104,30 @@ Sources:
 <a name="proxy"></a>
 ### How do I run my bot behind a proxy?
 
-*Not done. PRs welcome!*
+In order to work with webhooks on your local server, you need to have a proxy server that tunnels to your local machine. One way is to use ngrok to create a public HTTPS URL to tunnel to your local web server.
+
+
+Setting up ngrok
+
+```
+npm install -g ngrok // Install ngrok using npm
+ngrok http 8080 // Assuming that you are using port 8080 to run your local server
+```
+
+On your command line, you should see something like this:
+
+```
+Forwarding http://756f7557.ngrok.io -> localhost:8080      
+Forwarding https://756f7557.ngrok.io -> localhost:8080
+```
+
+Update your webhook code:
+
+```
+bot.setWebHook(`${url}/bot${TELEGRAM_TOKEN}`) // url is your https link
+```
+
+
 
 Sources:
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -770,7 +770,7 @@ class TelegramBot extends EventEmitter {
    * @param  {Object} [options] Additional Telegram query options
    * @param  {Object} [fileOptions] Optional file related meta-data
    * @return {Promise}
-   * @see https://core.telegram.org/bots/api#sendDocument
+   * @see https://core.telegram.org/bots/api#senddocument
    * @see https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files
    */
   sendDocument(chatId, doc, options = {}, fileOptions = {}) {


### PR DESCRIPTION
- [ ] All tests pass
- [x] I have run `npm run doc`

### Description

1. Added documentation for tunneling to local machine using ngrok. Included simple instructions to install ngrok and configuring webhook to use the HTTPS URL generated by ngrok.

2. Incidentally, when running 'npm run doc', it changed doc/api.md. So it would reflect the link https://core.telegram.org/bots/api#sendDocument instead of https://core.telegram.org/bots/api#senddocument. The former link does not redirect the user to the sendDocument section of the documentation page. Thus, in order to prevent 'npm run doc' from automatically modifying doc/api.md, I have configured sendDocument with senddocument under @see on line 773 in src/telegram.js.
