### PR TITLE
Upgrade NPM packages - Phase 1 (Update mocha & migrated to nyc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 coverage/
+.nyc_output/
 npm-debug.log
 .package.json
 package-lock.json

--- a/doc/api.md
+++ b/doc/api.md
@@ -73,6 +73,8 @@ TelegramBot
         * [.exportChatInviteLink(chatId, [options])](#TelegramBot+exportChatInviteLink) ⇒ <code>Promise</code>
         * [.createChatInviteLink(chatId, [options])](#TelegramBot+createChatInviteLink) ⇒ <code>Object</code>
         * [.editChatInviteLink(chatId, inviteLink, [options])](#TelegramBot+editChatInviteLink) ⇒ <code>Promise</code>
+        * [.createChatSubscriptionInviteLink(chatId, subscriptionPeriod, subscriptionPrice, [options])](#TelegramBot+createChatSubscriptionInviteLink) ⇒ <code>Promise</code>
+        * [.editChatSubscriptionInviteLink(chatId, inviteLink, [options])](#TelegramBot+editChatSubscriptionInviteLink) ⇒ <code>Promise</code>
         * [.revokeChatInviteLink(chatId, inviteLink, [options])](#TelegramBot+revokeChatInviteLink) ⇒ <code>Promise</code>
         * [.approveChatJoinRequest(chatId, userId, [options])](#TelegramBot+approveChatJoinRequest) ⇒ <code>Promise</code>
         * [.declineChatJoinRequest(chatId, userId, [options])](#TelegramBot+declineChatJoinRequest) ⇒ <code>Promise</code>
@@ -146,6 +148,7 @@ TelegramBot
         * [.createInvoiceLink(title, description, payload, providerToken, currency, prices, [options])](#TelegramBot+createInvoiceLink) ⇒ <code>Promise</code>
         * [.answerShippingQuery(shippingQueryId, ok, [options])](#TelegramBot+answerShippingQuery) ⇒ <code>Promise</code>
         * [.answerPreCheckoutQuery(preCheckoutQueryId, ok, [options])](#TelegramBot+answerPreCheckoutQuery) ⇒ <code>Promise</code>
+        * [.getStarTransactions([options])](#TelegramBot+getStarTransactions) ⇒ <code>Promise</code>
         * [.refundStarPayment(userId, telegramPaymentChargeId, [options])](#TelegramBot+refundStarPayment) ⇒ <code>Promise</code>
         * [.sendGame(chatId, gameShortName, [options])](#TelegramBot+sendGame) ⇒ <code>Promise</code>
         * [.setGameScore(userId, score, [options])](#TelegramBot+setGameScore) ⇒ <code>Promise</code>
@@ -1170,6 +1173,41 @@ The bot **must be an administrator in the chat** for this to work and must have 
 | --- | --- | --- |
 | chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
 | inviteLink | <code>String</code> | Text with the invite link to edit |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+createChatSubscriptionInviteLink"></a>
+
+### telegramBot.createChatSubscriptionInviteLink(chatId, subscriptionPeriod, subscriptionPrice, [options]) ⇒ <code>Promise</code>
+Use this method to create a subscription invite link for a channel chat.
+
+The bot must have the can_invite_users administrator rights
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - The new invite link as a [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
+**See**: https://core.telegram.org/bots/api#createchatsubscriptioninvitelink  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
+| subscriptionPeriod | <code>Number</code> | The number of seconds the subscription will be active for before the next payment. Currently, it must always be 2592000 (30 days) |
+| subscriptionPrice | <code>Number</code> | The amount of Telegram Stars a user must pay initially and after each subsequent subscription period to be a member of the chat (1-2500) |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+editChatSubscriptionInviteLink"></a>
+
+### telegramBot.editChatSubscriptionInviteLink(chatId, inviteLink, [options]) ⇒ <code>Promise</code>
+Use this method to edit a subscription invite link created by the bot.
+
+The bot must have the can_invite_users administrator rights
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - The new invite link as a [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
+**See**: https://core.telegram.org/bots/api#editchatsubscriptioninvitelink  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
+| inviteLink | <code>String</code> | The invite link to edit |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+revokeChatInviteLink"></a>
@@ -2363,6 +2401,19 @@ an [Update](https://core.telegram.org/bots/api#update) with the field *pre_check
 | --- | --- | --- |
 | preCheckoutQueryId | <code>String</code> | Unique identifier for the query to be answered |
 | ok | <code>Boolean</code> | Specify if every order details are ok |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+getStarTransactions"></a>
+
+### telegramBot.getStarTransactions([options]) ⇒ <code>Promise</code>
+Use this method for get the bot's Telegram Star transactions in chronological order
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - On success, returns a [StarTransactions](https://core.telegram.org/bots/api#startransactions) object  
+**See**: https://core.telegram.org/bots/api#getstartransactions  
+
+| Param | Type | Description |
+| --- | --- | --- |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+refundStarPayment"></a>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "eslint ./src ./test ./examples",
     "mocha": "mocha",
     "pretest": "npm run build",
-    "test": "npm run eslint && istanbul cover ./node_modules/mocha/bin/_mocha"
+    "test": "npm run eslint && nyc --reporter=lcov --reporter=json --reporter=text-summary npm run mocha"
   },
   "author": "Yago Pérez <yagoperezs@gmail.com>",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "eventemitter3": "^3.0.0",
     "file-type": "^3.9.0",
     "mime": "^1.6.0",
-    "pump": "^2.0.0"
+    "pump": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -57,11 +57,11 @@
     "eslint-plugin-mocha": "^4.11.0",
     "is": "^3.2.1",
     "is-ci": "^1.0.10",
-    "istanbul": "^1.1.0-alpha.1",
     "jsdoc-to-markdown": "^3.0.3",
-    "mocha": "^3.5.3",
+    "mocha": "^10.7.3",
     "mocha-lcov-reporter": "^1.3.0",
-    "node-static": "^0.7.10"
+    "node-static": "^0.7.10",
+    "nyc": "^17.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [ ] All tests pass
- [x] I have run `npm run doc`

### Description

All the packages are outdated of this NodeJS project. So this is my attempt to get all the NPM depedences upgraded, starting with phase 1. 

In this phase 1 PR, I focused first of upgrading Mocha. And migrating away from Istanbul to the new nyc command. Which should be compatible. 

If you didn't know, instanbul is NOT maintained anymore: https://www.npmjs.com/package/istanbul, but.. nyc is: https://github.com/istanbuljs/nyc
