### PR TITLE
docs: update api.md for setWebHook (fix #1083)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -428,6 +428,7 @@ that is being deprecated.
 | url | <code>String</code> | URL where Telegram will make HTTP Post. Leave empty to delete webHook. |
 | [options] | <code>Object</code> | Additional Telegram query options |
 | [options.certificate] | <code>String</code> \| <code>stream.Stream</code> | PEM certificate key (public). |
+| [options.secret_token] | <code>String</code> | A secret token to be sent in a header `X-Telegram-Bot-Api-Secret-Token` in every webhook request. |
 | [fileOptions] | <code>Object</code> | Optional file related meta-data |
 
 <a name="TelegramBot+deleteWebHook"></a>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -803,6 +803,7 @@ class TelegramBot extends EventEmitter {
    * delete webHook.
    * @param  {Object} [options] Additional Telegram query options
    * @param  {String|stream.Stream} [options.certificate] PEM certificate key (public).
+   * @param  {String} [options.secret_token] Optional secret token to be sent in a header `X-Telegram-Bot-Api-Secret-Token` in every webhook request.
    * @param  {Object} [fileOptions] Optional file related meta-data
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#setwebhook


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->
Add missing `setWebhook` `secret_token` parameter to the documentation

### References
- [x] Fixes #1083 

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
