### PR TITLE
Added support for listening on UNIX sockets for webhook requests

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -132,7 +132,7 @@ Emits `message` when a message arrives.
 | [options.webHook] | <code>Boolean</code> \| <code>Object</code> | <code>false</code> | Set true to enable WebHook or set options |
 | [options.webHook.host] | <code>String</code> | <code>&quot;0.0.0.0&quot;</code> | Host to bind to |
 | [options.webHook.port] | <code>Number</code> | <code>8443</code> | Port to bind to |
-| [options.webHook.path] | <code>String</code> |  | Path for a UNIX socket to bind to. Setting this option disables the TCP WebHook server unless host and/or port are explicitly specified |
+| [options.webHook.socketPath] | <code>String</code> |  | Path for a UNIX socket to bind to. Setting this option disables the TCP WebHook server unless host and/or port are explicitly specified |
 | [options.webHook.key] | <code>String</code> |  | Path to file with PEM private key for webHook server.  The file is read **synchronously**! |
 | [options.webHook.cert] | <code>String</code> |  | Path to file with PEM certificate (public) for webHook server.  The file is read **synchronously**! |
 | [options.webHook.pfx] | <code>String</code> |  | Path to file with PFX private key and certificate chain for webHook server.  The file is read **synchronously**! |

--- a/doc/api.md
+++ b/doc/api.md
@@ -114,7 +114,9 @@ TelegramBot
 <a name="new_TelegramBot_new"></a>
 
 ### new TelegramBot(token, [options])
