### PR TITLE
fix: add missing stringifying scope field for deleteMyCommands

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -2504,6 +2504,9 @@ class TelegramBot extends EventEmitter {
    * @see https://core.telegram.org/bots/api#deletemycommands
    */
   deleteMyCommands(form = {}) {
+    if (form.scope) {
+      form.scope = stringify(form.scope);
+    }
     return this._request('deleteMyCommands', { form });
   }
 


### PR DESCRIPTION
<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [ ] All tests pass
- [x] I have run `npm run doc`

### Description

<!-- Explain what you are trying to achieve with this PR -->
According to the telegram bot api [documentation]((https://core.telegram.org/bots/api#deleteMyCommands)), there is a `scope` field of `deleteMyCommands` which should be stringified before sending request. 
Based on other related methods, such as `setMyCommands`, adds missing stringifying `scope` of the method `deleteMyCommands`.
Fixes [#1281](https://github.com/yagop/node-telegram-bot-api/issues/1281)

Sorry, I didn't run tests.

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->
[#1281](https://github.com/yagop/node-telegram-bot-api/issues/1281)
[Telegram Bot API](https://core.telegram.org/bots/api#deleteMyCommands)
