### PR TITLE
Adding thumb support for for supported methods

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -240,6 +240,24 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Add thumb data if it is not URL string
+   * @param {Object} opts Object; Both 'qs' and 'form'
+   */
+  _addThumbData(opts) {
+    if (typeof opts.qs.thumb === 'object' && !Array.isArray(opts.qs.thumb)) {
+      if (!opts.qs.thumb.file) {
+        throw new errors.FatalError('Thumb file not provided.');
+      }
+      const thumbFile = opts.qs.thumb.file;
+      delete opts.qs.thumb.file;
+      const thumbData = this._formatSendData('thumb', thumbFile, opts.qs.thumb);
+      opts.formData = Object.assign(opts.formData, thumbData[0]);
+      opts.qs.thumb = thumbData[1];
+    }
+    return opts;
+  }
+
+  /**
    * Make request against the API
    * @param  {String} _path API endpoint
    * @param  {Object} [options]
@@ -815,7 +833,7 @@ class TelegramBot extends EventEmitter {
     } catch (ex) {
       return Promise.reject(ex);
     }
-    return this._request('sendAudio', opts);
+    return this._request('sendAudio', this._addThumbData(opts));
   }
 
   /**
@@ -863,7 +881,7 @@ class TelegramBot extends EventEmitter {
     } catch (ex) {
       return Promise.reject(ex);
     }
-    return this._request('sendDocument', opts);
+    return this._request('sendDocument', this._addThumbData(opts));
   }
 
   /**
@@ -914,7 +932,7 @@ class TelegramBot extends EventEmitter {
     } catch (ex) {
       return Promise.reject(ex);
     }
-    return this._request('sendVideo', opts);
+    return this._request('sendVideo', this._addThumbData(opts));
   }
 
   /**
@@ -940,7 +958,7 @@ class TelegramBot extends EventEmitter {
     } catch (ex) {
       return Promise.reject(ex);
     }
-    return this._request('sendAnimation', opts);
+    return this._request('sendAnimation', this._addThumbData(opts));
   }
 
   /**
@@ -967,7 +985,7 @@ class TelegramBot extends EventEmitter {
     } catch (ex) {
       return Promise.reject(ex);
     }
-    return this._request('sendVideoNote', opts);
+    return this._request('sendVideoNote', this._addThumbData(opts));
   }
 
   /**


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [ ] I have run `npm run doc`

### Description

Ability send `thumb`s for supported methods.
<!-- Explain what you are trying to achieve with this PR -->

### References

https://core.telegram.org/bots/api#sendaudio
<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
