### PR TITLE
Update api.md

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1137,7 +1137,6 @@ Use this method to send an invoice.
 | description | <code>String</code> | product description |
 | payload | <code>String</code> | Bot defined invoice payload |
 | providerToken | <code>String</code> | Payments provider token |
-| startParameter | <code>String</code> | Deep-linking parameter |
 | currency | <code>String</code> | Three-letter ISO 4217 currency code |
 | prices | <code>Array</code> | Breakdown of prices |
 | [options] | <code>Object</code> | Additional Telegram query options |


### PR DESCRIPTION
removed start_parameter in the function sendInvoice
As in version 0.59, start parameters have been removed (refer: https://github.com/yagop/node-telegram-bot-api/commit/f50cf982c78022f496397211ad860b68115a2a9d)

### Description

Updated the documentation for sendInvoice

### References
https://github.com/yagop/node-telegram-bot-api/commit/f50cf982c78022f496397211ad860b68115a2a9d