### PR TITLE
[v4.0] Add tests and add minor improvement

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1228,7 +1228,7 @@ class TelegramBot extends EventEmitter {
    * @see https://core.telegram.org/bots/api#editmessagemedia
    */
   editMessageMedia(media, form = {}) {
-    form.media = media;
+    form.media = stringify(media);
     return this._request('editMessageMedia', { form });
   }  
 

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -1436,4 +1436,28 @@ describe('TelegramBot', function telegramSuite() {
       });
     });
   });
+
+  describe('#sendAnimation', function sendAnimationSuite() {
+    before(function before() {
+      utils.handleRatelimit(bot, 'sendAnimation', this);
+    });
+    it('should send a gif as an animation', function test() {
+      return bot.sendAnimation(USERID, `${__dirname}/data/photo.gif`).then(resp => {
+        assert.ok(is.object(resp));
+        assert.ok(is.object(resp.document));
+
+        describe('#editMessageMedia', function editMessageMediaSuite() {
+          before(function before() {
+            utils.handleRatelimit(bot, 'editMessageMedia', this);
+          });
+          it('should edit a media message', function test() {
+            return bot.editMessageMedia({ type: 'animation', media: resp.document.file_id, caption: 'media message edited'}, { chat_id: resp.chat.id, message_id: resp.message_id}).then(editedResp => {
+              assert.ok(is.object(editedResp));
+              assert.ok(is.string(editedResp.caption));
+            });
+          });
+        });
+      });
+    });
+  });  
 }); // End Telegram


### PR DESCRIPTION
 Follow up update to #625

 - Tests for both methods (sendAnimation, editMediaMessage) have been
 added. editMediaMessage is nested under sendAnimation, hence both tests
 are technically under a single block.

- Add an improvement/minor fix to the editMediaMessage method, where we
now stringify the first parameter (media) object interally within the
library. This allows the lib user to simply pass an object as the 1st
param without stringifying it.