### PR TITLE
feat: Telegram Bot API 6.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.63.0][0.61.0] - 2023-08-23
+1. Support Telegram Bot API v6.8 (@danielperez9430)
+ * unpinAllGeneralForumTopicMessages
+
 ## [0.62.0][0.62.0] - 2023-03-19
 
-1. Support Telegram Bot API v6.6 (@danielperez9430)
+1. Support Telegram Bot API v6.6 & v6.7 (@danielperez9430)
  * setMyDescription
  * getMyDescription
  * setMyShortDescription

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node.js module to interact with the official [Telegram Bot API](https://core.telegram.org/bots/api).
 
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-v.6.3-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-v.6.8-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
 [![Build Status](https://img.shields.io/travis/yagop/node-telegram-bot-api/master?style=flat-square&logo=travis)](https://travis-ci.org/yagop/node-telegram-bot-api)
 [![Coverage Status](https://img.shields.io/codecov/c/github/yagop/node-telegram-bot-api?style=flat-square&logo=codecov)](https://codecov.io/gh/yagop/node-telegram-bot-api)

--- a/doc/api.md
+++ b/doc/api.md
@@ -99,6 +99,7 @@ TelegramBot
         * [.reopenGeneralForumTopic(chatId, [options])](#TelegramBot+reopenGeneralForumTopic) ⇒ <code>Promise</code>
         * [.hideGeneralForumTopic(chatId, [options])](#TelegramBot+hideGeneralForumTopic) ⇒ <code>Promise</code>
         * [.unhideGeneralForumTopic(chatId, [options])](#TelegramBot+unhideGeneralForumTopic) ⇒ <code>Promise</code>
+        * [.unpinAllGeneralForumTopicMessages(chatId, [options])](#TelegramBot+unpinAllGeneralForumTopicMessages) ⇒ <code>Promise</code>
         * [.answerCallbackQuery(callbackQueryId, [options])](#TelegramBot+answerCallbackQuery) ⇒ <code>Promise</code>
         * [.setMyCommands(commands, [options])](#TelegramBot+setMyCommands) ⇒ <code>Promise</code>
         * [.deleteMyCommands([options])](#TelegramBot+deleteMyCommands) ⇒ <code>Promise</code>
@@ -440,7 +441,7 @@ that is being deprecated.
 | url | <code>String</code> | URL where Telegram will make HTTP Post. Leave empty to delete webHook. |
 | [options] | <code>Object</code> | Additional Telegram query options |
 | [options.certificate] | <code>String</code> \| <code>stream.Stream</code> | PEM certificate key (public). |
-| [options.secret_token] | <code>String</code> | A secret token to be sent in a header `X-Telegram-Bot-Api-Secret-Token` in every webhook request. |
+| [options.secret_token] | <code>String</code> | Optional secret token to be sent in a header `X-Telegram-Bot-Api-Secret-Token` in every webhook request. |
 | [fileOptions] | <code>Object</code> | Optional file related meta-data |
 
 <a name="TelegramBot+deleteWebHook"></a>
@@ -1575,6 +1576,21 @@ The bot must be an administrator in the chat for this to work and must have the 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
 **See**: https://core.telegram.org/bots/api#unhidegeneralforumtopic  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername) |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+unpinAllGeneralForumTopicMessages"></a>
+
+### telegramBot.unpinAllGeneralForumTopicMessages(chatId, [options]) ⇒ <code>Promise</code>
+Use this method to clear the list of pinned messages in a General forum topic.
+The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - True on success  
+**See**: https://core.telegram.org/bots/api#unpinallgeneralforumtopicmessages  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "0.61.0",
+  "version": "0.63.0",
   "description": "Telegram Bot API",
   "main": "./index.js",
   "directories": {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -2070,6 +2070,20 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Use this method to clear the list of pinned messages in a General forum topic.
+   * The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+   *
+   * @param {Number|String} chatId Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise} True on success
+   * @see https://core.telegram.org/bots/api#unpinallgeneralforumtopicmessages
+   */
+  unpinAllGeneralForumTopicMessages(chatId, form = {}) {
+    form.chat_id = chatId;
+    return this._request('unhideGeneralForumTopic', { form });
+  }
+
+  /**
    * Use this method to send answers to callback queries sent from
    * [inline keyboards](https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating).
    *


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

Update for support Telegram Bot API v6.8

Added:
* unpinAllGeneralForumTopicMessages

### References
* Telegram Bot API - https://core.telegram.org/bots/api#august-18-2023
