### PR TITLE
feat: Telegram Bot API 6.4 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 2. Minor changes:
  * The parameters `name` and `icon_custom_emoji_id` of the method `editForumTopic` are now optional.
- 
+ * Fix add thumb in sendAudio, sendVideo and sendVideoNote
 ## [0.60.0][0.60.0] - 2022-10-06
 
 1. Support Telegram Bot API v6.3 (@danielperez9430)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  * hideGeneralForumTopic
  * unhideGeneralForumTopic
 
-2. Minor changes:
+2. Minor changes: (@danielperez9430)
  * The parameters `name` and `icon_custom_emoji_id` of the method `editForumTopic` are now optional.
  * Fix add thumb in sendAudio, sendVideo and sendVideoNote
+ * Fix getMyCommands and setMyCommands
+ * Suggested tip amounts stringify in sendInvoice
 ## [0.60.0][0.60.0] - 2022-10-06
 
 1. Support Telegram Bot API v6.3 (@danielperez9430)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.61.0][0.61.0] - 2022-12-30
+
+1. Support Telegram Bot API v6.4 (@danielperez9430)
+ * editGeneralForumTopic
+ * closeGeneralForumTopic
+ * reopenGeneralForumTopic
+ * hideGeneralForumTopic
+ * unhideGeneralForumTopic
+
+2. Minor changes:
+ * The parameters `name` and `icon_custom_emoji_id` of the method `editForumTopic` are now optional.
+ 
 ## [0.60.0][0.60.0] - 2022-10-06
 
 1. Support Telegram Bot API v6.3 (@danielperez9430)

