### PR TITLE
Add methods to clear reply and text listeners

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1621,6 +1621,13 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Remove all listeners registered with `onText()`.
+   */
+  clearTextListeners() {
+    this._textRegexpCallbacks = [];
+  }
+
+  /**
    * Register a reply to wait for a message response.
    * @param  {Number|String}   chatId       The chat id where the message cames from.
    * @param  {Number|String}   messageId    The message id to be replied.
@@ -1654,6 +1661,13 @@ class TelegramBot extends EventEmitter {
       return null;
     }
     return this._replyListeners.splice(index, 1)[0];
+  }
+
+  /**
+   * Removes all replies that have been prev. registered for a message response.
+   */
+  clearReplyListeners() {
+    this._replyListeners = [];
   }
 
   /**


### PR DESCRIPTION
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

Sometimes it can be handy to be able to remote all reply and text listeners. Also removes the burden of needing to track what listeners are registered so you can unregister them with `removeTextListeners`/`removeReplyListeners`. Instead you can just use `clearTextListeners`/`clearReplyListeners`.
