### PR TITLE
Support for Telegram Bot API 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.55.0][0.55.0] - 2021-11-06
+
+Added:
+
+1. Support Bot API v5.4: (@danielperez9430)
+
+   * Add method *approveChatJoinRequest()*
+   * Add method *declineChatJoinRequest()*
+   * Add support for new updates:
+     * *chat_join_request*
+
 ## [0.54.0][0.54.0] - 2021-06-29
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Added:
    * Add method *declineChatJoinRequest()*
    * Add support for new updates:
      * *chat_join_request*
+   
+   Fixes:
+
+   * Method *editMessageMedia*: Now you can send a local file (`"attach://" + filePatch`)
 
 ## [0.54.0][0.54.0] - 2021-06-29
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node.js module to interact with the official [Telegram Bot API](https://core.telegram.org/bots/api).
 
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-v.5.2-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-v.5.4-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
 [![Build Status](https://img.shields.io/travis/yagop/node-telegram-bot-api/master?style=flat-square&logo=travis)](https://travis-ci.org/yagop/node-telegram-bot-api)
 [![Coverage Status](https://img.shields.io/codecov/c/github/yagop/node-telegram-bot-api?style=flat-square&logo=codecov)](https://codecov.io/gh/yagop/node-telegram-bot-api)

--- a/doc/api.md
+++ b/doc/api.md
@@ -782,6 +782,40 @@ Returns the revoked invite link as ChatInviteLink object.
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target supergroup |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
+<a name="TelegramBot+approveChatJoinRequest"></a>
+
+### telegramBot.approveChatJoinRequest(chatId, userId, [options]) ⇒ <code>Boolean</code>
+Use this method to approve a chat join request. 
+The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right.
+Returns True on success.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Boolean</code> - True on success  
+**See**: https://core.telegram.org/bots/api#approvechatjoinrequest  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target supergroup |
+| userId | <code>Number</code> | Unique identifier of the target user |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+declineChatJoinRequest"></a>
+
+### telegramBot.declineChatJoinRequest(chatId, userId, [options]) ⇒ <code>Boolean</code>
+Use this method to decline a chat join request.
+The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right.
+Returns True on success.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Boolean</code> - True on success  
+**See**: https://core.telegram.org/bots/api#declinechatjoinrequest  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target supergroup |
+| userId | <code>Number</code> | Unique identifier of the target user |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
 <a name="TelegramBot+setChatPhoto"></a>
 
 ### telegramBot.setChatPhoto(chatId, photo, [options], [fileOptions]) ⇒ <code>Promise</code>

--- a/doc/api.md
+++ b/doc/api.md
@@ -54,6 +54,8 @@ TelegramBot
         * [.createChatInviteLink(chatId, [options])](#TelegramBot+createChatInviteLink) ⇒ <code>Object</code>
         * [.editChatInviteLink(chatId, inviteLink, [options])](#TelegramBot+editChatInviteLink) ⇒ <code>Object</code>
         * [.revokeChatInviteLink(chatId, [options])](#TelegramBot+revokeChatInviteLink) ⇒ <code>Object</code>
+        * [.approveChatJoinRequest(chatId, userId, [options])](#TelegramBot+approveChatJoinRequest) ⇒ <code>Boolean</code>
+        * [.declineChatJoinRequest(chatId, userId, [options])](#TelegramBot+declineChatJoinRequest) ⇒ <code>Boolean</code>
         * [.setChatPhoto(chatId, photo, [options], [fileOptions])](#TelegramBot+setChatPhoto) ⇒ <code>Promise</code>
         * [.deleteChatPhoto(chatId, [options])](#TelegramBot+deleteChatPhoto) ⇒ <code>Promise</code>
         * [.setChatTitle(chatId, title, [options])](#TelegramBot+setChatTitle) ⇒ <code>Promise</code>
@@ -584,7 +586,8 @@ Send chat action.
 `typing` for text messages,
 `upload_photo` for photos, `record_video` or `upload_video` for videos,
 `record_voice` or `upload_voice` for audio files, `upload_document` for general files,
-`find_location` for location data.
+`choose_sticker` for stickers, `find_location` for location data,
+`record_video_note` or `upload_video_note` for video notes.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#sendchataction  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Telegram Bot API",
   "main": "./index.js",
   "directories": {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -624,6 +624,7 @@ class TelegramBot extends EventEmitter {
     const pollAnswer = update.poll_answer;
     const chatMember = update.chat_member;
     const myChatMember = update.my_chat_member;
+    const chatJoinRequest = update.chat_join_request;
 
     if (message) {
       debug('Process Update message %j', message);
@@ -713,6 +714,9 @@ class TelegramBot extends EventEmitter {
     } else if (myChatMember) {
       debug('Process Update my_chat_member %j', myChatMember);
       this.emit('my_chat_member', myChatMember);
+    } else if (chatJoinRequest) {
+      debug('Process Update my_chat_member %j', chatJoinRequest);
+      this.emit('chat_join_request', chatJoinRequest);
     }
   }
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1017,7 +1017,8 @@ class TelegramBot extends EventEmitter {
    * `typing` for text messages,
    * `upload_photo` for photos, `record_video` or `upload_video` for videos,
    * `record_voice` or `upload_voice` for audio files, `upload_document` for general files,
-   * `find_location` for location data.
+   * `choose_sticker` for stickers, `find_location` for location data,
+   * `record_video_note` or `upload_video_note` for video notes.
    *
    * @param  {Number|String} chatId  Unique identifier for the message recipient
    * @param  {String} action Type of action to broadcast.

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1225,6 +1225,40 @@ class TelegramBot extends EventEmitter {
     return this._request('revokeChatInviteLink', { form });
   }
 
+  /**
+   * Use this method to approve a chat join request. 
+   * The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right.
+   * Returns True on success.
+   *
+   * @param  {Number|String} chatId Unique identifier for the target chat or username of the target supergroup
+   * @param  {Number} userId  Unique identifier of the target user
+   * @param  {Object} [options] Additional Telegram query options
+   * @return {Boolean} True on success
+   * @see https://core.telegram.org/bots/api#approvechatjoinrequest
+   */
+  approveChatJoinRequest(chatId, userId, form = {}) {
+    form.chat_id = chatId;
+    form.user_id = userId;
+    return this._request('approveChatJoinRequest', { form });
+  }
+
+  /**
+   * Use this method to decline a chat join request.
+   * The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right.
+   * Returns True on success.
+   *
+   * @param  {Number|String} chatId Unique identifier for the target chat or username of the target supergroup
+   * @param  {Number} userId  Unique identifier of the target user
+   * @param  {Object} [options] Additional Telegram query options
+   * @return {Boolean} True on success
+   * @see https://core.telegram.org/bots/api#declinechatjoinrequest
+   */
+  declineChatJoinRequest(chatId, userId, form = {}) {
+    form.chat_id = chatId;
+    form.user_id = userId;
+    return this._request('declineChatJoinRequest', { form });
+  }
+
 
   /**
    * Use this method to set a new profile photo for the chat. Photos can't be changed for private chats.


### PR DESCRIPTION
- [X] All tests pass
- [X] I have run `npm run doc`

### Description

 Support Bot API v5.4: 
   * Add method *approveChatJoinRequest()*
   * Add method *declineChatJoinRequest()*
   * Add support for new updates:
     * *chat_join_request*
Fixes:
* Method *editMessageMedia()* (Now you can send local files)
 

### References

* Telegram Bot API v5.4 - https://core.telegram.org/bots/api#november-5-2021https://core.telegram.org/bots/api#november-5-2021

### Use examples

Listen event "chat_join_request": 

```js
bot.on('chat_join_request', data => {
  console.log("Join Request");
  console.log(data);
});
```

Example `approveChatJoinRequest`:

```js
bot.on('chat_join_request', join_request => {

  let chat_id = join_request.chat.id;
  let user_id = join_request.from.id;
  
  bot.approveChatJoinRequest(chat_id, user_id);

  bot.sendMessage(chat_id, "Welcome " + join_request.from.first_name + ", invitation accepted")
})
```

Example `declineChatJoinRequest`:

```js
bot.on('chat_join_request', join_request => {

  let chat_id = join_request.chat.id;
  let user_id = join_request.from.id;

  bot.declineChatJoinRequest(chat_id, user_id)

  bot.sendMessage(chat_id, "Decline chat join for " + join_request.from.first_name)
})
```