### PR TITLE
fix: forwardMessages yagop#1215

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -255,6 +255,13 @@ class TelegramBot extends EventEmitter {
     }
   }
 
+  _fixMessageIds(obj) {
+    const messageIds = obj.message_ids;
+    if (messageIds && typeof messageIds !== 'string') {
+      obj.message_ids = stringify(messageIds);
+    }
+  }
+
   /**
    * Fix 'reply_parameters' parameter by making it JSON-serialized, as
    * required by the Telegram Bot API
@@ -288,6 +295,7 @@ class TelegramBot extends EventEmitter {
       this._fixReplyMarkup(options.form);
       this._fixEntitiesField(options.form);
       this._fixReplyParameters(options.form);
+      this._fixMessageIds(options.form);
     }
     if (options.qs) {
       this._fixReplyMarkup(options.qs);


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [ ] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->

fix `forwardMessages` sends incorrectly formatted `message_ids`

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->

Issue #1215
Telegram Bot API - forwardMessages: https://core.telegram.org/bots/api#forwardmessages
