### PR TITLE
Fix caption_entities stringify in sendAudio

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1008,6 +1008,10 @@ class TelegramBot extends EventEmitter {
     } catch (ex) {
       return Promise.reject(ex);
     }
+    if( opts.qs.hasOwnProperty( "caption_entities" ) )
+    {
+      opts.qs.caption_entities = stringify(opts.qs.caption_entities);
+    }
 
     return this._request('sendAudio', opts);
   }


### PR DESCRIPTION
caption_entities option in sendAudio was not automatically stringified

<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [ ] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