-Both request method to obtain messages are implemented. To use standard polling, set `polling: true`on `options`. Notice that [webHook](https://core.telegram.org/bots/api#setwebhook) will need a SSL certificate.Emits `message` when a message arrives.
+Both request method to obtain messages are implemented. To use standard polling, set `polling: true`
+on `options`. Notice that [webHook](https://core.telegram.org/bots/api#setwebhook) will need a SSL certificate.
+Emits `message` when a message arrives.
 
 
 | Param | Type | Default | Description |
@@ -130,6 +132,7 @@ Both request method to obtain messages are implemented. To use standard polling,
 | [options.webHook] | <code>Boolean</code> \| <code>Object</code> | <code>false</code> | Set true to enable WebHook or set options |
 | [options.webHook.host] | <code>String</code> | <code>&quot;0.0.0.0&quot;</code> | Host to bind to |
 | [options.webHook.port] | <code>Number</code> | <code>8443</code> | Port to bind to |
+| [options.webHook.path] | <code>String</code> |  | Path for a UNIX socket to bind to. Setting this option disables the TCP WebHook server unless host and/or port are explicitly specified |
 | [options.webHook.key] | <code>String</code> |  | Path to file with PEM private key for webHook server.  The file is read **synchronously**! |
 | [options.webHook.cert] | <code>String</code> |  | Path to file with PEM certificate (public) for webHook server.  The file is read **synchronously**! |
 | [options.webHook.pfx] | <code>String</code> |  | Path to file with PFX private key and certificate chain for webHook server.  The file is read **synchronously**! |
@@ -145,7 +148,8 @@ Both request method to obtain messages are implemented. To use standard polling,
 <a name="TelegramBot+on"></a>
 
 ### telegramBot.on(event, listener)
-Add listener for the specified [event](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#events).This is the usual `emitter.on()` method.
+Add listener for the specified [event](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#events).
+This is the usual `emitter.on()` method.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**
@@ -162,7 +166,8 @@ Add listener for the specified [event](https://github.com/yagop/node-telegram-bo
 <a name="TelegramBot+startPolling"></a>
 
 ### telegramBot.startPolling([options]) ⇒ <code>Promise</code>
-Start polling.Rejects returned promise if a WebHook is being used by this instance.
+Start polling.
+Rejects returned promise if a WebHook is being used by this instance.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 
@@ -187,7 +192,9 @@ Alias of `TelegramBot#startPolling()`. This is **deprecated**.
 <a name="TelegramBot+stopPolling"></a>
 
 ### telegramBot.stopPolling([options]) ⇒ <code>Promise</code>
-Stops polling after the last polling request resolves.Multiple invocations do nothing if polling is already stopped.Returning the promise of the last polling request is **deprecated**.
+Stops polling after the last polling request resolves.
+Multiple invocations do nothing if polling is already stopped.
+Returning the promise of the last polling request is **deprecated**.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 
@@ -206,20 +213,24 @@ Return true if polling. Otherwise, false.
 <a name="TelegramBot+openWebHook"></a>
 
 ### telegramBot.openWebHook() ⇒ <code>Promise</code>
-Open webhook.Multiple invocations do nothing if webhook is already open.Rejects returned promise if Polling is being used by this instance.
+Open webhook.
+Multiple invocations do nothing if webhook is already open.
+Rejects returned promise if Polling is being used by this instance.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 <a name="TelegramBot+closeWebHook"></a>
 
 ### telegramBot.closeWebHook() ⇒ <code>Promise</code>
-Close webhook after closing all current connections.Multiple invocations do nothing if webhook is already closed.
+Close webhook after closing all current connections.
+Multiple invocations do nothing if webhook is already closed.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - promise  
 <a name="TelegramBot+hasOpenWebHook"></a>
 
 ### telegramBot.hasOpenWebHook() ⇒ <code>Boolean</code>
-Return true if using webhook and it is open i.e. accepts connections.Otherwise, false.
+Return true if using webhook and it is open i.e. accepts connections.
+Otherwise, false.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 <a name="TelegramBot+getMe"></a>
@@ -237,7 +248,10 @@ Returns basic information about the bot in form of a `User` object.
 <a name="TelegramBot+logOut"></a>
 
 ### telegramBot.logOut([options]) ⇒ <code>Promise</code>
-This method log out your bot from the cloud Bot API server before launching the bot locally.You must log out the bot before running it locally, otherwise there is no guarantee that the bot will receive updates.After a successful call, you will not be able to log in again using the same token for 10 minutes.Returns True on success.
+This method log out your bot from the cloud Bot API server before launching the bot locally.
+You must log out the bot before running it locally, otherwise there is no guarantee that the bot will receive updates.
+After a successful call, you will not be able to log in again using the same token for 10 minutes.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#logout  
@@ -249,7 +263,9 @@ This method log out your bot from the cloud Bot API server before launching the 
 <a name="TelegramBot+close"></a>
 
 ### telegramBot.close([options]) ⇒ <code>Promise</code>
-This method close the bot instance before moving it from one local server to another.This method will return error 429 in the first 10 minutes after the bot is launched.Returns True on success.
+This method close the bot instance before moving it from one local server to another.
+This method will return error 429 in the first 10 minutes after the bot is launched.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#close  
@@ -261,7 +277,9 @@ This method close the bot instance before moving it from one local server to ano
 <a name="TelegramBot+setWebHook"></a>
 
 ### telegramBot.setWebHook(url, [options], [fileOptions]) ⇒ <code>Promise</code>
-Specify an url to receive incoming updates via an outgoing webHook.This method has an [older, compatible signature][setWebHook-v0.25.0]that is being deprecated.
+Specify an url to receive incoming updates via an outgoing webHook.
+This method has an [older, compatible signature][setWebHook-v0.25.0]
+that is being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**
@@ -280,7 +298,8 @@ Specify an url to receive incoming updates via an outgoing webHook.This method 
 <a name="TelegramBot+deleteWebHook"></a>
 
 ### telegramBot.deleteWebHook([options]) ⇒ <code>Promise</code>
-Use this method to remove webhook integration if you decide toswitch back to getUpdates. Returns True on success.
+Use this method to remove webhook integration if you decide to
+switch back to getUpdates. Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#deletewebhook  
@@ -292,7 +311,10 @@ Use this method to remove webhook integration if you decide toswitch back to ge
 <a name="TelegramBot+getWebHookInfo"></a>
 
 ### telegramBot.getWebHookInfo([options]) ⇒ <code>Promise</code>
-Use this method to get current webhook status.On success, returns a [WebhookInfo](https://core.telegram.org/bots/api#webhookinfo) object.If the bot is using getUpdates, will return an object with theurl field empty.
+Use this method to get current webhook status.
+On success, returns a [WebhookInfo](https://core.telegram.org/bots/api#webhookinfo) object.
+If the bot is using getUpdates, will return an object with the
+url field empty.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getwebhookinfo  
@@ -304,7 +326,9 @@ Use this method to get current webhook status.On success, returns a [WebhookInf
 <a name="TelegramBot+getUpdates"></a>
 
 ### telegramBot.getUpdates([options]) ⇒ <code>Promise</code>
-Use this method to receive incoming updates using long polling.This method has an [older, compatible signature][getUpdates-v0.25.0]that is being deprecated.
+Use this method to receive incoming updates using long polling.
+This method has an [older, compatible signature][getUpdates-v0.25.0]
+that is being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getupdates  
@@ -316,7 +340,9 @@ Use this method to receive incoming updates using long polling.This method has 
 <a name="TelegramBot+processUpdate"></a>
 
 ### telegramBot.processUpdate(update)
-Process an update; emitting the proper events and executing regexpcallbacks. This method is useful should you be using a differentway to fetch updates, other than those provided by TelegramBot.
+Process an update; emitting the proper events and executing regexp
+callbacks. This method is useful should you be using a different
+way to fetch updates, other than those provided by TelegramBot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#update  
@@ -371,7 +397,10 @@ Forward messages of any kind.
 <a name="TelegramBot+copyMessage"></a>
 
 ### telegramBot.copyMessage(chatId, fromChatId, messageId, [options]) ⇒ <code>Promise</code>
-Copy messages of any kind.The method is analogous to the method forwardMessages, but the copied message doesn'thave a link to the original message.Returns the MessageId of the sent message on success.
+Copy messages of any kind.
+The method is analogous to the method forwardMessages, but the copied message doesn't
+have a link to the original message.
+Returns the MessageId of the sent message on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#copymessage  
@@ -424,7 +453,8 @@ Send audio
 <a name="TelegramBot+sendDice"></a>
 
 ### telegramBot.sendDice(chatId, [options]) ⇒ <code>Promise</code>
-Send DiceUse this method to send a dice.
+Send Dice
+Use this method to send a dice.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#senddice  
@@ -548,7 +578,11 @@ Send voice
 <a name="TelegramBot+sendChatAction"></a>
 
 ### telegramBot.sendChatAction(chatId, action, [options]) ⇒ <code>Promise</code>
-Send chat action.`typing` for text messages,`upload_photo` for photos, `record_video` or `upload_video` for videos,`record_audio` or `upload_audio` for audio files, `upload_document` for general files,`find_location` for location data.
+Send chat action.
+`typing` for text messages,
+`upload_photo` for photos, `record_video` or `upload_video` for videos,
+`record_voice` or `upload_voice` for audio files, `upload_document` for general files,
+`find_location` for location data.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendchataction  
@@ -562,7 +596,11 @@ Send chat action.`typing` for text messages,`upload_photo` for photos, `record
 <a name="TelegramBot+kickChatMember"></a>
 
 ### telegramBot.kickChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to kick a user from a group or a supergroup.In the case of supergroups, the user will not be able to returnto the group on their own using invite links, etc., unless unbannedfirst. The bot must be an administrator in the group for this to work.Returns True on success.
+Use this method to kick a user from a group or a supergroup.
+In the case of supergroups, the user will not be able to return
+to the group on their own using invite links, etc., unless unbanned
+first. The bot must be an administrator in the group for this to work.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#kickchatmember  
@@ -576,7 +614,10 @@ Use this method to kick a user from a group or a supergroup.In the case of supe
 <a name="TelegramBot+unbanChatMember"></a>
 
 ### telegramBot.unbanChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to unban a previously kicked user in a supergroup.The user will not return to the group automatically, but will beable to join via link, etc. The bot must be an administrator inthe group for this to work. Returns True on success.
+Use this method to unban a previously kicked user in a supergroup.
+The user will not return to the group automatically, but will be
+able to join via link, etc. The bot must be an administrator in
+the group for this to work. Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#unbanchatmember  
@@ -590,7 +631,10 @@ Use this method to unban a previously kicked user in a supergroup.The user will
 <a name="TelegramBot+restrictChatMember"></a>
 
 ### telegramBot.restrictChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to restrict a user in a supergroup.The bot must be an administrator in the supergroup for this to workand must have the appropriate admin rights. Pass True for all boolean parametersto lift restrictions from a user. Returns True on success.
+Use this method to restrict a user in a supergroup.
+The bot must be an administrator in the supergroup for this to work
+and must have the appropriate admin rights. Pass True for all boolean parameters
+to lift restrictions from a user. Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#restrictchatmember  
@@ -604,7 +648,10 @@ Use this method to restrict a user in a supergroup.The bot must be an administr
 <a name="TelegramBot+promoteChatMember"></a>
 
 ### telegramBot.promoteChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to promote or demote a user in a supergroup or a channel.The bot must be an administrator in the chat for this to workand must have the appropriate admin rights. Pass False for all boolean parameters to demote a user.Returns True on success.
+Use this method to promote or demote a user in a supergroup or a channel.
+The bot must be an administrator in the chat for this to work
+and must have the appropriate admin rights. Pass False for all boolean parameters to demote a user.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#promotechatmember  
@@ -618,7 +665,8 @@ Use this method to promote or demote a user in a supergroup or a channel.The bo
 <a name="TelegramBot+setChatAdministratorCustomTitle"></a>
 
 ### telegramBot.setChatAdministratorCustomTitle(chatId, userId, customTitle, [options]) ⇒ <code>Promise</code>
-Use this method to set a custom title for an administrator in a supergroup promoted by the bot.Returns True on success.
+Use this method to set a custom title for an administrator in a supergroup promoted by the bot.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setchatadministratorcustomtitle  
@@ -633,7 +681,10 @@ Use this method to set a custom title for an administrator in a supergroup promo
 <a name="TelegramBot+setChatPermissions"></a>
 
 ### telegramBot.setChatPermissions(chatId, chatPermissions, [options]) ⇒ <code>Promise</code>
-Use this method to set default chat permissions for all members.The bot must be an administrator in the group or a supergroup for this towork and must have the can_restrict_members admin rights.Returns True on success.
+Use this method to set default chat permissions for all members.
+The bot must be an administrator in the group or a supergroup for this to
+work and must have the can_restrict_members admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setchatpermissions  
@@ -647,7 +698,9 @@ Use this method to set default chat permissions for all members.The bot must be
 <a name="TelegramBot+exportChatInviteLink"></a>
 
 ### telegramBot.exportChatInviteLink(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to export an invite link to a supergroup or a channel.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns exported invite link as String on success.
+Use this method to export an invite link to a supergroup or a channel.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns exported invite link as String on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#exportchatinvitelink  
@@ -660,7 +713,9 @@ Use this method to export an invite link to a supergroup or a channel.The bot m
 <a name="TelegramBot+createChatInviteLink"></a>
 
 ### telegramBot.createChatInviteLink(chatId, [options]) ⇒ <code>Object</code>
-Use this method to create an additional invite link for a chat.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns the new invite link as ChatInviteLink object.
+Use this method to create an additional invite link for a chat.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns the new invite link as ChatInviteLink object.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Object</code> - ChatInviteLink  
@@ -674,7 +729,9 @@ Use this method to create an additional invite link for a chat.The bot must be 
 <a name="TelegramBot+editChatInviteLink"></a>
 
 ### telegramBot.editChatInviteLink(chatId, inviteLink, [options]) ⇒ <code>Object</code>
-Use this method to edit a non-primary invite link created by the bot.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns the edited invite link as a ChatInviteLink object.
+Use this method to edit a non-primary invite link created by the bot.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns the edited invite link as a ChatInviteLink object.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Object</code> - ChatInviteLink  
@@ -689,7 +746,10 @@ Use this method to edit a non-primary invite link created by the bot.The bot mu
 <a name="TelegramBot+revokeChatInviteLink"></a>
 
 ### telegramBot.revokeChatInviteLink(chatId, [options]) ⇒ <code>Object</code>
-Use this method to revoke an invite link created by the bot.Note: If the primary link is revoked, a new link is automatically generatedThe bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns the revoked invite link as ChatInviteLink object.
+Use this method to revoke an invite link created by the bot.
+Note: If the primary link is revoked, a new link is automatically generated
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns the revoked invite link as ChatInviteLink object.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Object</code> - ChatInviteLink  
@@ -703,7 +763,9 @@ Use this method to revoke an invite link created by the bot.Note: If the primar
 <a name="TelegramBot+setChatPhoto"></a>
 
 ### telegramBot.setChatPhoto(chatId, photo, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to set a new profile photo for the chat. Photos can't be changed for private chats.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to set a new profile photo for the chat. Photos can't be changed for private chats.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setchatphoto  
@@ -718,7 +780,9 @@ Use this method to set a new profile photo for the chat. Photos can't be changed
 <a name="TelegramBot+deleteChatPhoto"></a>
 
 ### telegramBot.deleteChatPhoto(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to delete a chat photo. Photos can't be changed for private chats.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to delete a chat photo. Photos can't be changed for private chats.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#deletechatphoto  
@@ -731,7 +795,9 @@ Use this method to delete a chat photo. Photos can't be changed for private chat
 <a name="TelegramBot+setChatTitle"></a>
 
 ### telegramBot.setChatTitle(chatId, title, [options]) ⇒ <code>Promise</code>
-Use this method to change the title of a chat. Titles can't be changed for private chats.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to change the title of a chat. Titles can't be changed for private chats.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setchattitle  
@@ -745,7 +811,9 @@ Use this method to change the title of a chat. Titles can't be changed for priva
 <a name="TelegramBot+setChatDescription"></a>
 
 ### telegramBot.setChatDescription(chatId, description, [options]) ⇒ <code>Promise</code>
-Use this method to change the description of a supergroup or a channel.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to change the description of a supergroup or a channel.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setchatdescription  
@@ -759,7 +827,9 @@ Use this method to change the description of a supergroup or a channel.The bot 
 <a name="TelegramBot+pinChatMessage"></a>
 
 ### telegramBot.pinChatMessage(chatId, messageId, [options]) ⇒ <code>Promise</code>
-Use this method to pin a message in a supergroup.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to pin a message in a supergroup.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#pinchatmessage  
@@ -773,7 +843,9 @@ Use this method to pin a message in a supergroup.The bot must be an administrat
 <a name="TelegramBot+unpinChatMessage"></a>
 
 ### telegramBot.unpinChatMessage(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to unpin a message in a supergroup chat.The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to unpin a message in a supergroup chat.
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#unpinchatmessage  
@@ -786,7 +858,9 @@ Use this method to unpin a message in a supergroup chat.The bot must be an admi
 <a name="TelegramBot+unpinAllChatMessages"></a>
 
 ### telegramBot.unpinAllChatMessages(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to clear the list of pinned messages in a chatThe bot must be an administrator in the chat for this to work and must have the appropriate admin rights.Returns True on success.
+Use this method to clear the list of pinned messages in a chat
+The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#unpinallchatmessages  
@@ -799,7 +873,13 @@ Use this method to clear the list of pinned messages in a chatThe bot must be a
 <a name="TelegramBot+answerCallbackQuery"></a>
 
 ### telegramBot.answerCallbackQuery(callbackQueryId, [options]) ⇒ <code>Promise</code>
-Use this method to send answers to callback queries sent frominline keyboards. The answer will be displayed to the user asa notification at the top of the chat screen or as an alert.On success, True is returned.This method has **older, compatible signatures ([1][answerCallbackQuery-v0.27.1])([2][answerCallbackQuery-v0.29.0])**that are being deprecated.
+Use this method to send answers to callback queries sent from
+inline keyboards. The answer will be displayed to the user as
+a notification at the top of the chat screen or as an alert.
+On success, True is returned.
+
+This method has **older, compatible signatures ([1][answerCallbackQuery-v0.27.1])([2][answerCallbackQuery-v0.29.0])**
+that are being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#answercallbackquery  
@@ -812,7 +892,8 @@ Use this method to send answers to callback queries sent frominline keyboards. 
 <a name="TelegramBot+setMyCommands"></a>
 
 ### telegramBot.setMyCommands(commands, [options]) ⇒ <code>Promise</code>
-Returns True on success.Use this method to change the list of the bot's commands.
+Returns True on success.
+Use this method to change the list of the bot's commands.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setmycommands  
@@ -837,7 +918,12 @@ Returns Array of BotCommand on success.
 <a name="TelegramBot+editMessageText"></a>
 
 ### telegramBot.editMessageText(text, [options]) ⇒ <code>Promise</code>
-Use this method to edit text messages sent by the bot or viathe bot (for inline bots). On success, the edited Message isreturned.Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
+Use this method to edit text messages sent by the bot or via
+the bot (for inline bots). On success, the edited Message is
+returned.
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#editmessagetext  
@@ -850,7 +936,12 @@ Use this method to edit text messages sent by the bot or viathe bot (for inline
 <a name="TelegramBot+editMessageCaption"></a>
 
 ### telegramBot.editMessageCaption(caption, [options]) ⇒ <code>Promise</code>
-Use this method to edit captions of messages sent by thebot or via the bot (for inline bots). On success, theedited Message is returned.Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
+Use this method to edit captions of messages sent by the
+bot or via the bot (for inline bots). On success, the
+edited Message is returned.
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#editmessagecaption  
@@ -863,7 +954,14 @@ Use this method to edit captions of messages sent by thebot or via the bot (for
 <a name="TelegramBot+editMessageMedia"></a>
 
 ### telegramBot.editMessageMedia(media, [options]) ⇒ <code>Promise</code>
-Use this method to edit audio, document, photo, or video messages.If a message is a part of a message album, then it can be edited only to a photo or a video.Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded.Use previously uploaded file via its file_id or specify a URL.On success, the edited Message is returned.Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
+Use this method to edit audio, document, photo, or video messages.
+If a message is a part of a message album, then it can be edited only to a photo or a video.
+Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded.
+Use previously uploaded file via its file_id or specify a URL.
+On success, the edited Message is returned.
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#editmessagemedia  
@@ -876,7 +974,12 @@ Use this method to edit audio, document, photo, or video messages.If a message 
 <a name="TelegramBot+editMessageReplyMarkup"></a>
 
 ### telegramBot.editMessageReplyMarkup(replyMarkup, [options]) ⇒ <code>Promise</code>
-Use this method to edit only the reply markup of messagessent by the bot or via the bot (for inline bots).On success, the edited Message is returned.Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
+Use this method to edit only the reply markup of messages
+sent by the bot or via the bot (for inline bots).
+On success, the edited Message is returned.
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#editmessagetext  
@@ -889,7 +992,10 @@ Use this method to edit only the reply markup of messagessent by the bot or via
 <a name="TelegramBot+getUserProfilePhotos"></a>
 
 ### telegramBot.getUserProfilePhotos(userId, [options]) ⇒ <code>Promise</code>
-Use this method to get a list of profile pictures for a user.Returns a [UserProfilePhotos](https://core.telegram.org/bots/api#userprofilephotos) object.This method has an [older, compatible signature][getUserProfilePhotos-v0.25.0]that is being deprecated.
+Use this method to get a list of profile pictures for a user.
+Returns a [UserProfilePhotos](https://core.telegram.org/bots/api#userprofilephotos) object.
+This method has an [older, compatible signature][getUserProfilePhotos-v0.25.0]
+that is being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getuserprofilephotos  
@@ -902,7 +1008,8 @@ Use this method to get a list of profile pictures for a user.Returns a [UserPro
 <a name="TelegramBot+sendLocation"></a>
 
 ### telegramBot.sendLocation(chatId, latitude, longitude, [options]) ⇒ <code>Promise</code>
-Send location.Use this method to send point on the map.
+Send location.
+Use this method to send point on the map.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendlocation  
@@ -917,7 +1024,11 @@ Send location.Use this method to send point on the map.
 <a name="TelegramBot+editMessageLiveLocation"></a>
 
 ### telegramBot.editMessageLiveLocation(latitude, longitude, [options]) ⇒ <code>Promise</code>
-Use this method to edit live location messages sent bythe bot or via the bot (for inline bots).Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
+Use this method to edit live location messages sent by
+the bot or via the bot (for inline bots).
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#editmessagelivelocation  
@@ -931,7 +1042,11 @@ Use this method to edit live location messages sent bythe bot or via the bot (f
 <a name="TelegramBot+stopMessageLiveLocation"></a>
 
 ### telegramBot.stopMessageLiveLocation([options]) ⇒ <code>Promise</code>
-Use this method to stop updating a live location message sent bythe bot or via the bot (for inline bots) before live_period expires.Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
+Use this method to stop updating a live location message sent by
+the bot or via the bot (for inline bots) before live_period expires.
+
+Note that you must provide one of chat_id, message_id, or
+inline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#stopmessagelivelocation  
@@ -943,7 +1058,8 @@ Use this method to stop updating a live location message sent bythe bot or via 
 <a name="TelegramBot+sendVenue"></a>
 
 ### telegramBot.sendVenue(chatId, latitude, longitude, title, address, [options]) ⇒ <code>Promise</code>
-Send venue.Use this method to send information about a venue.
+Send venue.
+Use this method to send information about a venue.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendvenue  
@@ -960,7 +1076,8 @@ Send venue.Use this method to send information about a venue.
 <a name="TelegramBot+sendContact"></a>
 
 ### telegramBot.sendContact(chatId, phoneNumber, firstName, [options]) ⇒ <code>Promise</code>
-Send contact.Use this method to send phone contacts.
+Send contact.
+Use this method to send phone contacts.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendcontact  
@@ -975,7 +1092,8 @@ Send contact.Use this method to send phone contacts.
 <a name="TelegramBot+sendPoll"></a>
 
 ### telegramBot.sendPoll(chatId, question, pollOptions, [options]) ⇒ <code>Promise</code>
-Send poll.Use this method to send a native poll.
+Send poll.
+Use this method to send a native poll.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendpoll  
@@ -990,7 +1108,8 @@ Send poll.Use this method to send a native poll.
 <a name="TelegramBot+stopPoll"></a>
 
 ### telegramBot.stopPoll(chatId, pollId, [options]) ⇒ <code>Promise</code>
-Stop poll.Use this method to stop a native poll.
+Stop poll.
+Use this method to stop a native poll.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#stoppoll  
@@ -1004,7 +1123,9 @@ Stop poll.Use this method to stop a native poll.
 <a name="TelegramBot+getFile"></a>
 
 ### telegramBot.getFile(fileId, [options]) ⇒ <code>Promise</code>
-Get file.Use this method to get basic info about a file and prepare it for downloading.Attention: link will be valid for 1 hour.
+Get file.
+Use this method to get basic info about a file and prepare it for downloading.
+Attention: link will be valid for 1 hour.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getfile  
@@ -1017,7 +1138,12 @@ Get file.Use this method to get basic info about a file and prepare it for down
 <a name="TelegramBot+getFileLink"></a>
 
 ### telegramBot.getFileLink(fileId, [options]) ⇒ <code>Promise</code>
-Get link for file.Use this method to get link for file for subsequent use.Attention: link will be valid for 1 hour.This method is a sugar extension of the (getFile)[#getfilefileid] method,which returns just path to file on remote server (you will have to manually build full uri after that).
+Get link for file.
+Use this method to get link for file for subsequent use.
+Attention: link will be valid for 1 hour.
+
+This method is a sugar extension of the (getFile)[#getfilefileid] method,
+which returns just path to file on remote server (you will have to manually build full uri after that).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - promise Promise which will have *fileURI* in resolve callback  
@@ -1031,7 +1157,15 @@ Get link for file.Use this method to get link for file for subsequent use.Atte
 <a name="TelegramBot+getFileStream"></a>
 
 ### telegramBot.getFileStream(fileId, [options]) ⇒ <code>stream.Readable</code>
-Return a readable stream for file.`fileStream.path` is the specified file ID i.e. `fileId`.`fileStream` emits event `info` passing a single argument i.e.`info` with the interface `{ uri }` where `uri` is the URI of thefile on Telegram servers.This method is a sugar extension of the [getFileLink](#TelegramBot+getFileLink) method,which returns the full URI to the file on remote server.
+Return a readable stream for file.
+
+`fileStream.path` is the specified file ID i.e. `fileId`.
+`fileStream` emits event `info` passing a single argument i.e.
+`info` with the interface `{ uri }` where `uri` is the URI of the
+file on Telegram servers.
+
+This method is a sugar extension of the [getFileLink](#TelegramBot+getFileLink) method,
+which returns the full URI to the file on remote server.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>stream.Readable</code> - fileStream  
@@ -1044,7 +1178,10 @@ Return a readable stream for file.`fileStream.path` is the specified file ID i
 <a name="TelegramBot+downloadFile"></a>
 
 ### telegramBot.downloadFile(fileId, downloadDir, [options]) ⇒ <code>Promise</code>
-Downloads file in the specified folder.This method is a sugar extension of the [getFileStream](#TelegramBot+getFileStream) method,which returns a readable file stream.
+Downloads file in the specified folder.
+
+This method is a sugar extension of the [getFileStream](#TelegramBot+getFileStream) method,
+which returns a readable file stream.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - promise Promise, which will have *filePath* of downloaded file in resolve callback  
@@ -1073,7 +1210,9 @@ Register a RegExp to test against an incomming text message.
 Remove a listener registered with `onText()`.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
-**Returns**: <code>Object</code> - deletedListener The removed reply listener if  found. This object has `regexp` and `callback`  properties. If not found, returns `null`.  
+**Returns**: <code>Object</code> - deletedListener The removed reply listener if
+  found. This object has `regexp` and `callback`
+  properties. If not found, returns `null`.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1105,7 +1244,9 @@ Register a reply to wait for a message response.
 Removes a reply that has been prev. registered for a message response.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
-**Returns**: <code>Object</code> - deletedListener      The removed reply listener if  found. This object has `id`, `chatId`, `messageId` and `callback`  properties. If not found, returns `null`.  
+**Returns**: <code>Object</code> - deletedListener      The removed reply listener if
+  found. This object has `id`, `chatId`, `messageId` and `callback`
+  properties. If not found, returns `null`.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1120,7 +1261,9 @@ Removes all replies that have been prev. registered for a message response.
 <a name="TelegramBot+getChat"></a>
 
 ### telegramBot.getChat(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to get up to date information about the chat(current name of the user for one-on-one conversations, currentusername of a user, group or channel, etc.).
+Use this method to get up to date information about the chat
+(current name of the user for one-on-one conversations, current
+username of a user, group or channel, etc.).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getchat  
@@ -1268,7 +1411,8 @@ Use this method to delete a message.
 <a name="TelegramBot+sendInvoice"></a>
 
 ### telegramBot.sendInvoice(chatId, title, description, payload, providerToken, startParameter, currency, prices, [options]) ⇒ <code>Promise</code>
-Send invoice.Use this method to send an invoice.
+Send invoice.
+Use this method to send an invoice.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendinvoice  
@@ -1288,7 +1432,8 @@ Send invoice.Use this method to send an invoice.
 <a name="TelegramBot+answerShippingQuery"></a>
 
 ### telegramBot.answerShippingQuery(shippingQueryId, ok, [options]) ⇒ <code>Promise</code>
-Answer shipping query..Use this method to reply to shipping queries.
+Answer shipping query..
+Use this method to reply to shipping queries.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#answershippingquery  
@@ -1302,7 +1447,8 @@ Answer shipping query..Use this method to reply to shipping queries.
 <a name="TelegramBot+answerPreCheckoutQuery"></a>
 
 ### telegramBot.answerPreCheckoutQuery(preCheckoutQueryId, ok, [options]) ⇒ <code>Promise</code>
-Answer pre-checkout query.Use this method to confirm shipping of a product.
+Answer pre-checkout query.
+Use this method to confirm shipping of a product.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#answerprecheckoutquery  
@@ -1329,7 +1475,8 @@ Use this method to get a sticker set. On success, a [StickerSet](https://core.te
 <a name="TelegramBot+uploadStickerFile"></a>
 
 ### telegramBot.uploadStickerFile(userId, pngSticker, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to upload a .png file with a sticker for later use in *createNewStickerSet* and *addStickerToSet* methods (can be used multipletimes). Returns the uploaded [File](https://core.telegram.org/bots/api#file) on success.
+Use this method to upload a .png file with a sticker for later use in *createNewStickerSet* and *addStickerToSet* methods (can be used multiple
+times). Returns the uploaded [File](https://core.telegram.org/bots/api#file) on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#uploadstickerfile  
@@ -1344,7 +1491,9 @@ Use this method to upload a .png file with a sticker for later use in *createNew
 <a name="TelegramBot+createNewStickerSet"></a>
 
 ### telegramBot.createNewStickerSet(userId, name, title, pngSticker, emojis, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to create new sticker set owned by a user.The bot will be able to edit the created sticker set.Returns True on success.
+Use this method to create new sticker set owned by a user.
+The bot will be able to edit the created sticker set.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#createnewstickerset  
@@ -1366,7 +1515,8 @@ Use this method to create new sticker set owned by a user.The bot will be able 
 <a name="TelegramBot+addStickerToSet"></a>
 
 ### telegramBot.addStickerToSet(userId, name, pngSticker, emojis, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to add a new sticker to a set created by the bot.Returns True on success.
+Use this method to add a new sticker to a set created by the bot.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#addstickertoset  
@@ -1387,7 +1537,8 @@ Use this method to add a new sticker to a set created by the bot.Returns True o
 <a name="TelegramBot+setStickerPositionInSet"></a>
 
 ### telegramBot.setStickerPositionInSet(sticker, position, [options]) ⇒ <code>Promise</code>
-Use this method to move a sticker in a set created by the bot to a specific position.Returns True on success.
+Use this method to move a sticker in a set created by the bot to a specific position.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setstickerpositioninset  
@@ -1405,7 +1556,8 @@ Use this method to move a sticker in a set created by the bot to a specific posi
 <a name="TelegramBot+deleteStickerFromSet"></a>
 
 ### telegramBot.deleteStickerFromSet(sticker, [options]) ⇒ <code>Promise</code>
-Use this method to delete a sticker from a set created by the bot.Returns True on success.
+Use this method to delete a sticker from a set created by the bot.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#deletestickerfromset  
@@ -1422,7 +1574,12 @@ Use this method to delete a sticker from a set created by the bot.Returns True 
 <a name="TelegramBot+sendMediaGroup"></a>
 
 ### telegramBot.sendMediaGroup(chatId, media, [options]) ⇒ <code>Promise</code>
-Use this method to send a group of photos or videos as an album.On success, an array of the sent [Messages](https://core.telegram.org/bots/api#message)is returned.If you wish to [specify file options](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files),add a `fileOptions` property to the target input in `media`.
+Use this method to send a group of photos or videos as an album.
+On success, an array of the sent [Messages](https://core.telegram.org/bots/api#message)
+is returned.
+
+If you wish to [specify file options](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files),
+add a `fileOptions` property to the target input in `media`.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**
@@ -1452,7 +1609,8 @@ The types of message updates the library handles.
 <a name="TelegramBot.Promise"></a>
 
 ### TelegramBot.Promise
-Change Promise library used internally, for all existing and newinstances.
+Change Promise library used internally, for all existing and new
+instances.
 
 **Kind**: static property of [<code>TelegramBot</code>](#TelegramBot)  
 
@@ -1462,7 +1620,8 @@ Change Promise library used internally, for all existing and newinstances.
 
 **Example**  
 ```js
-const TelegramBot = require('node-telegram-bot-api');TelegramBot.Promise = myPromise;
+const TelegramBot = require('node-telegram-bot-api');
+TelegramBot.Promise = myPromise;
 ```
 * * *
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-telegram-bot-api",
+  "name": "@kascheml/node-telegram-bot-api",
   "version": "0.53.0",
   "description": "Telegram Bot API",
   "main": "./index.js",

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -166,7 +166,7 @@ class TelegramBot extends EventEmitter {
    * @param {Boolean|Object} [options.webHook=false] Set true to enable WebHook or set options
    * @param {String} [options.webHook.host="0.0.0.0"] Host to bind to
    * @param {Number} [options.webHook.port=8443] Port to bind to
-   * @param {String} [options.webHook.path] Path for a UNIX socket to bind to. Setting this option disables the TCP WebHook server unless host and/or port are explicitly specified
+   * @param {String} [options.webHook.socketPath] Path for a UNIX socket to bind to. Setting this option disables the TCP WebHook server unless host and/or port are explicitly specified
    * @param {String} [options.webHook.key] Path to file with PEM private key for webHook server.
    *  The file is read **synchronously**!
    * @param {String} [options.webHook.cert] Path to file with PEM certificate (public) for webHook server.

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -166,6 +166,7 @@ class TelegramBot extends EventEmitter {
    * @param {Boolean|Object} [options.webHook=false] Set true to enable WebHook or set options
    * @param {String} [options.webHook.host="0.0.0.0"] Host to bind to
    * @param {Number} [options.webHook.port=8443] Port to bind to
+   * @param {String} [options.webHook.path] Path for a UNIX socket to bind to. Setting this option disables the TCP WebHook server unless host and/or port are explicitly specified
    * @param {String} [options.webHook.key] Path to file with PEM private key for webHook server.
    *  The file is read **synchronously**!
    * @param {String} [options.webHook.cert] Path to file with PEM certificate (public) for webHook server.

--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -51,29 +51,23 @@ class TelegramBotWebHook {
       return Promise.resolve();
     }
 
-    const promises = [];
-
-    if (this.options.path) {
-      promises.push(new Promise(resolve => {
-        this._webServer.listen(this.options.path, () => {
-          debug('WebHook listening on UNIX socket %s', this.options.path);
-          this._open = true;
-          return resolve();
-        });
-      }));
-    }
-
-    if (this.options.host || this.options.port || !this.options.path) {
-      promises.push(new Promise(resolve => {
+    if (this.options.host || this.options.port || !this.options.socketPath) {
+      return new Promise(resolve => {
         this._webServer.listen(this.options.port || 8443, this.options.host || '0.0.0.0', () => {
           debug('WebHook listening on port %s', this.options.port);
           this._open = true;
           return resolve();
         });
-      }));
+      });
     }
 
-    return Promise.all(promises);
+    return new Promise(resolve => {
+      this._webServer.listen(this.options.socketPath, () => {
+        debug('WebHook listening on UNIX socket %s', this.options.socketPath);
+        this._open = true;
+        return resolve();
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
  - I don't have a provider token to run the tests
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->
This PR allows bot admins to use webhooks with UNIX sockets to bind for reverse proxies
