### PR TITLE
If port is already in use open is rejected when opening the webhook

### DIFF
--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -45,16 +45,20 @@ class TelegramBotWebHook {
   /**
    * Open WebHook by listening on the port
    * @return {Promise}
-   */
+   */  
   open() {
     if (this.isOpen()) {
       return Promise.resolve();
     }
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this._webServer.listen(this.options.port, this.options.host, () => {
         debug('WebHook listening on port %s', this.options.port);
         this._open = true;
         return resolve();
+      });
+
+      this._webServer.once('error', (err) => {
+        reject(err);
       });
     });
   }


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [ ] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [ ] I have run `npm run doc`

### Description
To avoid unhandled exceptions in case of a port conflict when opening a webhook,
the promise rejects as soon as an error occurred from now on.

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
