### PR TITLE
chore: Add dotenv to simplify local development

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,0 +1,19 @@
+# Token to be used
+TEST_TELEGRAM_TOKEN=<YOUR_BOT_TOKEN>
+
+# User Id which you want to send the messages.
+TEST_USER_ID=<USER_ID>
+
+# Group Id which to use in some of the tests, e.g. for TelegramBot#getChat()
+TEST_GROUP_ID=<GROUP_ID>
+
+# Game short name to use in some tests, e.g. TelegramBot#sendGame()
+# Defaults to "medusalab_test".
+TEST_GAME_SHORT_NAME=<GAME_SHORT_NAME>
+
+# Sticker set name to use in some tests, e.g. TelegramBot#getStickerSet()
+# Defaults to "pusheen".
+TEST_STICKER_SET_NAME=<STICKER_SET_NAME>
+
+# Payment provider token to be used
+TEST_PROVIDER_TOKEN=<YOUR_PROVIDER_TOKEN>

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   "scripts": {
     "gen-doc": "echo 'WARNING: `npm run gen-doc` is deprecated. Use `npm run doc` instead.' && npm run doc",
     "doc": "jsdoc2md --files src/telegram.js --template doc/api.hbs > doc/api.md",
+    "prepare-env": "cp env.template .env",
     "build": "babel -d ./lib src",
     "prepublishOnly": "npm run build && npm run gen-doc",
     "eslint": "eslint ./src ./test ./examples",
     "mocha": "mocha",
+    "mocha:dev": "mocha -r dotenv/config",
     "pretest": "npm run build",
     "test": "npm run eslint && istanbul cover ./node_modules/mocha/bin/_mocha"
   },
@@ -52,6 +54,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "concat-stream": "^1.6.0",
+    "dotenv": "16.3.1",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-mocha": "^4.11.0",

--- a/test/README.md
+++ b/test/README.md
@@ -26,6 +26,14 @@ npm run test
 
 # Run individual tests
 npm run eslint              # static-analysis
-npm run mocha               # mocha tests
+```
+Running the mocha:
+```bash
+npm run prepare-env
+```
+Edit the [.env](../.env) file by filling in the value of the environment variables with your data.
+
+```bash
+npm run mocha:dev           # mocha tests
 ```
 Note: The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.


### PR DESCRIPTION
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

So that you don't have to constantly export environment variables and be able to change them conveniently.