### PR TITLE
fix: send animation

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -890,7 +890,7 @@ class TelegramBot extends EventEmitter {
     try {
       const sendData = this._formatSendData('animation', animation, fileOptions);
       opts.formData = sendData[0];
-      opts.qs.document = sendData[1];
+      opts.qs.animation = sendData[1];
     } catch (ex) {
       return Promise.reject(ex);
     }


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [ ] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->

Send Animation requires an `animation` field instead of `document`.

### References

https://core.telegram.org/bots/api#sendanimation

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
