### PR TITLE
Remove travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Node.js module to interact with the official [Telegram Bot API](https://core.tel
 
 [![Bot API](https://img.shields.io/badge/Bot%20API-v.7.4-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
-[![Build Status](https://img.shields.io/travis/yagop/node-telegram-bot-api/master?style=flat-square&logo=travis)](https://travis-ci.org/yagop/node-telegram-bot-api)
 [![Coverage Status](https://img.shields.io/codecov/c/github/yagop/node-telegram-bot-api?style=flat-square&logo=codecov)](https://codecov.io/gh/yagop/node-telegram-bot-api)
 
 [![https://telegram.me/node_telegram_bot_api](https://img.shields.io/badge/💬%20Telegram-Channel-blue.svg?style=flat-square)](https://telegram.me/node_telegram_bot_api)


### PR DESCRIPTION
### Description

You are not using Travis anymore. Remove the broken badge on your README.

If you want to add a AppVeyor badge, feel free to add that. See also: https://www.appveyor.com/docs/status-badges/

@danielperez9430 However, _I_ can _not_ add an AppVeyor badge, since it requires a security token in the URL. Only project members can generate such a badge. So..
