### PR TITLE
RFC: fix: FatalError set reference to causing error

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -30,7 +30,10 @@ exports.FatalError = class FatalError extends exports.BaseError {
     const error = (typeof data === 'string') ? null : data;
     const message = error ? error.message : data;
     super('EFATAL', message);
-    if (error) this.stack = error.stack;
+    if (error) {
+      this.stack = error.stack;
+      this.cause = error;
+    }
   }
 };
 


### PR DESCRIPTION
- [ ] All tests pass _(no - I don't have suitable tokens to test all integration tests)_
- [ ] I have run `npm run doc` _(not part of external api)_

### Description
FatalError does not provide enough context for understanding underlying issues.
Where available, attach the "causing" error to the FatalError to allow later inspection on `.cause` (see https://nodejs.org/api/errors.html#errorcause)

Serializing Error objects with `util.inspect()` recursively serializes `error.cause` if it is set and would allow better log messages in consuming applications.

I don't believe the existing approach of copying of the stack from the causing error is "least surprise" for consuming authors, but I do not yet understand reasons for why it is as is, or likelihood of breaking existing code.

### References
Recent node versions introduced a bug (https://github.com/nodejs/node/issues/54359) in certain network configurations that is becoming more numerous triggering EFATAL errors.

Reports often miss much depth, with only "EFATAL: AggregateError" as a description:
* Issues at this repo: https://github.com/yagop/node-telegram-bot-api/issues/1174 
* Issue on consuming repo: https://github.com/windkh/node-red-contrib-telegrambot/issues/345

