### PR TITLE
Unlimited message size

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -39,6 +39,7 @@ TelegramBot
         * [.logOut([options])](#TelegramBot+logOut) ⇒ <code>Promise</code>
         * [.close([options])](#TelegramBot+close) ⇒ <code>Promise</code>
         * [.sendMessage(chatId, text, [options])](#TelegramBot+sendMessage) ⇒ <code>Promise</code>
+        * [.sendLargeMessage(chatId, text, form)](#TelegramBot+sendLargeMessage) ⇒ <code>Promise</code>
         * [.forwardMessage(chatId, fromChatId, messageId, [options])](#TelegramBot+forwardMessage) ⇒ <code>Promise</code>
         * [.copyMessage(chatId, fromChatId, messageId, [options])](#TelegramBot+copyMessage) ⇒ <code>Promise</code>
         * [.sendPhoto(chatId, photo, [options], [fileOptions])](#TelegramBot+sendPhoto) ⇒ <code>Promise</code>
@@ -120,7 +121,7 @@ TelegramBot
         * [.getGameHighScores(userId, [options])](#TelegramBot+getGameHighScores) ⇒ <code>Promise</code>
     * _static_
         * [.errors](#TelegramBot.errors) : <code>Object</code>
-        * [.messageTypes](#TelegramBot.messageTypes) : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+        * [.messageTypes](#TelegramBot.messageTypes) : <code>Array.&lt;String&gt;</code>
 
 <a name="new_TelegramBot_new"></a>
 
@@ -500,6 +501,20 @@ Send text message.
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
 | text | <code>String</code> | Text of the message to be sent |
 | [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+sendLargeMessage"></a>
+
+### telegramBot.sendLargeMessage(chatId, text, form) ⇒ <code>Promise</code>
+Send text message larger than 4096 characters.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - On success all the sent messages are returned as an array  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
+| text | <code>String</code> | Text of the message to be sent |
+| form | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+forwardMessage"></a>
 
@@ -1677,7 +1692,7 @@ Animated stickers can be added to animated sticker sets and only to them:
 | --- | --- | --- | --- |
 | userId | <code>Number</code> |  | User identifier of sticker set owner |
 | name | <code>String</code> |  | Sticker set name |
-| sticker | <code>String</code> \| <code>stream.Stream</code> \| <code>Buffer</code> |  | Png image with the sticker (must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px), [TGS animation](https://core.telegram.org/stickers#animated-sticker-requirements) with the sticker or [WEBM video](https://core.telegram.org/stickers#video-sticker-requirements) with the sticker. |
+| sticker | <code>String</code> \| <code>stream.Stream</code> \| <code>Buffer</code> |  | Png image with the sticker (must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px, [TGS animation](https://core.telegram.org/stickers#animated-sticker-requirements) with the sticker or [WEBM video](https://core.telegram.org/stickers#video-sticker-requirements) with the sticker. |
 | emojis | <code>String</code> |  | One or more emoji corresponding to the sticker |
 | stickerType | <code>String</code> | <code>png_sticker</code> | Allow values: `png_sticker`, `tgs_sticker`, or `webm_sticker`. |
 | [options] | <code>Object</code> |  | Additional Telegram query options |
@@ -1749,7 +1764,7 @@ Note: No more than 50 results per query are allowed.
 | Param | Type | Description |
 | --- | --- | --- |
 | inlineQueryId | <code>String</code> | Unique identifier of the query |
-| results | <code>[ &#x27;Array&#x27; ].&lt;InlineQueryResult&gt;</code> | An array of results for the inline query |
+| results | <code>Array.&lt;InlineQueryResult&gt;</code> | An array of results for the inline query |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+answerWebAppQuery"></a>
@@ -1899,7 +1914,7 @@ The different errors the library uses.
 **Kind**: static property of [<code>TelegramBot</code>](#TelegramBot)  
 <a name="TelegramBot.messageTypes"></a>
 
-### TelegramBot.messageTypes : <code>[ &#x27;Array&#x27; ].&lt;String&gt;</code>
+### TelegramBot.messageTypes : <code>Array.&lt;String&gt;</code>
 The types of message updates the library handles.
 
 **Kind**: static property of [<code>TelegramBot</code>](#TelegramBot)  

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -887,10 +887,10 @@ class TelegramBot extends EventEmitter {
 
   /**
    * Send text message larger than 4096 characters.
-   * @param {Number|String} chatId Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
-   * @param {String} text Text of the message to be sent
-   * @param {Object} form Additional Telegram query options
-   * @returns {Promise} On success all the sent messages are returned as an array
+   * @param  {Number|String} chatId Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
+   * @param  {String} text Text of the message to be sent
+   * @param  {Object} form Additional Telegram query options
+   * @return {Promise} On success all the sent messages are returned as an array
    */
   sendLargeMessage(chatId, text, form = {}){
     form.chat_id = chatId;


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->
This PR try to solve the issue with the error "Message too long" when sending message larger than 4096 characters.
I have added an additional function **sendLargeMessage()** for sending message larger than 4096 char.
The max message size right now is 4096 since there is no specification on the official telegram documentation of the maximum message size for premium account (i assume the limit is the same as a non-premium account).

This PR is a better implementation of the closed PR #992 since: 
- This is an additional functionality and will not break existing code
- The function don't use async/await so it doesn't break current code style.

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->

* Issue #223 https://github.com/yagop/node-telegram-bot-api/issues/223
* Issue #19  https://github.com/yagop/node-telegram-bot-api/issues/19
