### PR TITLE
Fix: field change from thumb to thumbnail since Bot API 6.6

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -238,13 +238,13 @@ class TelegramBot extends EventEmitter {
   }
 
   _fixAddFileThumbnail(options, opts) {
-    if (options.thumb) {
+    if (options.thumbnail) {
       if (opts.formData === null) {
         opts.formData = {};
       }
 
       const attachName = 'photo';
-      const [formData] = this._formatSendData(attachName, options.thumb.replace('attach://', ''));
+      const [formData] = this._formatSendData(attachName, options.thumbnail.replace('attach://', ''));
 
       if (formData) {
         opts.formData[attachName] = formData[attachName];

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -730,14 +730,14 @@ describe('TelegramBot', function telegramSuite() {
         assert.ok(is.object(resp.audio));
       });
     });
-    it('should send an audio file with thumb', function test() {
+    it('should send an audio file with thumbnail', function test() {
       const audio = `${__dirname}/data/audio.mp3`;
       const thumbImg = `attach://${__dirname}/data/sticker_thumb.png`;
 
-      return bot.sendAudio(USERID, audio, { thumb: thumbImg }).then(resp => {
+      return bot.sendAudio(USERID, audio, { thumbnail: thumbImg }).then(resp => {
         assert.ok(is.object(resp));
         assert.ok(is.object(resp.audio));
-        assert.ok(is.object(resp.audio.thumb));
+        assert.ok(is.object(resp.audio.thumbnail));
       });
     });
   });
@@ -1916,7 +1916,7 @@ describe('TelegramBot', function telegramSuite() {
       utils.handleRatelimit(bot, 'setStickerSetThumbnail', this);
     });
 
-    it('should set a sticker set thumb', function test() {
+    it('should set a sticker set thumbnail', function test() {
       const stickerThumb = `${__dirname}/data/sticker_thumb.png`;
       const stickerPackName = `s${CURRENT_TIMESTAMP}_by_${BOT_USERNAME}`;
 


### PR DESCRIPTION
- [ ] All tests pass (I did't run tests since I have no payment provider token yet)
- [x] I have run `npm run doc`

### Description

As Bot API 6.6 changelog said,

> Renamed the field **`thumb`** in the classes `Animation`, `Audio`, `Document`, `Sticker`, `Video`, `VideoNote`, `InputMediaAnimation`, `InputMediaAudio`, `InputMediaDocument`, `InputMediaVideo`, `StickerSet` to **`thumbnail`**.

But the field **`thumb`** in `_fixAddFileThumbnail` function remains unchanged. 

Users won't be able to add `thumbnail` in `sendAudio` and similar functions if they follow the official API documents unless they use old `thumb`.

P.S. Users of NTBA also need to update their code since the field change. I wonder whether NTBA's documentation should notice this change or not.


### References

[Telegram Bot API Changelog 2023-03-09](https://core.telegram.org/bots/api#march-9-2023)
