### PR TITLE
Fixed getUserChatBoosts method

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -104,7 +104,7 @@ TelegramBot
         * [.unhideGeneralForumTopic(chatId, [options])](#TelegramBot+unhideGeneralForumTopic) ⇒ <code>Promise</code>
         * [.unpinAllGeneralForumTopicMessages(chatId, [options])](#TelegramBot+unpinAllGeneralForumTopicMessages) ⇒ <code>Promise</code>
         * [.answerCallbackQuery(callbackQueryId, [options])](#TelegramBot+answerCallbackQuery) ⇒ <code>Promise</code>
-        * [.getUserChatBoosts(chatId, user_id, [options])](#TelegramBot+getUserChatBoosts) ⇒ <code>Promise</code>
+        * [.getUserChatBoosts(chatId, userId, [options])](#TelegramBot+getUserChatBoosts) ⇒ <code>Promise</code>
         * [.getBusinessConnection(businessConnectionId, [options])](#TelegramBot+getBusinessConnection) ⇒ <code>Promise</code>
         * [.setMyCommands(commands, [options])](#TelegramBot+setMyCommands) ⇒ <code>Promise</code>
         * [.deleteMyCommands([options])](#TelegramBot+deleteMyCommands) ⇒ <code>Promise</code>
@@ -1680,7 +1680,7 @@ that are being deprecated.
 
 <a name="TelegramBot+getUserChatBoosts"></a>
 
-### telegramBot.getUserChatBoosts(chatId, user_id, [options]) ⇒ <code>Promise</code>
+### telegramBot.getUserChatBoosts(chatId, userId, [options]) ⇒ <code>Promise</code>
 Use this method to get the list of boosts added to a chat by a use.
 Requires administrator rights in the chat
 
@@ -1691,7 +1691,7 @@ Requires administrator rights in the chat
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the group/channel |
-| user_id | <code>Number</code> | Unique identifier of the target user |
+| userId | <code>Number</code> | Unique identifier of the target user |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+getBusinessConnection"></a>

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -2248,14 +2248,14 @@ class TelegramBot extends EventEmitter {
    * Requires administrator rights in the chat
    *
    * @param  {Number|String} chatId  Unique identifier for the group/channel
-   * @param  {Number} user_id Unique identifier of the target user
+   * @param  {Number} userId Unique identifier of the target user
    * @param  {Object} [options] Additional Telegram query options
    * @return {Promise} On success, returns a [UserChatBoosts](https://core.telegram.org/bots/api#userchatboosts) object
    * @see https://core.telegram.org/bots/api#getuserchatboosts
    */
-  getUserChatBoosts(chatId, pollId, form = {}) {
+  getUserChatBoosts(chatId, userId, form = {}) {
     form.chat_id = chatId;
-    form.message_id = pollId;
+    form.user_id = userId;
     return this._request('getUserChatBoosts', { form });
   }
 


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [x] I have run `npm run doc`

### Description

Fixed an error on calling `getUserChatBoosts`, when `message_id` was sent instead of `user_id`

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->

Issue #1200
Telegram Bot API - getUserChatBoosts: https://core.telegram.org/bots/api#getuserchatboosts
