### PR TITLE
fixed unpinChatMessageBug

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -78,7 +78,7 @@ TelegramBot
         * [.setChatTitle(chatId, title, [options])](#TelegramBot+setChatTitle) ⇒ <code>Promise</code>
         * [.setChatDescription(chatId, description, [options])](#TelegramBot+setChatDescription) ⇒ <code>Promise</code>
         * [.pinChatMessage(chatId, messageId, [options])](#TelegramBot+pinChatMessage) ⇒ <code>Promise</code>
-        * [.unpinChatMessage(chatId, [options])](#TelegramBot+unpinChatMessage) ⇒ <code>Promise</code>
+        * [.unpinChatMessage(chatId, messageId, [options])](#TelegramBot+unpinChatMessage) ⇒ <code>Promise</code>
         * [.unpinAllChatMessages(chatId, [options])](#TelegramBot+unpinAllChatMessages) ⇒ <code>Promise</code>
         * [.leaveChat(chatId, [options])](#TelegramBot+leaveChat) ⇒ <code>Promise</code>
         * [.getChat(chatId, [options])](#TelegramBot+getChat) ⇒ <code>Promise</code>
@@ -1236,7 +1236,7 @@ right in a supergroup or `can_edit_messages` administrator right in a channel.
 
 <a name="TelegramBot+unpinChatMessage"></a>
 
-### telegramBot.unpinChatMessage(chatId, [options]) ⇒ <code>Promise</code>
+### telegramBot.unpinChatMessage(chatId, messageId, [options]) ⇒ <code>Promise</code>
 Use this method to remove a message from the list of pinned messages in a chat
 
 If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administrator
@@ -1249,6 +1249,7 @@ right in a supergroup or `can_edit_messages` administrator right in a channel.
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
+| messageId | <code>Number</code> | Identifier of a message to unpin |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+unpinAllChatMessages"></a>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1754,12 +1754,14 @@ class TelegramBot extends EventEmitter {
    * right in a supergroup or `can_edit_messages` administrator right in a channel.
    *
    * @param  {Number|String} chatId  Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
+   * @param  {Number} messageId Identifier of a message to unpin
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise} True on success
    * @see https://core.telegram.org/bots/api#unpinchatmessage
    */
-  unpinChatMessage(chatId, form = {}) {
+  unpinChatMessage(chatId, messageId, form = {}) {
     form.chat_id = chatId;
+    form.message_id = messageId;
     return this._request('unpinChatMessage', { form });
   }
 

--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -45,7 +45,7 @@ class TelegramBotWebHook {
   /**
    * Open WebHook by listening on the port
    * @return {Promise}
-   */  
+   */
   open() {
     if (this.isOpen()) {
       return Promise.resolve();

--- a/test/README.md
+++ b/test/README.md
@@ -2,13 +2,13 @@ Running the tests:
 
 ```bash
 # Token to be used
-export TEST_TELEGRAM_TOKEN=<YOUR_BOT_TOKEN>
+export TEST_TELEGRAM_TOKEN='5919747862:AAH9HvgGwQpj5yAGGJh8mZ4161DqHVzhQAE'
 
 # User Id which you want to send the messages.
-export TEST_USER_ID=<USER_ID>
+export TEST_USER_ID=5668418433
 
 # Group Id which to use in some of the tests, e.g. for TelegramBot#getChat()
-export TEST_GROUP_ID=<GROUP_ID>
+export TEST_GROUP_ID='-992795244'
 
 # Game short name to use in some tests, e.g. TelegramBot#sendGame()
 # Defaults to "medusalab_test".

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -1301,7 +1301,10 @@ describe('TelegramBot', function telegramSuite() {
     before(function before() {
       utils.handleRatelimit(bot, 'unpinChatMessage', this);
       return bot.sendMessage(GROUPID, 'To be pinned').then(resp => {
-        messageId = resp.message_id;
+        bot.pinChatMessage(GROUPID, resp.message_id);
+        return resp.message_id;
+      }).then(id => {
+        messageId = id;
       });
     });
     it('should unpin chat message', function test() {

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -1297,11 +1297,15 @@ describe('TelegramBot', function telegramSuite() {
   });
 
   describe('#unpinChatMessage', function unpinChatMessageSuite() {
+    let messageId;
     before(function before() {
       utils.handleRatelimit(bot, 'unpinChatMessage', this);
+      return bot.sendMessage(GROUPID, 'To be pinned').then(resp => {
+        messageId = resp.message_id;
+      });
     });
     it('should unpin chat message', function test() {
-      return bot.unpinChatMessage(GROUPID).then(resp => {
+      return bot.unpinChatMessage(GROUPID, messageId).then(resp => {
         assert.strictEqual(resp, true);
       });
     });


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->

unpinChatMessage method had a bug, it didn't use messageId properly so I got error
`Failed to unpin message: TypeError: Cannot create property 'chat_id' on number <message id>`

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
