### PR TITLE
added _fixCaptionEntities

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -252,6 +252,11 @@ class TelegramBot extends EventEmitter {
       }
     }
   }
+  _fixCaptionEntities(opts) {
+    if( opts.qs.hasOwnProperty( "caption_entities" ) && Array.isArray(opts.qs.caption_entities) ){
+      opts.qs.caption_entities = stringify(opts.qs.caption_entities);
+    }
+  }
 
   /**
    * Make request against the API
@@ -973,6 +978,7 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('photo', photo, fileOptions);
       opts.formData = sendData[0];
       opts.qs.photo = sendData[1];
+      this._fixCaptionEntities(opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
@@ -1005,6 +1011,7 @@ class TelegramBot extends EventEmitter {
       opts.formData = sendData[0];
       opts.qs.audio = sendData[1];
       this._fixAddFileThumbnail(options, opts);
+      this._fixCaptionEntities(opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
@@ -1033,6 +1040,7 @@ class TelegramBot extends EventEmitter {
       opts.formData = sendData[0];
       opts.qs.document = sendData[1];
       this._fixAddFileThumbnail(options, opts);
+      this._fixCaptionEntities(opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
@@ -1062,6 +1070,7 @@ class TelegramBot extends EventEmitter {
       opts.formData = sendData[0];
       opts.qs.video = sendData[1];
       this._fixAddFileThumbnail(options, opts);
+      this._fixCaptionEntities(opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
@@ -1088,6 +1097,7 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('animation', animation, fileOptions);
       opts.formData = sendData[0];
       opts.qs.animation = sendData[1];
+      this._fixCaptionEntities(opts);
     } catch (ex) {
       return Promise.reject(ex);
     }
@@ -1116,6 +1126,7 @@ class TelegramBot extends EventEmitter {
       const sendData = this._formatSendData('voice', voice, fileOptions);
       opts.formData = sendData[0];
       opts.qs.voice = sendData[1];
+      this._fixCaptionEntities(opts);
     } catch (ex) {
       return Promise.reject(ex);
     }


### PR DESCRIPTION
Sent caption_entities messages are not stringified by default, this function will do that

I implemented it ONLY in: sendVoice sendAnimation sendVideo sendDocument sendAudio and sendPhoto

May be missing copyMessage and all edit functions

<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [ ] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