--- a/doc/api.md
+++ b/doc/api.md
@@ -89,11 +89,16 @@ TelegramBot
         * [.deleteChatStickerSet(chatId, [options])](#TelegramBot+deleteChatStickerSet) ⇒ <code>Promise</code>
         * [.getForumTopicIconStickers(chatId, [options])](#TelegramBot+getForumTopicIconStickers) ⇒ <code>Promise</code>
         * [.createForumTopic(chatId, name, [options])](#TelegramBot+createForumTopic)
-        * [.editForumTopic(chatId, messageThreadId, name, iconCustomEmojiId, [options])](#TelegramBot+editForumTopic) ⇒ <code>Promise</code>
+        * [.editForumTopic(chatId, messageThreadId, [options])](#TelegramBot+editForumTopic) ⇒ <code>Promise</code>
         * [.closeForumTopic(chatId, messageThreadId, [options])](#TelegramBot+closeForumTopic) ⇒ <code>Promise</code>
         * [.reopenForumTopic(chatId, messageThreadId, [options])](#TelegramBot+reopenForumTopic) ⇒ <code>Promise</code>
         * [.deleteForumTopic(chatId, messageThreadId, [options])](#TelegramBot+deleteForumTopic) ⇒ <code>Promise</code>
         * [.unpinAllForumTopicMessages(chatId, messageThreadId, [options])](#TelegramBot+unpinAllForumTopicMessages) ⇒ <code>Promise</code>
+        * [.editGeneralForumTopic(chatId, name, [options])](#TelegramBot+editGeneralForumTopic) ⇒ <code>Promise</code>
+        * [.closeGeneralForumTopic(chatId, [options])](#TelegramBot+closeGeneralForumTopic) ⇒ <code>Promise</code>
+        * [.reopenGeneralForumTopic(chatId, [options])](#TelegramBot+reopenGeneralForumTopic) ⇒ <code>Promise</code>
+        * [.hideGeneralForumTopic(chatId, [options])](#TelegramBot+hideGeneralForumTopic) ⇒ <code>Promise</code>
+        * [.unhideGeneralForumTopic(chatId, [options])](#TelegramBot+unhideGeneralForumTopic) ⇒ <code>Promise</code>
         * [.answerCallbackQuery(callbackQueryId, [options])](#TelegramBot+answerCallbackQuery) ⇒ <code>Promise</code>
         * [.setMyCommands(commands, [options])](#TelegramBot+setMyCommands) ⇒ <code>Promise</code>
         * [.deleteMyCommands([options])](#TelegramBot+deleteMyCommands) ⇒ <code>Promise</code>
@@ -1405,7 +1410,7 @@ Returns information about the created topic as a [ForumTopic](https://core.teleg
 
 <a name="TelegramBot+editForumTopic"></a>
 
-### telegramBot.editForumTopic(chatId, messageThreadId, name, iconCustomEmojiId, [options]) ⇒ <code>Promise</code>
+### telegramBot.editForumTopic(chatId, messageThreadId, [options]) ⇒ <code>Promise</code>
 Use this method to edit name and icon of a topic in a forum supergroup chat.
 The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the topic.
 
@@ -1417,8 +1422,6 @@ The bot must be an administrator in the chat for this to work and must have can_
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
 | messageThreadId | <code>Number</code> | Unique identifier for the target message thread of the forum topic |
-| name | <code>String</code> | New topic name, 1-128 characters |
-| iconCustomEmojiId | <code>String</code> | New unique identifier of the custom emoji shown as the topic icon. Use [getForumTopicIconStickers](https://core.telegram.org/bots/api#getforumtopiciconstickers) to get all allowed custom emoji identifiers |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+closeForumTopic"></a>
@@ -1483,6 +1486,86 @@ The bot must be an administrator in the chat for this to work and must have the 
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
 | messageThreadId | <code>Number</code> | Unique identifier for the target message thread of the forum topic |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+editGeneralForumTopic"></a>
+
+### telegramBot.editGeneralForumTopic(chatId, name, [options]) ⇒ <code>Promise</code>
+Use this method to edit the name of the 'General' topic in a forum supergroup chat.
+The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+The topic will be automatically unhidden if it was hidden.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - True on success  
+**See**: https://core.telegram.org/bots/api#editgeneralforumtopic  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
+| name | <code>String</code> | New topic name, 1-128 characters |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+closeGeneralForumTopic"></a>
+
+### telegramBot.closeGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
+Use this method to close an open 'General' topic in a forum supergroup chat.
+The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+The topic will be automatically unhidden if it was hidden.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - True on success  
+**See**: https://core.telegram.org/bots/api#closegeneralforumtopic  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+reopenGeneralForumTopic"></a>
+
+### telegramBot.reopenGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
+Use this method to reopen a closed 'General' topic in a forum supergroup chat.
+The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+The topic will be automatically unhidden if it was hidden.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - True on success  
+**See**: https://core.telegram.org/bots/api#reopengeneralforumtopic  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+hideGeneralForumTopic"></a>
+
+### telegramBot.hideGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
+Use this method to hide the 'General' topic in a forum supergroup chat.
+The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+The topic will be automatically closed if it was open.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - True on success  
+**See**: https://core.telegram.org/bots/api#hidegeneralforumtopic  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+unhideGeneralForumTopic"></a>
+
+### telegramBot.unhideGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
+Use this method to unhide the 'General' topic in a forum supergroup chat.
+The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - True on success  
+**See**: https://core.telegram.org/bots/api#unhidegeneralforumtopic  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+answerCallbackQuery"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Telegram Bot API",
   "main": "./index.js",
   "directories": {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -237,6 +237,26 @@ class TelegramBot extends EventEmitter {
     }
   }
 
+  _fixAddFileThumb(options, opts) {
+    if (options.thumb) {
+      if (opts.formData === null) {
+        opts.formData = {};
+      }
+
+      try {
+        const attachName = 'photo';
+        const [formData] = this._formatSendData(attachName, options.thumb.replace('attach://', ''));
+
+        if (formData) {
+          opts.formData[attachName] = formData[attachName];
+          opts.qs.thumb = `attach://${attachName}`;
+        }
+      } catch (ex) {
+        throw Promise.reject(ex);
+      }
+    }
+  }
+
   /**
    * Make request against the API
    * @param  {String} _path API endpoint
@@ -987,26 +1007,9 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('audio', audio, fileOptions);
       opts.formData = sendData[0];
       opts.qs.audio = sendData[1];
+      this._fixAddFileThumb(options, opts);
     } catch (ex) {
       return Promise.reject(ex);
-    }
-
-    if (options.thumb) {
-      if (opts.formData === null) {
-        opts.formData = {};
-      }
-
-      try {
-        const attachName = 'photo';
-        const [formData] = this._formatSendData(attachName, options.thumb.replace('attach://', ''));
-
-        if (formData) {
-          opts.formData[attachName] = formData[attachName];
-          opts.qs.thumb = `attach://${attachName}`;
-        }
-      } catch (ex) {
-        return Promise.reject(ex);
-      }
     }
 
     return this._request('sendAudio', opts);
@@ -1032,9 +1035,11 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('document', doc, fileOptions);
       opts.formData = sendData[0];
       opts.qs.document = sendData[1];
+      this._fixAddFileThumb(options, opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
+
     return this._request('sendDocument', opts);
   }
 
@@ -1059,6 +1064,7 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('video', video, fileOptions);
       opts.formData = sendData[0];
       opts.qs.video = sendData[1];
+      this._fixAddFileThumb(options, opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
@@ -1141,6 +1147,7 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('video_note', videoNote, fileOptions);
       opts.formData = sendData[0];
       opts.qs.video_note = sendData[1];
+      this._fixAddFileThumb(options, opts);
     } catch (ex) {
       return Promise.reject(ex);
     }

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1916,17 +1916,13 @@ class TelegramBot extends EventEmitter {
    *
    * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
    * @param {Number} messageThreadId Unique identifier for the target message thread of the forum topic
-   * @param {String} name New topic name, 1-128 characters
-   * @param {String} iconCustomEmojiId New unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers
    * @param {Object} [options] Additional Telegram query options
    * @return {Promise} True on success
    * @see https://core.telegram.org/bots/api#editforumtopic
    */
-  editForumTopic(chatId, messageThreadId, name, iconCustomEmojiId, form = {}) {
+  editForumTopic(chatId, messageThreadId, form = {}) {
     form.chat_id = chatId;
     form.message_thread_id = messageThreadId;
-    form.name = name;
-    form.icon_custom_emoji_id = iconCustomEmojiId;
     return this._request('editForumTopic', { form });
   }
 
@@ -1994,6 +1990,81 @@ class TelegramBot extends EventEmitter {
     return this._request('unpinAllForumTopicMessages', { form });
   }
 
+  /**
+  * Use this method to edit the name of the 'General' topic in a forum supergroup chat.
+  * The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+  * The topic will be automatically unhidden if it was hidden.
+  *
+  * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+  * @param {String} name New topic name, 1-128 characters
+  * @param {Object} [options] Additional Telegram query options
+  * @return {Promise} True on success
+  * @see https://core.telegram.org/bots/api#editgeneralforumtopic
+  */
+  editGeneralForumTopic(chatId, name, form = {}) {
+    form.chat_id = chatId;
+    form.name = name;
+    return this._request('editGeneralForumTopic', { form });
+  }
+
+  /**
+  * Use this method to close an open 'General' topic in a forum supergroup chat.
+  * The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+  * The topic will be automatically unhidden if it was hidden.
+  *
+  * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+  * @param {Object} [options] Additional Telegram query options
+  * @return {Promise} True on success
+  * @see https://core.telegram.org/bots/api#closegeneralforumtopic
+  */
+  closeGeneralForumTopic(chatId, form = {}) {
+    form.chat_id = chatId;
+    return this._request('closeGeneralForumTopic', { form });
+  }
+
+  /**
+  * Use this method to reopen a closed 'General' topic in a forum supergroup chat.
+  * The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+  * The topic will be automatically unhidden if it was hidden.
+  *
+  * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+  * @param {Object} [options] Additional Telegram query options
+  * @return {Promise} True on success
+  * @see https://core.telegram.org/bots/api#reopengeneralforumtopic
+  */
+  reopenGeneralForumTopic(chatId, form = {}) {
+    form.chat_id = chatId;
+    return this._request('reopenGeneralForumTopic', { form });
+  }
+
+  /**
+  * Use this method to hide the 'General' topic in a forum supergroup chat.
+  * The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
+  * The topic will be automatically closed if it was open.
+  *
+  * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+  * @param {Object} [options] Additional Telegram query options
+  * @return {Promise} True on success
+  * @see https://core.telegram.org/bots/api#hidegeneralforumtopic
+  */
+  hideGeneralForumTopic(chatId, form = {}) {
+    form.chat_id = chatId;
+    return this._request('hideGeneralForumTopic', { form });
+  }
+
+  /**
+   * Use this method to unhide the 'General' topic in a forum supergroup chat.
+   * The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights
+   *
+   * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise} True on success
+   * @see https://core.telegram.org/bots/api#unhidegeneralforumtopic
+   */
+  unhideGeneralForumTopic(chatId, form = {}) {
+    form.chat_id = chatId;
+    return this._request('unhideGeneralForumTopic', { form });
+  }
 
   /**
    * Use this method to send answers to callback queries sent from

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -2127,6 +2127,11 @@ class TelegramBot extends EventEmitter {
    */
   setMyCommands(commands, form = {}) {
     form.commands = stringify(commands);
+
+    if (form.scope) {
+      form.scope = stringify(form.scope);
+    }
+
     return this._request('setMyCommands', { form });
   }
 
@@ -2152,6 +2157,9 @@ class TelegramBot extends EventEmitter {
    * @see https://core.telegram.org/bots/api#getmycommands
    */
   getMyCommands(form = {}) {
+    if (form.scope) {
+      form.scope = stringify(form.scope);
+    }
     return this._request('getMyCommands', { form });
   }
 
@@ -2622,6 +2630,9 @@ class TelegramBot extends EventEmitter {
     form.currency = currency;
     form.prices = stringify(prices);
     form.provider_data = stringify(form.provider_data);
+    if (form.suggested_tip_amounts) {
+      form.suggested_tip_amounts = stringify(form.suggested_tip_amounts);
+    }
     return this._request('sendInvoice', { form });
   }
 


### PR DESCRIPTION
- [X] All tests pass
- [x] I have run `npm run doc`

### Description

Add the support for Telegram Bot API v6.4

### References

Telegram Bot API - https://core.telegram.org/bots/api#december-30-2022

#### Use examples: 

```js
bot.onText(/\/editGeneralForum/, (msg) => {
    bot.editGeneralForumTopic(msg.chat.id, "The cave")
})


bot.onText(/\/closeGeneralForum/, (msg) => {
    bot.closeGeneralForumTopic(msg.chat.id)
})

bot.onText(/\/reopenGeneralForum/, (msg) => {
    bot.reopenGeneralForumTopic(msg.chat.id)
})

bot.onText(/\/hideGeneralForum/, (msg) => {
    bot.hideGeneralForumTopic(msg.chat.id)
})

bot.onText(/\/unhideGeneralForum/, (msg) => {
    bot.unhideGeneralForumTopic(msg.chat.id)
})
```
