### PR TITLE
Add @toptl/node-telegram-bot-api to extensions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Some things built using this library that might interest you:
 * [beetube-bot](https://github.com/kodjunkie/beetube-bot): A telegram bot for music, videos, movies, EDM tracks, torrent downloads, files and more.
 * [telegram-inline-calendar](https://github.com/VDS13/telegram-inline-calendar): Date and time picker and inline calendar for Node.js telegram bots.
 * [telegram-captcha](https://github.com/VDS13/telegram-captcha): Telegram bot to protect Telegram groups from automatic bots.
+* [@toptl/node-telegram-bot-api](https://github.com/top-tl/node-telegram-bot-api): Plugin for TOP.TL, the Telegram directory. Auto-tracks bot stats and enables vote checking.
 
 
 ## 👥 Contributors


### PR DESCRIPTION
Adds [@toptl/node-telegram-bot-api](https://www.npmjs.com/package/@toptl/node-telegram-bot-api) to the Community section.

[TOP.TL](https://top.tl) is a community-ranked Telegram directory (like top.gg for Telegram). This plugin auto-posts bot stats and provides vote-checking.

- npm: https://www.npmjs.com/package/@toptl/node-telegram-bot-api
- GitHub: https://github.com/top-tl/node-telegram-bot-api