### PR TITLE
chore: Replace request to node-fetch, #1076

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "eventemitter3": "^3.0.0",
     "file-type": "^3.9.0",
     "mime": "^1.6.0",
+    "node-fetch": "2.7.0",
     "pump": "^2.0.0",
-    "request": "^2.83.0",
     "request-promise": "^4.2.2"
   },
   "devDependencies": {

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -8,7 +8,8 @@ const debug = require('debug')('node-telegram-bot-api');
 const EventEmitter = require('eventemitter3');
 const fileType = require('file-type');
 const request = require('request-promise');
-const streamedRequest = require('request');
+const fetch = require('node-fetch');
+const { pipeline } = require('node:stream/promises');
 const qs = require('querystring');
 const stream = require('stream');
 const mime = require('mime');
@@ -474,7 +475,9 @@ class TelegramBot extends EventEmitter {
         fileStream.emit('info', {
           uri: fileURI,
         });
-        pump(streamedRequest(Object.assign({ uri: fileURI }, this.options.request)), fileStream);
+        fetch(fileURI)
+          .then((response) => pipeline(response.body, fileStream))
+          .catch((error) => new Error(error));
       })
       .catch((error) => {
         fileStream.emit('error', error);


### PR DESCRIPTION
- [x] All tests pass
- [x] I have run `npm run doc`

About tests:
I don't have TEST_STICKER_SET_NAME and TEST_PROVIDER_TOKEN to run the tests related to them. The rest of the test pass normally.

### Description
Getting rid of deprecated dependencies request.

### References
https://www.npmjs.com/package/request

Issue: #1076.