### PR TITLE
revokeChatInviteLink api doc fix

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1113,7 +1113,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 
 <a name="TelegramBot+revokeChatInviteLink"></a>
 
-### telegramBot.revokeChatInviteLink(chatId, [options]) ⇒ <code>Promise</code>
+### telegramBot.revokeChatInviteLink(chatId, inviteLink) ⇒ <code>Promise</code>
 Use this method to revoke an invite link created by the bot.
 Note: If the primary link is revoked, a new link is automatically generated
 
@@ -1126,7 +1126,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
-| [options] | <code>Object</code> | Additional Telegram query options |
+| inviteLink | <code>String</code> | Text with the invite link to revoke |
 
 <a name="TelegramBot+approveChatJoinRequest"></a>
 


### PR DESCRIPTION
- [x] All tests pass
- [x] I have run `npm run doc`

### Description

Fixed api error for revokeChatInviteLink

### References

No references. This api doc does not match [the actual code](https://github.com/yagop/node-telegram-bot-api/blob/595cdbd0c656be258bebda2aab5d343de1e938d4/src/telegram.js#L1616), which takes inviteLink: string as a second argument
