### PR TITLE
Security: Webhook authentication uses substring match on URL token

### DIFF
--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -133,7 +133,13 @@ class TelegramBotWebHook {
     debug('WebHook request URL: %s', req.url);
     debug('WebHook request headers: %j', req.headers);
 
-    if (req.url.indexOf(this.bot.token) !== -1) {
+    const urlPath = req.url.split('?')[0];
+    const expectedPath = `/bot${this.bot.token}`;
+    const hasValidPath = urlPath === expectedPath;
+    const hasValidSecretToken = !this.options.secretToken
+      || req.headers['x-telegram-bot-api-secret-token'] === this.options.secretToken;
+
+    if (hasValidPath && hasValidSecretToken) {
       if (req.method !== 'POST') {
         debug('WebHook request isn\'t a POST');
         res.statusCode = 418; // I'm a teabot!


### PR DESCRIPTION
## Problem

Webhook authorization accepts any request where `req.url.indexOf(this.bot.token) !== -1`. This is not an exact route check and can be satisfied by crafted paths/query strings containing the token anywhere, increasing risk of unintended endpoint acceptance if the token is exposed.

**Severity**: `high`
**File**: `src/telegramWebHook.js`

## Solution

Match the webhook path exactly (for example, strict equality against `/bot${token}` or a fixed configured path), and additionally validate Telegram's `X-Telegram-Bot-Api-Secret-Token` header.

## Changes

- `src/telegramWebHook.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
