### PR TITLE
Support for Telegram Bot API 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.57.0][0.57.0] - 2022-04-23
+
+Added:
+
+1. Support Bot API v6: (@danielperez9430)
+
+   * Add method *setChatMenuButton()*
+   * Add method *getChatMenuButton()*
+   * Add method *setMyDefaultAdministratorRights()*
+   * Add method *getMyDefaultAdministratorRights()*
+   * Add method *answerWebAppQuery()*
+   * Renamed the fields voice_chat_scheduled, voice_chat_started, voice_chat_ended, and voice_chat_participants_invited to video_chat_scheduled, video_chat_started, video_chat_ended, and video_chat_participants_invited 
+
+
+   Tests:
+
+   * answerWebAppQuery
+   * setChatMenuButton
+   * getChatMenuButton
+   * setMyDefaultAdministratorRights
+   * getMyDefaultAdministratorRights
+
 ## [0.56.0][0.56.0] - 2021-12-07
 
 Added:

--- a/doc/api.md
+++ b/doc/api.md
@@ -66,8 +66,13 @@ TelegramBot
         * [.unpinChatMessage(chatId, [options])](#TelegramBot+unpinChatMessage) ⇒ <code>Promise</code>
         * [.unpinAllChatMessages(chatId, [options])](#TelegramBot+unpinAllChatMessages) ⇒ <code>Promise</code>
         * [.answerCallbackQuery(callbackQueryId, [options])](#TelegramBot+answerCallbackQuery) ⇒ <code>Promise</code>
+        * [.answerWebAppQuery(webAppQueryId, result, [options])](#TelegramBot+answerWebAppQuery) ⇒ <code>Promise</code>
         * [.setMyCommands(commands, [options])](#TelegramBot+setMyCommands) ⇒ <code>Promise</code>
         * [.getMyCommands([options])](#TelegramBot+getMyCommands) ⇒ <code>Promise</code>
+        * [.setChatMenuButton([options])](#TelegramBot+setChatMenuButton) ⇒ <code>Promise</code>
+        * [.getChatMenuButton([options])](#TelegramBot+getChatMenuButton) ⇒ <code>Promise</code>
+        * [.setMyDefaultAdministratorRights([options])](#TelegramBot+setMyDefaultAdministratorRights) ⇒ <code>Promise</code>
+        * [.getMyDefaultAdministratorRights([options])](#TelegramBot+getMyDefaultAdministratorRights) ⇒ <code>Promise</code>
         * [.deleteMyCommands([options])](#TelegramBot+deleteMyCommands) ⇒ <code>Promise</code>
         * [.editMessageText(text, [options])](#TelegramBot+editMessageText) ⇒ <code>Promise</code>
         * [.editMessageCaption(caption, [options])](#TelegramBot+editMessageCaption) ⇒ <code>Promise</code>
@@ -985,11 +990,26 @@ that are being deprecated.
 | callbackQueryId | <code>String</code> | Unique identifier for the query to be answered |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
+<a name="TelegramBot+answerWebAppQuery"></a>
+
+### telegramBot.answerWebAppQuery(webAppQueryId, result, [options]) ⇒ <code>Promise</code>
+Use this method to set the result of an interaction with a Web App and send a corresponding message on behalf of the user to the chat from which the query originated.
+On success, a SentWebAppMessage object is returned.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**: https://core.telegram.org/bots/api#answercallbackquery  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| webAppQueryId | <code>String</code> | Unique identifier for the query to be answered |
+| result | <code>InlineQueryResult</code> | object that represents one result of an inline query |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
 <a name="TelegramBot+setMyCommands"></a>
 
 ### telegramBot.setMyCommands(commands, [options]) ⇒ <code>Promise</code>
-Returns True on success.
 Use this method to change the list of the bot's commands.
+Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#setmycommands  
@@ -1002,10 +1022,64 @@ Use this method to change the list of the bot's commands.
 <a name="TelegramBot+getMyCommands"></a>
 
 ### telegramBot.getMyCommands([options]) ⇒ <code>Promise</code>
-Returns Array of BotCommand on success.
+Use this method to get the current list of the bot's commands for the given scope and user language.
+Returns Array of BotCommand on success. If commands aren't set, an empty list is returned.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getmycommands  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+setChatMenuButton"></a>
+
+### telegramBot.setChatMenuButton([options]) ⇒ <code>Promise</code>
+Use this method to change the bot's menu button in a private chat, or the default menu button.
+Returns True on success.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**: https://core.telegram.org/bots/api#setchatmenubutton  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+getChatMenuButton"></a>
+
+### telegramBot.getChatMenuButton([options]) ⇒ <code>Promise</code>
+Use this method to get the current value of the bot's menu button in a private chat, or the default menu button.
+Returns MenuButton on success.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**: https://core.telegram.org/bots/api#getchatmenubutton  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+setMyDefaultAdministratorRights"></a>
+
+### telegramBot.setMyDefaultAdministratorRights([options]) ⇒ <code>Promise</code>
+Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels.
+These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+Returns True on success.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**: https://core.telegram.org/bots/api#getchatmenubutton  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+getMyDefaultAdministratorRights"></a>
+
+### telegramBot.getMyDefaultAdministratorRights([options]) ⇒ <code>Promise</code>
+Use this method to get the current default administrator rights of the bot.
+Returns ChatAdministratorRights on success.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**See**: https://core.telegram.org/bots/api#getmydefaultadministratorrights  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "Telegram Bot API",
   "main": "./index.js",
   "directories": {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -48,13 +48,14 @@ const _messageTypes = [
   'video',
   'video_note',
   'voice',
-  'voice_chat_started',
-  'voice_chat_ended',
-  'voice_chat_participants_invited',
-  'voice_chat_scheduled',
+  'video_chat_started',
+  'video_chat_ended',
+  'video_chat_participants_invited',
+  'video_chat_scheduled',
   'message_auto_delete_timer_changed',
   'chat_invite_link',
-  'chat_member_updated'
+  'chat_member_updated',
+  'web_app_data',
 ];
 const _deprecatedMessageTypes = [
   'new_chat_participant', 'left_chat_participant'
@@ -1469,8 +1470,25 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
-  * Returns True on success.
+   * Use this method to set the result of an interaction with a Web App and send a corresponding message on behalf of the user to the chat from which the query originated.
+   * On success, a SentWebAppMessage object is returned.
+   *
+   * @param  {String} webAppQueryId Unique identifier for the query to be answered
+   * @param  {InlineQueryResult} result object that represents one result of an inline query
+   * @param  {Object} [options] Additional Telegram query options
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#answercallbackquery
+   */
+  answerWebAppQuery(webAppQueryId, result, form = {}) {
+    form.web_app_query_id = webAppQueryId;
+    form.result = stringify(result);
+    return this._request('answerCallbackQuery', { form });
+  }
+
+
+  /**
   * Use this method to change the list of the bot's commands.
+  * Returns True on success.
   * @param  {Array} commands Poll options, between 2-10 options
   * @param  {Object} [options] Additional Telegram query options
   * @return {Promise}
@@ -1482,13 +1500,59 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
-  * Returns Array of BotCommand on success.
+  * Use this method to get the current list of the bot's commands for the given scope and user language.
+  * Returns Array of BotCommand on success. If commands aren't set, an empty list is returned.
   * @param  {Object} [options] Additional Telegram query options
   * @return {Promise}
   * @see https://core.telegram.org/bots/api#getmycommands
   */
   getMyCommands(form = {}) {
     return this._request('getMyCommands', { form });
+  }
+
+  /**
+  * Use this method to change the bot's menu button in a private chat, or the default menu button.
+  * Returns True on success.
+  * @param  {Object} [options] Additional Telegram query options
+  * @return {Promise}
+  * @see https://core.telegram.org/bots/api#setchatmenubutton
+  */
+  setChatMenuButton(form = {}) {
+    return this._request('setChatMenuButton', { form });
+  }
+
+  /**
+  * Use this method to get the current value of the bot's menu button in a private chat, or the default menu button.
+  * Returns MenuButton on success.
+  * @param  {Object} [options] Additional Telegram query options
+  * @return {Promise}
+  * @see https://core.telegram.org/bots/api#getchatmenubutton
+  */
+  getChatMenuButton(form = {}) {
+    return this._request('getChatMenuButton', { form });
+  }
+
+  /**
+  * Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels.
+  * These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+  * Returns True on success.
+  * @param  {Object} [options] Additional Telegram query options
+  * @return {Promise}
+  * @see https://core.telegram.org/bots/api#getchatmenubutton
+  */
+  setMyDefaultAdministratorRights(form = {}) {
+    return this._request('setMyDefaultAdministratorRights', { form });
+  }
+
+  /**
+  * Use this method to get the current default administrator rights of the bot.
+  * Returns ChatAdministratorRights on success.
+  * @param  {Object} [options] Additional Telegram query options
+  * @return {Promise}
+  * @see https://core.telegram.org/bots/api#getmydefaultadministratorrights
+  */
+  getMyDefaultAdministratorRights(form = {}) {
+    return this._request('getMyDefaultAdministratorRights', { form });
   }
 
   /**

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -864,6 +864,72 @@ describe('TelegramBot', function telegramSuite() {
     });
   });
 
+
+  describe('#setChatMenuButton', function setChatMenuButtonSuite() {
+    it('should set chat menu button', function test() {
+      return bot.setChatMenuButton({
+        chat_id: USERID,
+        menu_button: JSON.stringify({ type: 'web_app', text: 'Hello', web_app: { url: 'https://webappcontent.telegram.org/cafe' } }),
+      })
+        .then(resp => {
+          assert.ok(is.boolean(resp));
+        });
+    });
+  });
+
+  describe('#getChatMenuButton', function getChatMenuButtonSuite() {
+    it('should get chat menu button', function test() {
+      return bot.getChatMenuButton().then(resp => {
+        assert.ok(is.equal(resp, {
+          type: 'web_app',
+          text: 'Hello',
+          web_app: { url: 'https://webappcontent.telegram.org/cafe' }
+        }));
+      });
+    });
+  });
+
+  describe('#setMyDefaultAdministratorRights', function setMyDefaultAdministratorRightsSuite() {
+    it('should set default administrator rights', function test() {
+      return bot.setMyDefaultAdministratorRights({
+        rights: JSON.stringify({
+          can_manage_chat: true,
+          can_change_info: true,
+          can_delete_messages: false,
+          can_invite_users: true,
+          can_restrict_members: false,
+          can_pin_messages: true,
+          can_promote_members: false,
+          can_manage_video_chats: false,
+          is_anonymous: false
+        }),
+        for_channels: false
+      }).then(resp => {
+        assert.ok(is.boolean(resp));
+      });
+    });
+  });
+
+  describe('#getMyDefaultAdministratorRights ', function getMyDefaultAdministratorRightsSuite() {
+    it('should get my default administrator rights', function test() {
+      return bot.getMyDefaultAdministratorRights({
+        for_channels: false
+      }).then(resp => {
+        assert.ok(is.equal(resp, {
+          can_manage_chat: true,
+          can_change_info: true,
+          can_delete_messages: false,
+          can_invite_users: true,
+          can_restrict_members: false,
+          can_pin_messages: true,
+          can_promote_members: false,
+          can_manage_video_chats: false,
+          is_anonymous: false
+        }));
+      });
+    });
+  });
+
   describe('#deleteMyCommands', function deleteMyCommandsSuite() {
     it('should delete bot commands', function test() {
       return bot.deleteMyCommands().then(resp => {


### PR DESCRIPTION
   * Add method *setChatMenuButton()*
   * Add method *getChatMenuButton()*
   * Add method *setMyDefaultAdministratorRights()*
   * Add method *getMyDefaultAdministratorRights()*
   * Add method *answerWebAppQuery()*
   * Renamed the fields voice_chat_scheduled, voice_chat_started, voice_chat_ended, and voice_chat_participants_invited to video_chat_scheduled, video_chat_started, video_chat_ended, and video_chat_participants_invited

   Tests:

   * answerWebAppQuery
   * setChatMenuButton
   * getChatMenuButton
   * setMyDefaultAdministratorRights
   * getMyDefaultAdministratorRights

<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [X] All tests pass
- [X] I have run `npm run doc`

### Description

Telegram Bot API 6.0

### References

* Telegram Bot API 6.0 - https://core.telegram.org/bots/api/#april-16-2022
