### PR TITLE
feat: add support for poll_answer

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -588,6 +588,7 @@ class TelegramBot extends EventEmitter {
     const shippingQuery = update.shipping_query;
     const preCheckoutQuery = update.pre_checkout_query;
     const poll = update.poll;
+    const pollAnswer = update.poll_answer;
 
     if (message) {
       debug('Process Update message %j', message);
@@ -668,6 +669,9 @@ class TelegramBot extends EventEmitter {
     } else if (poll) {
       debug('Process Update poll %j', poll);
       this.emit('poll', poll);
+    } else if (pollAnswer) {
+      debug('Process Update poll_answer %j', pollAnswer);
+      this.emit('poll_answer', pollAnswer);
     }
   }
 


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass  (except game-related tests, which I managed to skip)
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->
Add support for `poll_answer`.
Currently, this library doesn't support `poll_answer` in `getUpdates`. Actually, this is easy to implement with several lines of code.

### References

https://core.telegram.org/bots/api#update (the last line of the table)

response format: (some data wiped)

```json
{
  "update_id": 12888888,
  "poll_answer": {
    "poll_id": "0000000000000000000",
    "user": {
      "id": 123456789,
      "is_bot": false,
      "first_name": "123456789",
      "last_name": "123456789",
      "username": "123456789",
      "language_code": "en"
    },
    "option_ids": [ 0 ]
  }
}
```

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
