### PR TITLE
Fix createNewStickerSet description

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1870,7 +1870,7 @@ You must use exactly one of the fields *png_sticker*, *tgs_sticker*, or *webm_st
 | Param | Type | Description |
 | --- | --- | --- |
 | userId | <code>Number</code> | User identifier of created sticker set owner |
-| name | <code>String</code> | Short name of sticker set, to be used in `t.me/addstickers/` URLs (e.g.,   *"animals"*). Can contain only english letters, digits and underscores.  Must begin with a letter, can't contain consecutive underscores and must end in `.` is case insensitive. 1-64 characters. |
+| name | <code>String</code> | Short name of sticker set, to be used in `t.me/addstickers/` URLs (e.g.,   *"animals"*). Can contain only english letters, digits and underscores.  Must begin with a letter, can't contain consecutive underscores and must end in `"_by_<bot_username>"`. `<bot_username>` is case insensitive. 1-64 characters. |
 | title | <code>String</code> | Sticker set title, 1-64 characters |
 | pngSticker | <code>String</code> \| <code>stream.Stream</code> \| <code>Buffer</code> | Png image with the sticker, must be up to 512 kilobytes in size,  dimensions must not exceed 512px, and either width or height must be exactly 512px. |
 | emojis | <code>String</code> | One or more emoji corresponding to the sticker |

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -2432,7 +2432,8 @@ class TelegramBot extends EventEmitter {
    *
    * @param  {Number} userId User identifier of created sticker set owner
    * @param  {String} name Short name of sticker set, to be used in `t.me/addstickers/` URLs (e.g.,   *"animals"*). Can contain only english letters, digits and underscores.
-   *  Must begin with a letter, can't contain consecutive underscores and must end in `.` is case insensitive. 1-64 characters.
+   *  Must begin with a letter, can't contain consecutive underscores and must end in `"_by_<bot_username>"`. `<bot_username>` is case insensitive. 1-64 characters.
+
    * @param  {String} title Sticker set title, 1-64 characters
    * @param  {String|stream.Stream|Buffer} pngSticker Png image with the sticker, must be up to 512 kilobytes in size,
    *  dimensions must not exceed 512px, and either width or height must be exactly 512px.


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->
Fix the missing `"_by_<bot_username>"` in documentation of `createNewStickerSet`.

https://core.telegram.org/bots/api#createnewstickerset

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
