### PR TITLE
feat: Support Telegram Bot API v10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+Added:
+
+1. Support Telegram Bot API v10.0
+   * `#answerGuestQuery` (Guest Mode)
+   * `#deleteMessageReaction`
+   * `#deleteAllMessageReactions`
+   * `#sendLivePhoto`
+   * `#getManagedBotAccessSettings`
+   * `#setManagedBotAccessSettings`
+   * `#getUserPersonalChatMessages`
+
 ## [0.68.0][0.68.0] - 2026-04-05
 
 Added:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node.js module to interact with the official [Telegram Bot API](https://core.telegram.org/bots/api).
 
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-v.9.6-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-v.10.0-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
 [![Coverage Status](https://img.shields.io/codecov/c/github/yagop/node-telegram-bot-api?style=flat-square&logo=codecov)](https://codecov.io/gh/yagop/node-telegram-bot-api)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -44,6 +44,7 @@ TelegramBot
         * [.copyMessage(chatId, fromChatId, messageId, [options])](#TelegramBot+copyMessage) ⇒ <code>Promise</code>
         * [.copyMessages(chatId, fromChatId, messageIds, [options])](#TelegramBot+copyMessages) ⇒ <code>Promise</code>
         * [.sendPhoto(chatId, photo, [options], [fileOptions])](#TelegramBot+sendPhoto) ⇒ <code>Promise</code>
+        * [.sendLivePhoto(chatId, livePhoto, photo, [options], [fileOptions])](#TelegramBot+sendLivePhoto) ⇒ <code>Promise</code>
         * [.sendAudio(chatId, audio, [options], [fileOptions])](#TelegramBot+sendAudio) ⇒ <code>Promise</code>
         * [.sendDocument(chatId, doc, [options], [fileOptions])](#TelegramBot+sendDocument) ⇒ <code>Promise</code>
         * [.sendVideo(chatId, video, [options], [fileOptions])](#TelegramBot+sendVideo) ⇒ <code>Promise</code>
@@ -63,6 +64,8 @@ TelegramBot
         * [.sendMessageDraft(chatId, draftId, text, [options])](#TelegramBot+sendMessageDraft) ⇒ <code>Promise</code>
         * [.sendChatAction(chatId, action, [options])](#TelegramBot+sendChatAction) ⇒ <code>Promise</code>
         * [.setMessageReaction(chatId, messageId, [options])](#TelegramBot+setMessageReaction) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+        * [.deleteMessageReaction(chatId, messageId, [options])](#TelegramBot+deleteMessageReaction) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+        * [.deleteAllMessageReactions(chatId, [options])](#TelegramBot+deleteAllMessageReactions) ⇒ <code>Promise.&lt;Boolean&gt;</code>
         * [.getUserProfilePhotos(userId, [options])](#TelegramBot+getUserProfilePhotos) ⇒ <code>Promise</code>
         * [.getUserProfileAudios(userId, [options])](#TelegramBot+getUserProfileAudios) ⇒ <code>Promise</code>
         * [.setUserEmojiStatus(userId, [options])](#TelegramBot+setUserEmojiStatus) ⇒ <code>Promise</code>
@@ -96,6 +99,7 @@ TelegramBot
         * [.getChatAdministrators(chatId, [options])](#TelegramBot+getChatAdministrators) ⇒ <code>Promise</code>
         * [.getChatMemberCount(chatId, [options])](#TelegramBot+getChatMemberCount) ⇒ <code>Promise</code>
         * [.getChatMember(chatId, userId, [options])](#TelegramBot+getChatMember) ⇒ <code>Promise</code>
+        * [.getUserPersonalChatMessages(userId, limit, [options])](#TelegramBot+getUserPersonalChatMessages) ⇒ <code>Promise</code>
         * [.setChatStickerSet(chatId, stickerSetName, [options])](#TelegramBot+setChatStickerSet) ⇒ <code>Promise</code>
         * [.deleteChatStickerSet(chatId, [options])](#TelegramBot+deleteChatStickerSet) ⇒ <code>Promise</code>
         * [.getForumTopicIconStickers(chatId, [options])](#TelegramBot+getForumTopicIconStickers) ⇒ <code>Promise</code>
@@ -112,12 +116,15 @@ TelegramBot
         * [.unhideGeneralForumTopic(chatId, [options])](#TelegramBot+unhideGeneralForumTopic) ⇒ <code>Promise</code>
         * [.unpinAllGeneralForumTopicMessages(chatId, [options])](#TelegramBot+unpinAllGeneralForumTopicMessages) ⇒ <code>Promise</code>
         * [.answerCallbackQuery(callbackQueryId, [options])](#TelegramBot+answerCallbackQuery) ⇒ <code>Promise</code>
+        * [.answerGuestQuery(guestQueryId, result, [options])](#TelegramBot+answerGuestQuery) ⇒ <code>Promise</code>
         * [.savePreparedInlineMessage(userId, result, [options])](#TelegramBot+savePreparedInlineMessage) ⇒ <code>Promise</code>
         * [.savePreparedKeyboardButton(userId, button, [options])](#TelegramBot+savePreparedKeyboardButton) ⇒ <code>Promise</code>
         * [.getUserChatBoosts(chatId, userId, [options])](#TelegramBot+getUserChatBoosts) ⇒ <code>Promise</code>
         * [.getBusinessConnection(businessConnectionId, [options])](#TelegramBot+getBusinessConnection) ⇒ <code>Promise</code>
         * [.getManagedBotToken(userId, [options])](#TelegramBot+getManagedBotToken) ⇒ <code>Promise</code>
         * [.replaceManagedBotToken(userId, [options])](#TelegramBot+replaceManagedBotToken) ⇒ <code>Promise</code>
+        * [.getManagedBotAccessSettings(userId, [options])](#TelegramBot+getManagedBotAccessSettings) ⇒ <code>Promise</code>
+        * [.setManagedBotAccessSettings(userId, isAccessRestricted, [options])](#TelegramBot+setManagedBotAccessSettings) ⇒ <code>Promise.&lt;Boolean&gt;</code>
         * [.setMyCommands(commands, [options])](#TelegramBot+setMyCommands) ⇒ <code>Promise</code>
         * [.deleteMyCommands([options])](#TelegramBot+deleteMyCommands) ⇒ <code>Promise</code>
         * [.getMyCommands([options])](#TelegramBot+getMyCommands) ⇒ <code>Promise</code>
@@ -206,9 +213,7 @@ TelegramBot
 <a name="new_TelegramBot_new"></a>
 
 ### new TelegramBot(token, [options])
-Both request method to obtain messages are implemented. To use standard polling, set `polling: true`
-on `options`. Notice that [webHook](https://core.telegram.org/bots/api#setwebhook) will need a SSL certificate.
-Emits `message` when a message arrives.
+Both request method to obtain messages are implemented. To use standard polling, set `polling: true`on `options`. Notice that [webHook](https://core.telegram.org/bots/api#setwebhook) will need a SSL certificate.Emits `message` when a message arrives.
 
 
 | Param | Type | Default | Description |
@@ -241,8 +246,7 @@ Emits `message` when a message arrives.
 <a name="TelegramBot+on"></a>
 
 ### telegramBot.on(event, listener)
-Add listener for the specified [event](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#events).
-This is the usual `emitter.on()` method.
+Add listener for the specified [event](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#events).This is the usual `emitter.on()` method.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**
@@ -259,8 +263,7 @@ This is the usual `emitter.on()` method.
 <a name="TelegramBot+startPolling"></a>
 
 ### telegramBot.startPolling([options]) ⇒ <code>Promise</code>
-Start polling.
-Rejects returned promise if a WebHook is being used by this instance.
+Start polling.Rejects returned promise if a WebHook is being used by this instance.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 
@@ -285,9 +288,7 @@ Alias of `TelegramBot#startPolling()`. This is **deprecated**.
 <a name="TelegramBot+stopPolling"></a>
 
 ### telegramBot.stopPolling([options]) ⇒ <code>Promise</code>
-Stops polling after the last polling request resolves.
-Multiple invocations do nothing if polling is already stopped.
-Returning the promise of the last polling request is **deprecated**.
+Stops polling after the last polling request resolves.Multiple invocations do nothing if polling is already stopped.Returning the promise of the last polling request is **deprecated**.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 
@@ -300,12 +301,7 @@ Returning the promise of the last polling request is **deprecated**.
 <a name="TelegramBot+getFileLink"></a>
 
 ### telegramBot.getFileLink(fileId, [options]) ⇒ <code>Promise</code>
-Get link for file.
-Use this method to get link for file for subsequent use.
-Attention: link will be valid for 1 hour.
-
-This method is a sugar extension of the (getFile)[#getfilefileid] method,
-which returns just path to file on remote server (you will have to manually build full uri after that).
+Get link for file.Use this method to get link for file for subsequent use.Attention: link will be valid for 1 hour.This method is a sugar extension of the (getFile)[#getfilefileid] method,which returns just path to file on remote server (you will have to manually build full uri after that).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Promise which will have  *fileURI* in resolve callback  
@@ -319,15 +315,7 @@ which returns just path to file on remote server (you will have to manually buil
 <a name="TelegramBot+getFileStream"></a>
 
 ### telegramBot.getFileStream(fileId, [options]) ⇒ <code>stream.Readable</code>
-Return a readable stream for file.
-
-`fileStream.path` is the specified file ID i.e. `fileId`.
-`fileStream` emits event `info` passing a single argument i.e.
-`info` with the interface `{ uri }` where `uri` is the URI of the
-file on Telegram servers.
-
-This method is a sugar extension of the [getFileLink](#TelegramBot+getFileLink) method,
-which returns the full URI to the file on remote server.
+Return a readable stream for file.`fileStream.path` is the specified file ID i.e. `fileId`.`fileStream` emits event `info` passing a single argument i.e.`info` with the interface `{ uri }` where `uri` is the URI of thefile on Telegram servers.This method is a sugar extension of the [getFileLink](#TelegramBot+getFileLink) method,which returns the full URI to the file on remote server.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>stream.Readable</code> - fileStream  
@@ -340,10 +328,7 @@ which returns the full URI to the file on remote server.
 <a name="TelegramBot+downloadFile"></a>
 
 ### telegramBot.downloadFile(fileId, downloadDir, [options]) ⇒ <code>Promise</code>
-Downloads file in the specified folder.
-
-This method is a sugar extension of the [getFileStream](#TelegramBot+getFileStream) method,
-which returns a readable file stream.
+Downloads file in the specified folder.This method is a sugar extension of the [getFileStream](#TelegramBot+getFileStream) method,which returns a readable file stream.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Promise, which will have *filePath* of downloaded file in resolve callback  
@@ -372,9 +357,7 @@ Register a RegExp to test against an incomming text message.
 Remove a listener registered with `onText()`.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
-**Returns**: <code>Object</code> - deletedListener The removed reply listener if
-  found. This object has `regexp` and `callback`
-  properties. If not found, returns `null`.  
+**Returns**: <code>Object</code> - deletedListener The removed reply listener if  found. This object has `regexp` and `callback`  properties. If not found, returns `null`.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -406,9 +389,7 @@ Register a reply to wait for a message response.
 Removes a reply that has been prev. registered for a message response.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
-**Returns**: <code>Object</code> - deletedListener The removed reply listener if
-  found. This object has `id`, `chatId`, `messageId` and `callback`
-  properties. If not found, returns `null`.  
+**Returns**: <code>Object</code> - deletedListener The removed reply listener if  found. This object has `id`, `chatId`, `messageId` and `callback`  properties. If not found, returns `null`.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -430,32 +411,26 @@ Return true if polling. Otherwise, false.
 <a name="TelegramBot+openWebHook"></a>
 
 ### telegramBot.openWebHook() ⇒ <code>Promise</code>
-Open webhook.
-Multiple invocations do nothing if webhook is already open.
-Rejects returned promise if Polling is being used by this instance.
+Open webhook.Multiple invocations do nothing if webhook is already open.Rejects returned promise if Polling is being used by this instance.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 <a name="TelegramBot+closeWebHook"></a>
 
 ### telegramBot.closeWebHook() ⇒ <code>Promise</code>
-Close webhook after closing all current connections.
-Multiple invocations do nothing if webhook is already closed.
+Close webhook after closing all current connections.Multiple invocations do nothing if webhook is already closed.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Promise  
 <a name="TelegramBot+hasOpenWebHook"></a>
 
 ### telegramBot.hasOpenWebHook() ⇒ <code>Boolean</code>
-Return true if using webhook and it is open i.e. accepts connections.
-Otherwise, false.
+Return true if using webhook and it is open i.e. accepts connections.Otherwise, false.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 <a name="TelegramBot+processUpdate"></a>
 
 ### telegramBot.processUpdate(update)
-Process an update; emitting the proper events and executing regexp
-callbacks. This method is useful should you be using a different
-way to fetch updates, other than those provided by TelegramBot.
+Process an update; emitting the proper events and executing regexpcallbacks. This method is useful should you be using a differentway to fetch updates, other than those provided by TelegramBot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#update  
@@ -467,9 +442,7 @@ way to fetch updates, other than those provided by TelegramBot.
 <a name="TelegramBot+getUpdates"></a>
 
 ### telegramBot.getUpdates([options]) ⇒ <code>Promise</code>
-Use this method to receive incoming updates using long polling.
-This method has an [older, compatible signature][getUpdates-v0.25.0]
-that is being deprecated.
+Use this method to receive incoming updates using long polling.This method has an [older, compatible signature][getUpdates-v0.25.0]that is being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getupdates  
@@ -481,9 +454,7 @@ that is being deprecated.
 <a name="TelegramBot+setWebHook"></a>
 
 ### telegramBot.setWebHook(url, [options], [fileOptions]) ⇒ <code>Promise</code>
-Specify an url to receive incoming updates via an outgoing webHook.
-This method has an [older, compatible signature][setWebHook-v0.25.0]
-that is being deprecated.
+Specify an url to receive incoming updates via an outgoing webHook.This method has an [older, compatible signature][setWebHook-v0.25.0]that is being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**
@@ -503,8 +474,7 @@ that is being deprecated.
 <a name="TelegramBot+deleteWebHook"></a>
 
 ### telegramBot.deleteWebHook([options]) ⇒ <code>Promise</code>
-Use this method to remove webhook integration if you decide to
-switch back to getUpdates. Returns True on success.
+Use this method to remove webhook integration if you decide toswitch back to getUpdates. Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#deletewebhook  
@@ -516,10 +486,7 @@ switch back to getUpdates. Returns True on success.
 <a name="TelegramBot+getWebHookInfo"></a>
 
 ### telegramBot.getWebHookInfo([options]) ⇒ <code>Promise</code>
-Use this method to get current webhook status.
-On success, returns a [WebhookInfo](https://core.telegram.org/bots/api#webhookinfo) object.
-If the bot is using getUpdates, will return an object with the
-url field empty.
+Use this method to get current webhook status.On success, returns a [WebhookInfo](https://core.telegram.org/bots/api#webhookinfo) object.If the bot is using getUpdates, will return an object with theurl field empty.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#getwebhookinfo  
@@ -544,9 +511,7 @@ A simple method for testing your bot's authentication token. Requires no paramet
 <a name="TelegramBot+logOut"></a>
 
 ### telegramBot.logOut([options]) ⇒ <code>Promise</code>
-This method log out your bot from the cloud Bot API server before launching the bot locally.
-You must log out the bot before running it locally, otherwise there is no guarantee that the bot will receive updates.
-After a successful call, you will not be able to log in again using the same token for 10 minutes.
+This method log out your bot from the cloud Bot API server before launching the bot locally.You must log out the bot before running it locally, otherwise there is no guarantee that the bot will receive updates.After a successful call, you will not be able to log in again using the same token for 10 minutes.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -559,8 +524,7 @@ After a successful call, you will not be able to log in again using the same tok
 <a name="TelegramBot+close"></a>
 
 ### telegramBot.close([options]) ⇒ <code>Promise</code>
-This method close the bot instance before moving it from one local server to another.
-This method will return error 429 in the first 10 minutes after the bot is launched.
+This method close the bot instance before moving it from one local server to another.This method will return error 429 in the first 10 minutes after the bot is launched.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -603,8 +567,7 @@ Forward messages of any kind.
 <a name="TelegramBot+forwardMessages"></a>
 
 ### telegramBot.forwardMessages(chatId, fromChatId, messageIds, [options]) ⇒ <code>Promise</code>
-Use this method to forward multiple messages of any kind.
-If some of the specified messages can't be found or forwarded, they are skipped.
+Use this method to forward multiple messages of any kind.If some of the specified messages can't be found or forwarded, they are skipped.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - An array of MessageId of the sent messages on success  
@@ -620,10 +583,7 @@ If some of the specified messages can't be found or forwarded, they are skipped.
 <a name="TelegramBot+copyMessage"></a>
 
 ### telegramBot.copyMessage(chatId, fromChatId, messageId, [options]) ⇒ <code>Promise</code>
-Copy messages of any kind. **Service messages and invoice messages can't be copied.**
-The method is analogous to the method forwardMessages, but the copied message doesn't
-have a link to the original message.
-Returns the MessageId of the sent message on success.
+Copy messages of any kind. **Service messages and invoice messages can't be copied.**The method is analogous to the method forwardMessages, but the copied message doesn'thave a link to the original message.Returns the MessageId of the sent message on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - The [MessageId](https://core.telegram.org/bots/api#messageid) of the sent message on success  
@@ -639,9 +599,7 @@ Returns the MessageId of the sent message on success.
 <a name="TelegramBot+copyMessages"></a>
 
 ### telegramBot.copyMessages(chatId, fromChatId, messageIds, [options]) ⇒ <code>Promise</code>
-Use this method to copy messages of any kind. If some of the specified messages can't be found or copied, they are skipped.
-Service messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied.
-Returns the MessageId of the sent message on success.
+Use this method to copy messages of any kind. If some of the specified messages can't be found or copied, they are skipped.Service messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied.Returns the MessageId of the sent message on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - An array of MessageId of the sent messages  
@@ -674,12 +632,31 @@ Send photo
 | [options] | <code>Object</code> | Additional Telegram query options |
 | [fileOptions] | <code>Object</code> | Optional file related meta-data |
 
+<a name="TelegramBot+sendLivePhoto"></a>
+
+### telegramBot.sendLivePhoto(chatId, livePhoto, photo, [options], [fileOptions]) ⇒ <code>Promise</code>
+Send live photo.A live photo is composed of a static photo and a short video. Both fields are required.Sending live photos by a URL is currently unsupported - use a `file_id` or upload the file via multipart/form-data.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
+**See**
+
+- https://core.telegram.org/bots/api#sendlivephoto
+- https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) |
+| livePhoto | <code>String</code> \| <code>stream.Stream</code> \| <code>Buffer</code> | Video of the live photo to send. Pass a `file_id` to send a video that exists on the Telegram servers,   or upload a new video using multipart/form-data. The video must be no longer than 10 seconds and must not exceed 10 MB in size. |
+| photo | <code>String</code> \| <code>stream.Stream</code> \| <code>Buffer</code> | The static photo to send. Pass a `file_id` to send a photo that exists on the Telegram servers,   or upload a new photo using multipart/form-data. |
+| [options] | <code>Object</code> | Additional Telegram query options |
+| [fileOptions] | <code>Object</code> | Optional file related meta-data (applied to uploaded files) |
+
 <a name="TelegramBot+sendAudio"></a>
 
 ### telegramBot.sendAudio(chatId, audio, [options], [fileOptions]) ⇒ <code>Promise</code>
-Send audio
-
-**Your audio must be in the .MP3 or .M4A format.**
+Send audio**Your audio must be in the .MP3 or .M4A format.**
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -759,9 +736,7 @@ Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without s
 <a name="TelegramBot+sendVoice"></a>
 
 ### telegramBot.sendVoice(chatId, voice, [options], [fileOptions]) ⇒ <code>Promise</code>
-Send voice
-
-**Your audio must be in an .OGG file encoded with OPUS**, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document)
+Send voice**Your audio must be in an .OGG file encoded with OPUS**, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document)
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -781,8 +756,7 @@ Send voice
 <a name="TelegramBot+sendVideoNote"></a>
 
 ### telegramBot.sendVideoNote(chatId, videoNote, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to send video messages
-Telegram clients support **rounded square MPEG4 videos** of up to 1 minute long.
+Use this method to send video messagesTelegram clients support **rounded square MPEG4 videos** of up to 1 minute long.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -819,16 +793,10 @@ Use this method to send paid media.
 <a name="TelegramBot+sendMediaGroup"></a>
 
 ### telegramBot.sendMediaGroup(chatId, media, [options]) ⇒ <code>Promise</code>
-Use this method to send a group of photos or videos as an album.
-
-**Documents and audio files can be only grouped in an album with messages of the same type**
-
-If you wish to [specify file options](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files),
-add a `fileOptions` property to the target input in `media`.
+Use this method to send a group of photos or videos as an album.**Documents and audio files can be only grouped in an album with messages of the same type**If you wish to [specify file options](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files),add a `fileOptions` property to the target input in `media`.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
-**Returns**: <code>Promise</code> - On success, an array of the sent [Messages](https://core.telegram.org/bots/api#message)
-is returned.  
+**Returns**: <code>Promise</code> - On success, an array of the sent [Messages](https://core.telegram.org/bots/api#message)is returned.  
 **See**
 
 - https://core.telegram.org/bots/api#sendmediagroup
@@ -844,8 +812,7 @@ is returned.
 <a name="TelegramBot+sendLocation"></a>
 
 ### telegramBot.sendLocation(chatId, latitude, longitude, [options]) ⇒ <code>Promise</code>
-Send location.
-Use this method to send point on the map.
+Send location.Use this method to send point on the map.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -861,13 +828,7 @@ Use this method to send point on the map.
 <a name="TelegramBot+editMessageLiveLocation"></a>
 
 ### telegramBot.editMessageLiveLocation(latitude, longitude, [options]) ⇒ <code>Promise</code>
-Use this method to edit live location messages sent by
-the bot or via the bot (for inline bots).
-
- A location **can be edited until its live_period expires or editing is explicitly disabled by a call to [stopMessageLiveLocation](https://core.telegram.org/bots/api#stopmessagelivelocation)**
-
-Note that you must provide one of chat_id, message_id, or
-inline_message_id in your request.
+Use this method to edit live location messages sent bythe bot or via the bot (for inline bots). A location **can be edited until its live_period expires or editing is explicitly disabled by a call to [stopMessageLiveLocation](https://core.telegram.org/bots/api#stopmessagelivelocation)**Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, if the edited message is not an inline message, the edited [Message](https://core.telegram.org/bots/api#message) is returned, otherwise True is returned.  
@@ -882,11 +843,7 @@ inline_message_id in your request.
 <a name="TelegramBot+stopMessageLiveLocation"></a>
 
 ### telegramBot.stopMessageLiveLocation([options]) ⇒ <code>Promise</code>
-Use this method to stop updating a live location message sent by
-the bot or via the bot (for inline bots) before live_period expires.
-
-Note that you must provide one of chat_id, message_id, or
-inline_message_id in your request.
+Use this method to stop updating a live location message sent bythe bot or via the bot (for inline bots) before live_period expires.Note that you must provide one of chat_id, message_id, orinline_message_id in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, if the edited message is not an inline message, the edited [Message](https://core.telegram.org/bots/api#message) is returned, otherwise True is returned.  
@@ -899,8 +856,7 @@ inline_message_id in your request.
 <a name="TelegramBot+sendVenue"></a>
 
 ### telegramBot.sendVenue(chatId, latitude, longitude, title, address, [options]) ⇒ <code>Promise</code>
-Send venue.
-Use this method to send information about a venue.
+Send venue.Use this method to send information about a venue.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned.  
@@ -918,8 +874,7 @@ Use this method to send information about a venue.
 <a name="TelegramBot+sendContact"></a>
 
 ### telegramBot.sendContact(chatId, phoneNumber, firstName, [options]) ⇒ <code>Promise</code>
-Send contact.
-Use this method to send phone contacts.
+Send contact.Use this method to send phone contacts.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -935,8 +890,7 @@ Use this method to send phone contacts.
 <a name="TelegramBot+sendPoll"></a>
 
 ### telegramBot.sendPoll(chatId, question, pollOptions, [options]) ⇒ <code>Promise</code>
-Send poll.
-Use this method to send a native poll.
+Send poll.Use this method to send a native poll.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -952,8 +906,7 @@ Use this method to send a native poll.
 <a name="TelegramBot+sendChecklist"></a>
 
 ### telegramBot.sendChecklist(businessConnectionId, chatId, checklist, [options]) ⇒ <code>Promise</code>
-Send sendChecklist.
-Use this method to send a checklist on behalf of a connected business account.
+Send sendChecklist.Use this method to send a checklist on behalf of a connected business account.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -969,8 +922,7 @@ Use this method to send a checklist on behalf of a connected business account.
 <a name="TelegramBot+sendDice"></a>
 
 ### telegramBot.sendDice(chatId, [options]) ⇒ <code>Promise</code>
-Send Dice
-Use this method to send an animated emoji that will display a random value.
+Send DiceUse this method to send an animated emoji that will display a random value.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned  
@@ -984,8 +936,7 @@ Use this method to send an animated emoji that will display a random value.
 <a name="TelegramBot+sendMessageDraft"></a>
 
 ### telegramBot.sendMessageDraft(chatId, draftId, text, [options]) ⇒ <code>Promise</code>
-Send Message Draft
-Use this method to stream a partial message to a user while the message is being generated; supported only for bots with forum topic mode enabled. Returns True on success.
+Send Message DraftUse this method to stream a partial message to a user while the message is being generated; supported only for bots with forum topic mode enabled. Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, return true  
@@ -1001,16 +952,7 @@ Use this method to stream a partial message to a user while the message is being
 <a name="TelegramBot+sendChatAction"></a>
 
 ### telegramBot.sendChatAction(chatId, action, [options]) ⇒ <code>Promise</code>
-Send chat action.
-
-Use this method when you need to tell the user that something is happening on the bot's side.
-**The status is set for 5 seconds or less** (when a message arrives from your bot, Telegram clients clear its typing status).
-
- Action `typing` for [text messages](https://core.telegram.org/bots/api#sendmessage),
-`upload_photo` for [photos](https://core.telegram.org/bots/api#sendphoto), `record_video` or `upload_video` for [videos](https://core.telegram.org/bots/api#sendvideo),
-`record_voice` or `upload_voice` for [voice notes](https://core.telegram.org/bots/api#sendvoice), `upload_document` for [general files](https://core.telegram.org/bots/api#senddocument),
-`choose_sticker` for [stickers](https://core.telegram.org/bots/api#sendsticker), `find_location` for [location data](https://core.telegram.org/bots/api#sendlocation),
-`record_video_note` or `upload_video_note` for [video notes](https://core.telegram.org/bots/api#sendvideonote).
+Send chat action.Use this method when you need to tell the user that something is happening on the bot's side.**The status is set for 5 seconds or less** (when a message arrives from your bot, Telegram clients clear its typing status). Action `typing` for [text messages](https://core.telegram.org/bots/api#sendmessage),`upload_photo` for [photos](https://core.telegram.org/bots/api#sendphoto), `record_video` or `upload_video` for [videos](https://core.telegram.org/bots/api#sendvideo),`record_voice` or `upload_voice` for [voice notes](https://core.telegram.org/bots/api#sendvoice), `upload_document` for [general files](https://core.telegram.org/bots/api#senddocument),`choose_sticker` for [stickers](https://core.telegram.org/bots/api#sendsticker), `find_location` for [location data](https://core.telegram.org/bots/api#sendlocation),`record_video_note` or `upload_video_note` for [video notes](https://core.telegram.org/bots/api#sendvideonote).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1025,10 +967,7 @@ Use this method when you need to tell the user that something is happening on th
 <a name="TelegramBot+setMessageReaction"></a>
 
 ### telegramBot.setMessageReaction(chatId, messageId, [options]) ⇒ <code>Promise.&lt;Boolean&gt;</code>
-Use this method to change the chosen reactions on a message.
-- Service messages can't be reacted to.
-- Automatically forwarded messages from a channel to its discussion group have the same available reactions as messages in the channel.
-- In albums, bots must react to the first message.
+Use this method to change the chosen reactions on a message.- Service messages can't be reacted to.- Automatically forwarded messages from a channel to its discussion group have the same available reactions as messages in the channel.- In albums, bots must react to the first message.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise.&lt;Boolean&gt;</code> - True on success  
@@ -1040,11 +979,39 @@ Use this method to change the chosen reactions on a message.
 | messageId | <code>Number</code> | Unique identifier of the target message |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
+<a name="TelegramBot+deleteMessageReaction"></a>
+
+### telegramBot.deleteMessageReaction(chatId, messageId, [options]) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+Use this method to remove a reaction from a message in a group or a supergroup chat.The bot **must have the `can_delete_messages` administrator right** in the chat.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise.&lt;Boolean&gt;</code> - True on success  
+**See**: https://core.telegram.org/bots/api#deletemessagereaction  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) |
+| messageId | <code>Number</code> | Identifier of the target message |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+deleteAllMessageReactions"></a>
+
+### telegramBot.deleteAllMessageReactions(chatId, [options]) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+Use this method to remove up to 10000 recent reactions in a group or a supergroup chatadded by a given user or chat.The bot **must have the `can_delete_messages` administrator right** in the chat.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise.&lt;Boolean&gt;</code> - True on success  
+**See**: https://core.telegram.org/bots/api#deleteallmessagereactions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number</code> \| <code>String</code> | Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
 <a name="TelegramBot+getUserProfilePhotos"></a>
 
 ### telegramBot.getUserProfilePhotos(userId, [options]) ⇒ <code>Promise</code>
-Use this method to get a list of profile pictures for a user.
-Returns a [UserProfilePhotos](https://core.telegram.org/bots/api#userprofilephotos) object.
+Use this method to get a list of profile pictures for a user.Returns a [UserProfilePhotos](https://core.telegram.org/bots/api#userprofilephotos) object.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Returns a [UserProfilePhotos](https://core.telegram.org/bots/api#userprofilephotos) object  
@@ -1058,8 +1025,7 @@ Returns a [UserProfilePhotos](https://core.telegram.org/bots/api#userprofilephot
 <a name="TelegramBot+getUserProfileAudios"></a>
 
 ### telegramBot.getUserProfileAudios(userId, [options]) ⇒ <code>Promise</code>
-Use this method to get a list of profile audios for a user.
-Returns a [UserProfileAudios](https://core.telegram.org/bots/api#userprofileaudios) object.
+Use this method to get a list of profile audios for a user.Returns a [UserProfileAudios](https://core.telegram.org/bots/api#userprofileaudios) object.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Returns a [UserProfileAudios](https://core.telegram.org/bots/api#userprofileaudios) object  
@@ -1073,8 +1039,7 @@ Returns a [UserProfileAudios](https://core.telegram.org/bots/api#userprofileaudi
 <a name="TelegramBot+setUserEmojiStatus"></a>
 
 ### telegramBot.setUserEmojiStatus(userId, [options]) ⇒ <code>Promise</code>
-Changes the emoji status for a given user that previously allowed the bot to manage their emoji status
-via the Mini App method [requestEmojiStatusAccess](https://core.telegram.org/bots/webapps#initializing-mini-apps).
+Changes the emoji status for a given user that previously allowed the bot to manage their emoji statusvia the Mini App method [requestEmojiStatusAccess](https://core.telegram.org/bots/webapps#initializing-mini-apps).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1088,10 +1053,7 @@ via the Mini App method [requestEmojiStatusAccess](https://core.telegram.org/bot
 <a name="TelegramBot+getFile"></a>
 
 ### telegramBot.getFile(fileId, [options]) ⇒ <code>Promise</code>
-Get file.
-Use this method to get basic info about a file and prepare it for downloading.
-
-Attention: **link will be valid for 1 hour.**
+Get file.Use this method to get basic info about a file and prepare it for downloading.Attention: **link will be valid for 1 hour.**
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, a [File](https://core.telegram.org/bots/api#file) object is returned  
@@ -1105,11 +1067,7 @@ Attention: **link will be valid for 1 hour.**
 <a name="TelegramBot+banChatMember"></a>
 
 ### telegramBot.banChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to ban a user in a group, a supergroup or a channel.
-In the case of supergroups and channels, the user will not be able to
-return to the chat on their own using invite links, etc., unless unbanned first..
-
-The **bot must be an administrator in the group, supergroup or a channel** for this to work.
+Use this method to ban a user in a group, a supergroup or a channel.In the case of supergroups and channels, the user will not be able toreturn to the chat on their own using invite links, etc., unless unbanned first..The **bot must be an administrator in the group, supergroup or a channel** for this to work.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success.  
@@ -1124,14 +1082,7 @@ The **bot must be an administrator in the group, supergroup or a channel** for t
 <a name="TelegramBot+unbanChatMember"></a>
 
 ### telegramBot.unbanChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to unban a previously kicked user in a supergroup.
-The user will not return to the group automatically, but will be
-able to join via link, etc.
-
-The **bot must be an administrator** in the supergroup or channel for this to work.
-
-**By default**, this method guarantees that after the call the user is not a member of the chat, but will be able to join it.
-So **if the user is a member of the chat they will also be removed from the chat**. If you don't want this, use the parameter *only_if_banned*
+Use this method to unban a previously kicked user in a supergroup.The user will not return to the group automatically, but will beable to join via link, etc.The **bot must be an administrator** in the supergroup or channel for this to work.**By default**, this method guarantees that after the call the user is not a member of the chat, but will be able to join it.So **if the user is a member of the chat they will also be removed from the chat**. If you don't want this, use the parameter *only_if_banned*
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1146,10 +1097,7 @@ So **if the user is a member of the chat they will also be removed from the chat
 <a name="TelegramBot+restrictChatMember"></a>
 
 ### telegramBot.restrictChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to restrict a user in a supergroup.
-The bot **must be an administrator in the supergroup** for this to work
-and must have the appropriate admin rights. Pass True for all boolean parameters
-to lift restrictions from a user. Returns True on success.
+Use this method to restrict a user in a supergroup.The bot **must be an administrator in the supergroup** for this to workand must have the appropriate admin rights. Pass True for all boolean parametersto lift restrictions from a user. Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1164,9 +1112,7 @@ to lift restrictions from a user. Returns True on success.
 <a name="TelegramBot+promoteChatMember"></a>
 
 ### telegramBot.promoteChatMember(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to promote or demote a user in a supergroup or a channel.
-The bot **must be an administrator** in the chat for this to work
-and must have the appropriate admin rights. Pass False for all boolean parameters to demote a user.
+Use this method to promote or demote a user in a supergroup or a channel.The bot **must be an administrator** in the chat for this to workand must have the appropriate admin rights. Pass False for all boolean parameters to demote a user.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success.  
@@ -1197,11 +1143,7 @@ Use this method to set a custom title for an administrator in a supergroup promo
 <a name="TelegramBot+setChatMemberTag"></a>
 
 ### telegramBot.setChatMemberTag(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to set a tag for a regular member in a group or a supergroup.
-
-The bot must be an administrator in the chat for this to work and must have the can_manage_tags administrator right.
-
-Note: If the user is a admin in the chat, then this method will fail with a 400 Bad Request error with the message "Bad Request: CHAT_ADMIN_REQUIRED".
+Use this method to set a tag for a regular member in a group or a supergroup.The bot must be an administrator in the chat for this to work and must have the can_manage_tags administrator right.Note: If the user is a admin in the chat, then this method will fail with a 400 Bad Request error with the message "Bad Request: CHAT_ADMIN_REQUIRED".
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1216,10 +1158,7 @@ Note: If the user is a admin in the chat, then this method will fail with a 400 
 <a name="TelegramBot+banChatSenderChat"></a>
 
 ### telegramBot.banChatSenderChat(chatId, senderChatId, [options]) ⇒ <code>Promise</code>
-Use this method to ban a channel chat in a supergroup or a channel.
-
-Until the chat is [unbanned](https://core.telegram.org/bots/api#unbanchatsenderchat), the owner of the banned chat won't be able to send messages on behalf of any of their channels.
-The bot **must be an administrator in the supergroup or channel** for this to work and must have the appropriate administrator rights
+Use this method to ban a channel chat in a supergroup or a channel.Until the chat is [unbanned](https://core.telegram.org/bots/api#unbanchatsenderchat), the owner of the banned chat won't be able to send messages on behalf of any of their channels.The bot **must be an administrator in the supergroup or channel** for this to work and must have the appropriate administrator rights
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success.  
@@ -1234,9 +1173,7 @@ The bot **must be an administrator in the supergroup or channel** for this to wo
 <a name="TelegramBot+unbanChatSenderChat"></a>
 
 ### telegramBot.unbanChatSenderChat(chatId, senderChatId, [options]) ⇒ <code>Promise</code>
-Use this method to unban a previously banned channel chat in a supergroup or channel.
-
-The bot **must be an administrator** for this to work and must have the appropriate administrator rights.
+Use this method to unban a previously banned channel chat in a supergroup or channel.The bot **must be an administrator** for this to work and must have the appropriate administrator rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1251,10 +1188,7 @@ The bot **must be an administrator** for this to work and must have the appropri
 <a name="TelegramBot+setChatPermissions"></a>
 
 ### telegramBot.setChatPermissions(chatId, chatPermissions, [options]) ⇒ <code>Promise</code>
-Use this method to set default chat permissions for all members.
-
-The bot **must be an administrator in the group or a supergroup** for this to
-work and **must have the `can_restrict_members` admin rights.**
+Use this method to set default chat permissions for all members.The bot **must be an administrator in the group or a supergroup** for this towork and **must have the `can_restrict_members` admin rights.**
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1269,9 +1203,7 @@ work and **must have the `can_restrict_members` admin rights.**
 <a name="TelegramBot+exportChatInviteLink"></a>
 
 ### telegramBot.exportChatInviteLink(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to generate a new primary invite link for a chat. **Any previously generated primary link is revoked**.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate administrator rights.
+Use this method to generate a new primary invite link for a chat. **Any previously generated primary link is revoked**.The bot **must be an administrator in the chat** for this to work and must have the appropriate administrator rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Exported invite link as String on success.  
@@ -1285,11 +1217,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+createChatInviteLink"></a>
 
 ### telegramBot.createChatInviteLink(chatId, [options]) ⇒ <code>Object</code>
-Use this method to create an additional invite link for a chat.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
-
-The link generated with this method can be revoked using the method [revokeChatInviteLink](https://core.telegram.org/bots/api#revokechatinvitelink)
+Use this method to create an additional invite link for a chat.The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.The link generated with this method can be revoked using the method [revokeChatInviteLink](https://core.telegram.org/bots/api#revokechatinvitelink)
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Object</code> - The new invite link as [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
@@ -1303,9 +1231,7 @@ The link generated with this method can be revoked using the method [revokeChatI
 <a name="TelegramBot+editChatInviteLink"></a>
 
 ### telegramBot.editChatInviteLink(chatId, inviteLink, [options]) ⇒ <code>Promise</code>
-Use this method to edit a non-primary invite link created by the bot.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
+Use this method to edit a non-primary invite link created by the bot.The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - The edited invite link as a [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
@@ -1320,9 +1246,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+createChatSubscriptionInviteLink"></a>
 
 ### telegramBot.createChatSubscriptionInviteLink(chatId, subscriptionPeriod, subscriptionPrice, [options]) ⇒ <code>Promise</code>
-Use this method to create a subscription invite link for a channel chat.
-
-The bot must have the can_invite_users administrator rights
+Use this method to create a subscription invite link for a channel chat.The bot must have the can_invite_users administrator rights
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - The new invite link as a [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
@@ -1338,9 +1262,7 @@ The bot must have the can_invite_users administrator rights
 <a name="TelegramBot+editChatSubscriptionInviteLink"></a>
 
 ### telegramBot.editChatSubscriptionInviteLink(chatId, inviteLink, [options]) ⇒ <code>Promise</code>
-Use this method to edit a subscription invite link created by the bot.
-
-The bot must have the can_invite_users administrator rights
+Use this method to edit a subscription invite link created by the bot.The bot must have the can_invite_users administrator rights
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - The new invite link as a [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
@@ -1355,10 +1277,7 @@ The bot must have the can_invite_users administrator rights
 <a name="TelegramBot+revokeChatInviteLink"></a>
 
 ### telegramBot.revokeChatInviteLink(chatId, inviteLink, [options]) ⇒ <code>Promise</code>
-Use this method to revoke an invite link created by the bot.
-Note: If the primary link is revoked, a new link is automatically generated
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
+Use this method to revoke an invite link created by the bot.Note: If the primary link is revoked, a new link is automatically generatedThe bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - The revoked invite link as [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink) object  
@@ -1373,9 +1292,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+approveChatJoinRequest"></a>
 
 ### telegramBot.approveChatJoinRequest(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to approve a chat join request.
-
-The bot **must be an administrator in the chat** for this to work and **must have the `can_invite_users` administrator right.**
+Use this method to approve a chat join request.The bot **must be an administrator in the chat** for this to work and **must have the `can_invite_users` administrator right.**
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1390,9 +1307,7 @@ The bot **must be an administrator in the chat** for this to work and **must hav
 <a name="TelegramBot+declineChatJoinRequest"></a>
 
 ### telegramBot.declineChatJoinRequest(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to decline a chat join request.
-
-The bot **must be an administrator in the chat** for this to work and **must have the `can_invite_users` administrator right**.
+Use this method to decline a chat join request.The bot **must be an administrator in the chat** for this to work and **must have the `can_invite_users` administrator right**.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1407,9 +1322,7 @@ The bot **must be an administrator in the chat** for this to work and **must hav
 <a name="TelegramBot+setChatPhoto"></a>
 
 ### telegramBot.setChatPhoto(chatId, photo, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to set a new profile photo for the chat. **Photos can't be changed for private chats**.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
+Use this method to set a new profile photo for the chat. **Photos can't be changed for private chats**.The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1425,9 +1338,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+deleteChatPhoto"></a>
 
 ### telegramBot.deleteChatPhoto(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to delete a chat photo. **Photos can't be changed for private chats**.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
+Use this method to delete a chat photo. **Photos can't be changed for private chats**.The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1441,9 +1352,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+setChatTitle"></a>
 
 ### telegramBot.setChatTitle(chatId, title, [options]) ⇒ <code>Promise</code>
-Use this method to change the title of a chat. **Titles can't be changed for private chats**.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
+Use this method to change the title of a chat. **Titles can't be changed for private chats**.The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1458,9 +1367,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+setChatDescription"></a>
 
 ### telegramBot.setChatDescription(chatId, description, [options]) ⇒ <code>Promise</code>
-Use this method to change the description of a group, a supergroup or a channel.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
+Use this method to change the description of a group, a supergroup or a channel.The bot **must be an administrator in the chat** for this to work and must have the appropriate admin rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1475,10 +1382,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+pinChatMessage"></a>
 
 ### telegramBot.pinChatMessage(chatId, messageId, [options]) ⇒ <code>Promise</code>
-Use this method to pin a message in a supergroup.
-
-If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administrator
-right in a supergroup or `can_edit_messages` administrator right in a channel.
+Use this method to pin a message in a supergroup.If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administratorright in a supergroup or `can_edit_messages` administrator right in a channel.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1493,10 +1397,7 @@ right in a supergroup or `can_edit_messages` administrator right in a channel.
 <a name="TelegramBot+unpinChatMessage"></a>
 
 ### telegramBot.unpinChatMessage(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to remove a message from the list of pinned messages in a chat
-
-If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administrator
-right in a supergroup or `can_edit_messages` administrator right in a channel.
+Use this method to remove a message from the list of pinned messages in a chatIf the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administratorright in a supergroup or `can_edit_messages` administrator right in a channel.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1510,10 +1411,7 @@ right in a supergroup or `can_edit_messages` administrator right in a channel.
 <a name="TelegramBot+unpinAllChatMessages"></a>
 
 ### telegramBot.unpinAllChatMessages(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to clear the list of pinned messages in a chat.
-
-If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administrator
-right in a supergroup or `can_edit_messages` administrator right in a channel.
+Use this method to clear the list of pinned messages in a chat.If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administratorright in a supergroup or `can_edit_messages` administrator right in a channel.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1541,9 +1439,7 @@ Use this method for your bot to leave a group, supergroup or channel
 <a name="TelegramBot+getChat"></a>
 
 ### telegramBot.getChat(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to get up to date information about the chat
-(current name of the user for one-on-one conversations, current
-username of a user, group or channel, etc.).
+Use this method to get up to date information about the chat(current name of the user for one-on-one conversations, currentusername of a user, group or channel, etc.).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo) object on success  
@@ -1560,8 +1456,7 @@ username of a user, group or channel, etc.).
 Use this method to get a list of administrators in a chat
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
-**Returns**: <code>Promise</code> - On success, returns an Array of [ChatMember](https://core.telegram.org/bots/api#chatmember) objects that contains information about all chat administrators except other bots.
-If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned  
+**Returns**: <code>Promise</code> - On success, returns an Array of [ChatMember](https://core.telegram.org/bots/api#chatmember) objects that contains information about all chat administrators except other bots.If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned  
 **See**: https://core.telegram.org/bots/api#getchatadministrators  
 
 | Param | Type | Description |
@@ -1598,14 +1493,25 @@ Use this method to get information about a member of a chat.
 | userId | <code>Number</code> | Unique identifier of the target user |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
+<a name="TelegramBot+getUserPersonalChatMessages"></a>
+
+### telegramBot.getUserPersonalChatMessages(userId, limit, [options]) ⇒ <code>Promise</code>
+Use this method to get the last messages from the personal chat(i.e., the chat currently added to their profile) of a given user.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - On success, returns an Array of [Message](https://core.telegram.org/bots/api#message) objects  
+**See**: https://core.telegram.org/bots/api#getuserpersonalchatmessages  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>Number</code> | Unique identifier for the target user |
+| limit | <code>Number</code> | The maximum number of messages to return; 1-20 |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
 <a name="TelegramBot+setChatStickerSet"></a>
 
 ### telegramBot.setChatStickerSet(chatId, stickerSetName, [options]) ⇒ <code>Promise</code>
-Use this method to set a new group sticker set for a supergroup.
-
-The bot **must be an administrator in the chat** for this to work and must have the appropriate administrator rights.
-
-**Note:** Use the field `can_set_sticker_set` optionally returned in [getChat](https://core.telegram.org/bots/api#getchat) requests to check if the bot can use this method.
+Use this method to set a new group sticker set for a supergroup.The bot **must be an administrator in the chat** for this to work and must have the appropriate administrator rights.**Note:** Use the field `can_set_sticker_set` optionally returned in [getChat](https://core.telegram.org/bots/api#getchat) requests to check if the bot can use this method.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1620,9 +1526,7 @@ The bot **must be an administrator in the chat** for this to work and must have 
 <a name="TelegramBot+deleteChatStickerSet"></a>
 
 ### telegramBot.deleteChatStickerSet(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to delete a group sticker set from a supergroup.
-
-Use the field `can_set_sticker_set` optionally returned in [getChat](https://core.telegram.org/bots/api#getchat) requests to check if the bot can use this method.
+Use this method to delete a group sticker set from a supergroup.Use the field `can_set_sticker_set` optionally returned in [getChat](https://core.telegram.org/bots/api#getchat) requests to check if the bot can use this method.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1650,10 +1554,7 @@ Use this method to get custom emoji stickers, which can be used as a forum topic
 <a name="TelegramBot+createForumTopic"></a>
 
 ### telegramBot.createForumTopic(chatId, name, [options])
-Use this method to create a topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
-
-Returns information about the created topic as a [ForumTopic](https://core.telegram.org/bots/api#forumtopic) object.
+Use this method to create a topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.Returns information about the created topic as a [ForumTopic](https://core.telegram.org/bots/api#forumtopic) object.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **See**: https://core.telegram.org/bots/api#createforumtopic  
@@ -1667,8 +1568,7 @@ Returns information about the created topic as a [ForumTopic](https://core.teleg
 <a name="TelegramBot+editForumTopic"></a>
 
 ### telegramBot.editForumTopic(chatId, messageThreadId, [options]) ⇒ <code>Promise</code>
-Use this method to edit name and icon of a topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the topic.
+Use this method to edit name and icon of a topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the topic.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1683,8 +1583,7 @@ The bot must be an administrator in the chat for this to work and must have can_
 <a name="TelegramBot+closeForumTopic"></a>
 
 ### telegramBot.closeForumTopic(chatId, messageThreadId, [options]) ⇒ <code>Promise</code>
-Use this method to close an open topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+Use this method to close an open topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1699,8 +1598,7 @@ The bot must be an administrator in the chat for this to work and must have the 
 <a name="TelegramBot+reopenForumTopic"></a>
 
 ### telegramBot.reopenForumTopic(chatId, messageThreadId, [options]) ⇒ <code>Promise</code>
-Use this method to reopen a closed topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+Use this method to reopen a closed topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1715,8 +1613,7 @@ The bot must be an administrator in the chat for this to work and must have the 
 <a name="TelegramBot+deleteForumTopic"></a>
 
 ### telegramBot.deleteForumTopic(chatId, messageThreadId, [options]) ⇒ <code>Promise</code>
-Use this method to delete a forum topic along with all its messages in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights.
+Use this method to delete a forum topic along with all its messages in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1731,8 +1628,7 @@ The bot must be an administrator in the chat for this to work and must have the 
 <a name="TelegramBot+unpinAllForumTopicMessages"></a>
 
 ### telegramBot.unpinAllForumTopicMessages(chatId, messageThreadId, [options]) ⇒ <code>Promise</code>
-Use this method to clear the list of pinned messages in a forum topic.
-The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+Use this method to clear the list of pinned messages in a forum topic.The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1747,9 +1643,7 @@ The bot must be an administrator in the chat for this to work and must have the 
 <a name="TelegramBot+editGeneralForumTopic"></a>
 
 ### telegramBot.editGeneralForumTopic(chatId, name, [options]) ⇒ <code>Promise</code>
-Use this method to edit the name of the 'General' topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
-The topic will be automatically unhidden if it was hidden.
+Use this method to edit the name of the 'General' topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.The topic will be automatically unhidden if it was hidden.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1764,9 +1658,7 @@ The topic will be automatically unhidden if it was hidden.
 <a name="TelegramBot+closeGeneralForumTopic"></a>
 
 ### telegramBot.closeGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to close an open 'General' topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
-The topic will be automatically unhidden if it was hidden.
+Use this method to close an open 'General' topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.The topic will be automatically unhidden if it was hidden.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1780,9 +1672,7 @@ The topic will be automatically unhidden if it was hidden.
 <a name="TelegramBot+reopenGeneralForumTopic"></a>
 
 ### telegramBot.reopenGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to reopen a closed 'General' topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
-The topic will be automatically unhidden if it was hidden.
+Use this method to reopen a closed 'General' topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.The topic will be automatically unhidden if it was hidden.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1796,9 +1686,7 @@ The topic will be automatically unhidden if it was hidden.
 <a name="TelegramBot+hideGeneralForumTopic"></a>
 
 ### telegramBot.hideGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to hide the 'General' topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.
-The topic will be automatically closed if it was open.
+Use this method to hide the 'General' topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights.The topic will be automatically closed if it was open.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1812,8 +1700,7 @@ The topic will be automatically closed if it was open.
 <a name="TelegramBot+unhideGeneralForumTopic"></a>
 
 ### telegramBot.unhideGeneralForumTopic(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to unhide the 'General' topic in a forum supergroup chat.
-The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights
+Use this method to unhide the 'General' topic in a forum supergroup chat.The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1827,8 +1714,7 @@ The bot must be an administrator in the chat for this to work and must have the 
 <a name="TelegramBot+unpinAllGeneralForumTopicMessages"></a>
 
 ### telegramBot.unpinAllGeneralForumTopicMessages(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to clear the list of pinned messages in a General forum topic.
-The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+Use this method to clear the list of pinned messages in a General forum topic.The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1842,13 +1728,7 @@ The bot must be an administrator in the chat for this to work and must have the 
 <a name="TelegramBot+answerCallbackQuery"></a>
 
 ### telegramBot.answerCallbackQuery(callbackQueryId, [options]) ⇒ <code>Promise</code>
-Use this method to send answers to callback queries sent from
-[inline keyboards](https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating).
-
-The answer will be displayed to the user as a notification at the top of the chat screen or as an alert.
-
-This method has **older, compatible signatures ([1][answerCallbackQuery-v0.27.1])([2][answerCallbackQuery-v0.29.0])**
-that are being deprecated.
+Use this method to send answers to callback queries sent from[inline keyboards](https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating).The answer will be displayed to the user as a notification at the top of the chat screen or as an alert.This method has **older, compatible signatures ([1][answerCallbackQuery-v0.27.1])([2][answerCallbackQuery-v0.29.0])**that are being deprecated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1857,6 +1737,21 @@ that are being deprecated.
 | Param | Type | Description |
 | --- | --- | --- |
 | callbackQueryId | <code>String</code> | Unique identifier for the query to be answered |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+answerGuestQuery"></a>
+
+### telegramBot.answerGuestQuery(guestQueryId, result, [options]) ⇒ <code>Promise</code>
+Use this method to reply to a received guest message.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - On success, a [SentGuestMessage](https://core.telegram.org/bots/api#sentguestmessage) object is returned  
+**See**: https://core.telegram.org/bots/api#answerguestquery  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| guestQueryId | <code>String</code> | Unique identifier for the query to be answered |
+| result | <code>Object</code> | A JSON-serialized object describing the message to be sent ([InlineQueryResult](https://core.telegram.org/bots/api#inlinequeryresult)) |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+savePreparedInlineMessage"></a>
@@ -1892,8 +1787,7 @@ Use this method to stores a message that can be sent by a user of a Mini App.
 <a name="TelegramBot+getUserChatBoosts"></a>
 
 ### telegramBot.getUserChatBoosts(chatId, userId, [options]) ⇒ <code>Promise</code>
-Use this method to get the list of boosts added to a chat by a use.
-Requires administrator rights in the chat
+Use this method to get the list of boosts added to a chat by a use.Requires administrator rights in the chat
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns a [UserChatBoosts](https://core.telegram.org/bots/api#userchatboosts) object  
@@ -1947,12 +1841,40 @@ Use this method to revoke the current token of a managed bot and generate a new 
 | userId | <code>Number</code> \| <code>String</code> | User identifier of the managed bot whose token will be replaced |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
+<a name="TelegramBot+getManagedBotAccessSettings"></a>
+
+### telegramBot.getManagedBotAccessSettings(userId, [options]) ⇒ <code>Promise</code>
+Use this method to get the access settings of a managed bot.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise</code> - On success, returns a [BotAccessSettings](https://core.telegram.org/bots/api#botaccesssettings) object  
+**See**: https://core.telegram.org/bots/api#getmanagedbotaccesssettings  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>Number</code> | User identifier of the managed bot whose access settings will be returned |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+setManagedBotAccessSettings"></a>
+
+### telegramBot.setManagedBotAccessSettings(userId, isAccessRestricted, [options]) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+Use this method to change the access settings of a managed bot.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
+**Returns**: <code>Promise.&lt;Boolean&gt;</code> - True on success  
+**See**: https://core.telegram.org/bots/api#setmanagedbotaccesssettings  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>Number</code> | User identifier of the managed bot whose access settings will be changed |
+| isAccessRestricted | <code>Boolean</code> | Pass `True`, if only selected users can access the bot. The bot's owner can always access it. |
+| [options] | <code>Object</code> | Additional Telegram query options |
+| [options.added_user_ids] | <code>Array.&lt;Number&gt;</code> | A JSON-serialized list of up to 10 identifiers of users who will have access to the bot   in addition to its owner. Ignored if `is_access_restricted` is `false`. |
+
 <a name="TelegramBot+setMyCommands"></a>
 
 ### telegramBot.setMyCommands(commands, [options]) ⇒ <code>Promise</code>
-Use this method to change the list of the bot's commands.
-
-See https://core.telegram.org/bots#commands for more details about bot commands
+Use this method to change the list of the bot's commands.See https://core.telegram.org/bots#commands for more details about bot commands
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -1966,9 +1888,7 @@ See https://core.telegram.org/bots#commands for more details about bot commands
 <a name="TelegramBot+deleteMyCommands"></a>
 
 ### telegramBot.deleteMyCommands([options]) ⇒ <code>Promise</code>
-Use this method to delete the list of the bot's commands for the given scope and user language.
-
- After deletion, [higher level commands](https://core.telegram.org/bots/api#determining-list-of-commands) will be shown to affected users.
+Use this method to delete the list of the bot's commands for the given scope and user language. After deletion, [higher level commands](https://core.telegram.org/bots/api#determining-list-of-commands) will be shown to affected users.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2020,9 +1940,7 @@ Use this method to get the current bot name for the given user language.
 <a name="TelegramBot+setMyDescription"></a>
 
 ### telegramBot.setMyDescription([options]) ⇒ <code>Promise</code>
-Use this method to change the bot's description, which is shown in the chat with the bot if the chat is empty.
-
-Returns True on success.
+Use this method to change the bot's description, which is shown in the chat with the bot if the chat is empty.Returns True on success.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2048,8 +1966,7 @@ Use this method to get the current bot description for the given user language.
 <a name="TelegramBot+setMyShortDescription"></a>
 
 ### telegramBot.setMyShortDescription([options]) ⇒ <code>Promise</code>
-Use this method to change the bot's short description, which is shown on the bot's profile page
-and is sent together with the link when users share the bot.
+Use this method to change the bot's short description, which is shown on the bot's profile pageand is sent together with the link when users share the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - Returns True on success.  
@@ -2128,9 +2045,7 @@ Use this method to get the current value of the bot's menu button in a private c
 <a name="TelegramBot+setMyDefaultAdministratorRights"></a>
 
 ### telegramBot.setMyDefaultAdministratorRights([options]) ⇒ <code>Promise</code>
-Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels.
-
-These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels.These rights will be suggested to users, but they are are free to modify the list before adding the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2156,9 +2071,7 @@ Use this method to get the current default administrator rights of the bot.
 <a name="TelegramBot+editMessageText"></a>
 
 ### telegramBot.editMessageText(text, [options]) ⇒ <code>Promise</code>
-Use this method to edit text or [game](https://core.telegram.org/bots/api#games) messages sent by the bot or via the bot (for inline bots).
-
-Note: that **you must provide one of chat_id, message_id, or inline_message_id** in your request.
+Use this method to edit text or [game](https://core.telegram.org/bots/api#games) messages sent by the bot or via the bot (for inline bots).Note: that **you must provide one of chat_id, message_id, or inline_message_id** in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, if the edited message is not an inline message, the edited [Message](https://core.telegram.org/bots/api#message) is returned, otherwise True is returned  
@@ -2172,9 +2085,7 @@ Note: that **you must provide one of chat_id, message_id, or inline_message_id**
 <a name="TelegramBot+editMessageCaption"></a>
 
 ### telegramBot.editMessageCaption(caption, [options]) ⇒ <code>Promise</code>
-Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
-
-Note: You **must provide one of chat_id, message_id, or inline_message_id** in your request.
+Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).Note: You **must provide one of chat_id, message_id, or inline_message_id** in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, if the edited message is not an inline message, the edited [Message](https://core.telegram.org/bots/api#message) is returned, otherwise True is returned  
@@ -2188,14 +2099,7 @@ Note: You **must provide one of chat_id, message_id, or inline_message_id** in y
 <a name="TelegramBot+editMessageMedia"></a>
 
 ### telegramBot.editMessageMedia(media, [options]) ⇒ <code>Promise</code>
-Use this method to edit animation, audio, document, photo, or video messages.
-
-If a message is a part of a message album, then it can be edited only to a photo or a video.
-
-Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded.
-Use previously uploaded file via its file_id or specify a URL.
-
-Note: You **must provide one of chat_id, message_id, or inline_message_id** in your request.
+Use this method to edit animation, audio, document, photo, or video messages.If a message is a part of a message album, then it can be edited only to a photo or a video.Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded.Use previously uploaded file via its file_id or specify a URL.Note: You **must provide one of chat_id, message_id, or inline_message_id** in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, if the edited message is not an inline message, the edited [Message](https://core.telegram.org/bots/api#message) is returned, otherwise True is returned  
@@ -2226,9 +2130,7 @@ Use this method to edit a checklist on behalf of a business connection.
 <a name="TelegramBot+editMessageReplyMarkup"></a>
 
 ### telegramBot.editMessageReplyMarkup(replyMarkup, [options]) ⇒ <code>Promise</code>
-Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
-
-Note: You **must provide one of chat_id, message_id, or inline_message_id** in your request.
+Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).Note: You **must provide one of chat_id, message_id, or inline_message_id** in your request.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, if the edited message is not an inline message, the edited [Message](https://core.telegram.org/bots/api#message) is returned, otherwise True is returned  
@@ -2257,9 +2159,7 @@ Use this method to stop a poll which was sent by the bot.
 <a name="TelegramBot+approveSuggestedPost"></a>
 
 ### telegramBot.approveSuggestedPost(chatId, messageId, [options]) ⇒ <code>Promise</code>
-Use this method to approve a suggested post in a direct messages chat.
-
-The bot must have the 'can_post_messages' administrator right in the corresponding channel chat.
+Use this method to approve a suggested post in a direct messages chat.The bot must have the 'can_post_messages' administrator right in the corresponding channel chat.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - on success, returns True  
@@ -2274,9 +2174,7 @@ The bot must have the 'can_post_messages' administrator right in the correspondi
 <a name="TelegramBot+declineSuggestedPost"></a>
 
 ### telegramBot.declineSuggestedPost(chatId, messageId, [options]) ⇒ <code>Promise</code>
-Use this method to decline a suggested post in a direct messages chat.
-
-The bot must have the 'can_manage_direct_messages' administrator right in the corresponding channel chat.
+Use this method to decline a suggested post in a direct messages chat.The bot must have the 'can_manage_direct_messages' administrator right in the corresponding channel chat.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - on success, returns True  
@@ -2291,8 +2189,7 @@ The bot must have the 'can_manage_direct_messages' administrator right in the co
 <a name="TelegramBot+sendSticker"></a>
 
 ### telegramBot.sendSticker(chatId, sticker, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to send static .WEBP, [animated](https://telegram.org/blog/animated-stickers) .TGS,
-or [video](https://telegram.org/blog/video-stickers-better-reactions) .WEBM stickers.
+Use this method to send static .WEBP, [animated](https://telegram.org/blog/animated-stickers) .TGS,or [video](https://telegram.org/blog/video-stickers-better-reactions) .WEBM stickers.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned  
@@ -2336,8 +2233,7 @@ Use this method to get information about custom emoji stickers by their identifi
 <a name="TelegramBot+uploadStickerFile"></a>
 
 ### telegramBot.uploadStickerFile(userId, sticker, stickerFormat, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to upload a file with a sticker for later use in *createNewStickerSet* and *addStickerToSet* methods (can be used multiple
-times).
+Use this method to upload a file with a sticker for later use in *createNewStickerSet* and *addStickerToSet* methods (can be used multipletimes).
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, a [File](https://core.telegram.org/bots/api#file) object is returned  
@@ -2354,11 +2250,7 @@ times).
 <a name="TelegramBot+createNewStickerSet"></a>
 
 ### telegramBot.createNewStickerSet(userId, name, title, pngSticker, emojis, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to create new sticker set owned by a user.
-
-The bot will be able to edit the created sticker set.
-
-You must use exactly one of the fields *png_sticker*, *tgs_sticker*, or *webm_sticker*
+Use this method to create new sticker set owned by a user.The bot will be able to edit the created sticker set.You must use exactly one of the fields *png_sticker*, *tgs_sticker*, or *webm_sticker*
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2377,15 +2269,7 @@ You must use exactly one of the fields *png_sticker*, *tgs_sticker*, or *webm_st
 <a name="TelegramBot+addStickerToSet"></a>
 
 ### telegramBot.addStickerToSet(userId, name, sticker, emojis, stickerType, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to add a new sticker to a set created by the bot.
-
-You must use exactly one of the fields *png_sticker*, *tgs_sticker*, or *webm_sticker*
-
-Animated stickers can be added to animated sticker sets and only to them
-
-Note:
-- Emoji sticker sets can have up to 200 sticker
-- Static or Animated sticker sets can have up to 120 stickers
+Use this method to add a new sticker to a set created by the bot.You must use exactly one of the fields *png_sticker*, *tgs_sticker*, or *webm_sticker*Animated stickers can be added to animated sticker sets and only to themNote:- Emoji sticker sets can have up to 200 sticker- Static or Animated sticker sets can have up to 120 stickers
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2457,9 +2341,7 @@ Use this method to replace an existing sticker in a sticker set with a new one
 <a name="TelegramBot+setStickerEmojiList"></a>
 
 ### telegramBot.setStickerEmojiList(sticker, emojiList, [options]) ⇒ <code>Promise</code>
-Use this method to change the list of emoji assigned to a regular or custom emoji sticker.
-
-The sticker must belong to a sticker set created by the bot.
+Use this method to change the list of emoji assigned to a regular or custom emoji sticker.The sticker must belong to a sticker set created by the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2474,9 +2356,7 @@ The sticker must belong to a sticker set created by the bot.
 <a name="TelegramBot+setStickerKeywords"></a>
 
 ### telegramBot.setStickerKeywords(sticker, [options]) ⇒ <code>Promise</code>
-Use this method to change the list of emoji assigned to a `regular` or `custom emoji` sticker.
-
-The sticker must belong to a sticker set created by the bot.
+Use this method to change the list of emoji assigned to a `regular` or `custom emoji` sticker.The sticker must belong to a sticker set created by the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2490,9 +2370,7 @@ The sticker must belong to a sticker set created by the bot.
 <a name="TelegramBot+setStickerMaskPosition"></a>
 
 ### telegramBot.setStickerMaskPosition(sticker, [options]) ⇒ <code>Promise</code>
-Use this method to change the [mask position](https://core.telegram.org/bots/api#maskposition) of a mask sticker.
-
-The sticker must belong to a sticker set created by the bot.
+Use this method to change the [mask position](https://core.telegram.org/bots/api#maskposition) of a mask sticker.The sticker must belong to a sticker set created by the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2506,9 +2384,7 @@ The sticker must belong to a sticker set created by the bot.
 <a name="TelegramBot+setStickerSetTitle"></a>
 
 ### telegramBot.setStickerSetTitle(name, title, [options]) ⇒ <code>Promise</code>
-Use this method to set the title of a created sticker set.
-
-The sticker must belong to a sticker set created by the bot.
+Use this method to set the title of a created sticker set.The sticker must belong to a sticker set created by the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2523,9 +2399,7 @@ The sticker must belong to a sticker set created by the bot.
 <a name="TelegramBot+setStickerSetThumbnail"></a>
 
 ### telegramBot.setStickerSetThumbnail(userId, name, thumbnail, [options], [fileOptions]) ⇒ <code>Promise</code>
-Use this method to add a thumb to a set created by the bot.
-
-Animated thumbnails can be set for animated sticker sets only. Video thumbnails can be set only for video sticker sets only
+Use this method to add a thumb to a set created by the bot.Animated thumbnails can be set for animated sticker sets only. Video thumbnails can be set only for video sticker sets only
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2542,9 +2416,7 @@ Animated thumbnails can be set for animated sticker sets only. Video thumbnails 
 <a name="TelegramBot+setCustomEmojiStickerSetThumbnail"></a>
 
 ### telegramBot.setCustomEmojiStickerSetThumbnail(name, [options]) ⇒ <code>Promise</code>
-Use this method to set the thumbnail of a custom emoji sticker set.
-
-The sticker must belong to a sticker set created by the bot.
+Use this method to set the thumbnail of a custom emoji sticker set.The sticker must belong to a sticker set created by the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2558,9 +2430,7 @@ The sticker must belong to a sticker set created by the bot.
 <a name="TelegramBot+deleteStickerSet"></a>
 
 ### telegramBot.deleteStickerSet(name, [options]) ⇒ <code>Promise</code>
-Use this method to delete a sticker set that was created by the bot.
-
-The sticker must belong to a sticker set created by the bot.
+Use this method to delete a sticker set that was created by the bot.The sticker must belong to a sticker set created by the bot.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2574,9 +2444,7 @@ The sticker must belong to a sticker set created by the bot.
 <a name="TelegramBot+answerInlineQuery"></a>
 
 ### telegramBot.answerInlineQuery(inlineQueryId, results, [options]) ⇒ <code>Promise</code>
-Send answers to an inline query.
-
-Note: No more than 50 results per query are allowed.
+Send answers to an inline query.Note: No more than 50 results per query are allowed.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, True is returned  
@@ -2591,8 +2459,7 @@ Note: No more than 50 results per query are allowed.
 <a name="TelegramBot+answerWebAppQuery"></a>
 
 ### telegramBot.answerWebAppQuery(webAppQueryId, result, [options]) ⇒ <code>Promise</code>
-Use this method to set the result of an interaction with a [Web App](https://core.telegram.org/bots/webapps)
-and send a corresponding message on behalf of the user to the chat from which the query originated.
+Use this method to set the result of an interaction with a [Web App](https://core.telegram.org/bots/webapps)and send a corresponding message on behalf of the user to the chat from which the query originated.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, a [SentWebAppMessage](https://core.telegram.org/bots/api#sentwebappmessage) object is returned  
@@ -2646,10 +2513,7 @@ Use this method to create a link for an invoice.
 <a name="TelegramBot+answerShippingQuery"></a>
 
 ### telegramBot.answerShippingQuery(shippingQueryId, ok, [options]) ⇒ <code>Promise</code>
-Use this method to reply to shipping queries.
-
-If you sent an invoice requesting a shipping address and the parameter is_flexible was specified,
-the Bot API will send an [Update](https://core.telegram.org/bots/api#update) with a shipping_query field to the bot
+Use this method to reply to shipping queries.If you sent an invoice requesting a shipping address and the parameter is_flexible was specified,the Bot API will send an [Update](https://core.telegram.org/bots/api#update) with a shipping_query field to the bot
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, True is returned  
@@ -2664,12 +2528,7 @@ the Bot API will send an [Update](https://core.telegram.org/bots/api#update) wit
 <a name="TelegramBot+answerPreCheckoutQuery"></a>
 
 ### telegramBot.answerPreCheckoutQuery(preCheckoutQueryId, ok, [options]) ⇒ <code>Promise</code>
-Use this method to respond to such pre-checkout queries
-
-Once the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form of
-an [Update](https://core.telegram.org/bots/api#update) with the field *pre_checkout_query*.
-
-**Note:** The Bot API must receive an answer within 10 seconds after the pre-checkout query was sent.
+Use this method to respond to such pre-checkout queriesOnce the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form ofan [Update](https://core.telegram.org/bots/api#update) with the field *pre_checkout_query*.**Note:** The Bot API must receive an answer within 10 seconds after the pre-checkout query was sent.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, True is returned  
@@ -2771,9 +2630,7 @@ Use this method to set the score of the specified user in a game message.
 <a name="TelegramBot+getGameHighScores"></a>
 
 ### telegramBot.getGameHighScores(userId, [options]) ⇒ <code>Promise</code>
-Use this method to get data for high score tables.
-
-Will return the score of the specified user and several of their neighbors in a game.
+Use this method to get data for high score tables.Will return the score of the specified user and several of their neighbors in a game.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns an Array of [GameHighScore](https://core.telegram.org/bots/api#gamehighscore) objects  
@@ -2787,14 +2644,7 @@ Will return the score of the specified user and several of their neighbors in a 
 <a name="TelegramBot+deleteMessage"></a>
 
 ### telegramBot.deleteMessage(chatId, messageId, [options]) ⇒ <code>Promise</code>
-Use this method to delete a message, including service messages, with the following limitations:
-- A message can only be deleted if it was sent less than 48 hours ago.
-- A dice message can only be deleted if it was sent more than 24 hours ago.
-- Bots can delete outgoing messages in groups and supergroups.
-- Bots can delete incoming messages in groups, supergroups and channels.
-- Bots granted `can_post_messages` permissions can delete outgoing messages in channels.
-- If the bot is an administrator of a group, it can delete any message there.
-- If the bot has `can_delete_messages` permission in a supergroup, it can delete any message there.
+Use this method to delete a message, including service messages, with the following limitations:- A message can only be deleted if it was sent less than 48 hours ago.- A dice message can only be deleted if it was sent more than 24 hours ago.- Bots can delete outgoing messages in groups and supergroups.- Bots can delete incoming messages in groups, supergroups and channels.- Bots granted `can_post_messages` permissions can delete outgoing messages in channels.- If the bot is an administrator of a group, it can delete any message there.- If the bot has `can_delete_messages` permission in a supergroup, it can delete any message there.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - True on success  
@@ -2923,9 +2773,7 @@ This method removes verification from a chat who is currently verified [on behal
 <a name="TelegramBot+readBusinessMessage"></a>
 
 ### telegramBot.readBusinessMessage(businessConnectionId, chatId, messageId, [options]) ⇒ <code>Promise</code>
-This method marks incoming message as read on behalf of a business account.
-
-Requires the **can_read_messages** business bot right
+This method marks incoming message as read on behalf of a business account.Requires the **can_read_messages** business bot right
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -2941,9 +2789,7 @@ Requires the **can_read_messages** business bot right
 <a name="TelegramBot+deleteBusinessMessages"></a>
 
 ### telegramBot.deleteBusinessMessages(businessConnectionId, messageIds, [options]) ⇒ <code>Promise</code>
-This method delete messages on behalf of a business account.
-
-Requires the **can_delete_outgoing_messages** business bot right to delete messages sent by the bot itself, or the **can_delete_all_messages business** bot right to delete any message.
+This method delete messages on behalf of a business account.Requires the **can_delete_outgoing_messages** business bot right to delete messages sent by the bot itself, or the **can_delete_all_messages business** bot right to delete any message.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -2958,9 +2804,7 @@ Requires the **can_delete_outgoing_messages** business bot right to delete messa
 <a name="TelegramBot+setBusinessAccountName"></a>
 
 ### telegramBot.setBusinessAccountName(businessConnectionId, firstName, [options]) ⇒ <code>Promise</code>
-This method changes the first and last name of a managed business account.
-
-Requires the **can_change_name** business bot right.
+This method changes the first and last name of a managed business account.Requires the **can_change_name** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -2975,9 +2819,7 @@ Requires the **can_change_name** business bot right.
 <a name="TelegramBot+setBusinessAccountUsername"></a>
 
 ### telegramBot.setBusinessAccountUsername(businessConnectionId, [options]) ⇒ <code>Promise</code>
-This method changes the username of a managed business account.
-
-Requires the **can_change_username** business bot right.
+This method changes the username of a managed business account.Requires the **can_change_username** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -2991,9 +2833,7 @@ Requires the **can_change_username** business bot right.
 <a name="TelegramBot+setBusinessAccountBio"></a>
 
 ### telegramBot.setBusinessAccountBio(businessConnectionId, [options]) ⇒ <code>Promise</code>
-This method changes the bio of a managed business account.
-
-Requires the **can_change_bio** business bot right.
+This method changes the bio of a managed business account.Requires the **can_change_bio** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -3007,9 +2847,7 @@ Requires the **can_change_bio** business bot right.
 <a name="TelegramBot+setBusinessAccountProfilePhoto"></a>
 
 ### telegramBot.setBusinessAccountProfilePhoto(businessConnectionId, photo, [options]) ⇒ <code>Promise</code>
-This method changes the profile photo of a managed business account.
-
-Requires the **can_edit_profile_photo** business bot right.
+This method changes the profile photo of a managed business account.Requires the **can_edit_profile_photo** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -3024,9 +2862,7 @@ Requires the **can_edit_profile_photo** business bot right.
 <a name="TelegramBot+removeBusinessAccountProfilePhoto"></a>
 
 ### telegramBot.removeBusinessAccountProfilePhoto(businessConnectionId, [options]) ⇒ <code>Promise</code>
-This method removes the current profile photo of a managed business account.
-
-Requires the **can_edit_profile_photo** business bot right.
+This method removes the current profile photo of a managed business account.Requires the **can_edit_profile_photo** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -3040,9 +2876,7 @@ Requires the **can_edit_profile_photo** business bot right.
 <a name="TelegramBot+setBusinessAccountGiftSettings"></a>
 
 ### telegramBot.setBusinessAccountGiftSettings(businessConnectionId, showGiftButton, acceptedGiftTypes, [options]) ⇒ <code>Promise</code>
-This method changes the privacy settings pertaining to incoming gifts in a managed business account.
-
-Requires the **can_change_gift_settings** business bot right.
+This method changes the privacy settings pertaining to incoming gifts in a managed business account.Requires the **can_change_gift_settings** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns true.  
@@ -3058,9 +2892,7 @@ Requires the **can_change_gift_settings** business bot right.
 <a name="TelegramBot+getBusinessAccountStarBalance"></a>
 
 ### telegramBot.getBusinessAccountStarBalance(businessConnectionId, [options]) ⇒ <code>Promise</code>
-This method returns the amount of Telegram Stars owned by a managed business account.
-
-Requires the **can_view_gifts_and_stars** business bot right.
+This method returns the amount of Telegram Stars owned by a managed business account.Requires the **can_view_gifts_and_stars** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns [StarAmount](https://core.telegram.org/bots/api#staramount).  
@@ -3074,9 +2906,7 @@ Requires the **can_view_gifts_and_stars** business bot right.
 <a name="TelegramBot+transferBusinessAccountStars"></a>
 
 ### telegramBot.transferBusinessAccountStars(businessConnectionId, starCount, [options]) ⇒ <code>Promise</code>
-This method transfers Telegram Stars from the business account balance to the bot's balance.
-
-Requires the **can_transfer_stars** business bot right.
+This method transfers Telegram Stars from the business account balance to the bot's balance.Requires the **can_transfer_stars** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns True.  
@@ -3091,9 +2921,7 @@ Requires the **can_transfer_stars** business bot right.
 <a name="TelegramBot+getBusinessAccountGifts"></a>
 
 ### telegramBot.getBusinessAccountGifts(businessConnectionId, [options]) ⇒ <code>Promise</code>
-This method returns the gifts received and owned by a managed business account.
-
-Requires the **can_view_gifts_and_stars** business bot right.
+This method returns the gifts received and owned by a managed business account.Requires the **can_view_gifts_and_stars** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns [OwnedGifts](https://core.telegram.org/bots/api#ownedgifts).  
@@ -3121,9 +2949,7 @@ Use this method to get gifts owned by a regular user.
 <a name="TelegramBot+getChatGifts"></a>
 
 ### telegramBot.getChatGifts(chatId, [options]) ⇒ <code>Promise</code>
-Use this method to get gifts received by a channel chat or a business account managed by the bot.
-
-Requires the **can_view_gifts_and_stars** administrator right if the chat is a channel.
+Use this method to get gifts received by a channel chat or a business account managed by the bot.Requires the **can_view_gifts_and_stars** administrator right if the chat is a channel.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns an [OwnedGifts](https://core.telegram.org/bots/api#ownedgifts) object.  
@@ -3137,9 +2963,7 @@ Requires the **can_view_gifts_and_stars** administrator right if the chat is a c
 <a name="TelegramBot+convertGiftToStars"></a>
 
 ### telegramBot.convertGiftToStars(businessConnectionId, ownedGiftId, [options]) ⇒ <code>Promise</code>
-This method converts a given regular gift to Telegram Stars.
-
-Requires the **can_convert_gifts_to_stars** business bot right.
+This method converts a given regular gift to Telegram Stars.Requires the **can_convert_gifts_to_stars** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns True.  
@@ -3154,10 +2978,7 @@ Requires the **can_convert_gifts_to_stars** business bot right.
 <a name="TelegramBot+upgradeGift"></a>
 
 ### telegramBot.upgradeGift(businessConnectionId, ownedGiftId, [options]) ⇒ <code>Promise</code>
-This method upgrades a given regular gift to a unique gift.
-
-Requires the **can_transfer_and_upgrade_gifts** business bot right.
-Additionally requires the **can_transfer_stars** business bot right **if the upgrade is paid**.
+This method upgrades a given regular gift to a unique gift.Requires the **can_transfer_and_upgrade_gifts** business bot right.Additionally requires the **can_transfer_stars** business bot right **if the upgrade is paid**.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns True.  
@@ -3172,10 +2993,7 @@ Additionally requires the **can_transfer_stars** business bot right **if the upg
 <a name="TelegramBot+transferGift"></a>
 
 ### telegramBot.transferGift(businessConnectionId, ownedGiftId, newOwnerChatId, [options]) ⇒ <code>Promise</code>
-This method transfers an owned unique gift to another user.
-
-Requires the **can_transfer_and_upgrade_gifts** business bot right.
-Additionally requires the **can_transfer_stars** business bot right **if the transfer is paid**.
+This method transfers an owned unique gift to another user.Requires the **can_transfer_and_upgrade_gifts** business bot right.Additionally requires the **can_transfer_stars** business bot right **if the transfer is paid**.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns True.  
@@ -3191,9 +3009,7 @@ Additionally requires the **can_transfer_stars** business bot right **if the tra
 <a name="TelegramBot+postStory"></a>
 
 ### telegramBot.postStory(businessConnectionId, content, activePeriod, [options]) ⇒ <code>Promise</code>
-This method posts a story on behalf of a managed business account.
-
-Requires the **can_manage_stories** business bot right.
+This method posts a story on behalf of a managed business account.Requires the **can_manage_stories** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns [Story](https://core.telegram.org/bots/api#story).  
@@ -3209,10 +3025,7 @@ Requires the **can_manage_stories** business bot right.
 <a name="TelegramBot+repostStory"></a>
 
 ### telegramBot.repostStory(businessConnectionId, fromChatId, fromStoryId, activePeriod, [options]) ⇒ <code>Promise</code>
-This method reposts a story on behalf of a managed business account.
-
-Requires the **can_manage_stories** business bot right for both the source and destination accounts.
-The story must have been originally posted or reposted by the bot itself.
+This method reposts a story on behalf of a managed business account.Requires the **can_manage_stories** business bot right for both the source and destination accounts.The story must have been originally posted or reposted by the bot itself.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns a [Story](https://core.telegram.org/bots/api#story) object.  
@@ -3229,9 +3042,7 @@ The story must have been originally posted or reposted by the bot itself.
 <a name="TelegramBot+editStory"></a>
 
 ### telegramBot.editStory(businessConnectionId, storyId, content, [options]) ⇒ <code>Promise</code>
-This method edits a story previously posted by the bot on behalf of a managed business account.
-
-Requires the **can_manage_stories** business bot right.
+This method edits a story previously posted by the bot on behalf of a managed business account.Requires the **can_manage_stories** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns [Story](https://core.telegram.org/bots/api#story).  
@@ -3247,9 +3058,7 @@ Requires the **can_manage_stories** business bot right.
 <a name="TelegramBot+deleteStory"></a>
 
 ### telegramBot.deleteStory(businessConnectionId, storyId, [options]) ⇒ <code>Promise</code>
-This method deletes a story previously posted by the bot on behalf of a managed business account.
-
-Requires the **can_manage_stories** business bot right.
+This method deletes a story previously posted by the bot on behalf of a managed business account.Requires the **can_manage_stories** business bot right.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)  
 **Returns**: <code>Promise</code> - On success, returns True.  

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1177,6 +1177,43 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Send live photo.
+   *
+   * A live photo is composed of a static photo and a short video. Both fields are required.
+   * Sending live photos by a URL is currently unsupported - use a `file_id` or upload the file via multipart/form-data.
+   *
+   * @param {Number|String} chatId Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
+   * @param {String|stream.Stream|Buffer} livePhoto Video of the live photo to send. Pass a `file_id` to send a video that exists on the Telegram servers,
+   *   or upload a new video using multipart/form-data. The video must be no longer than 10 seconds and must not exceed 10 MB in size.
+   * @param {String|stream.Stream|Buffer} photo The static photo to send. Pass a `file_id` to send a photo that exists on the Telegram servers,
+   *   or upload a new photo using multipart/form-data.
+   * @param {Object} [options] Additional Telegram query options
+   * @param {Object} [fileOptions] Optional file related meta-data (applied to uploaded files)
+   * @return {Promise} On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned
+   * @see https://core.telegram.org/bots/api#sendlivephoto
+   * @see https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files
+   */
+  sendLivePhoto(chatId, livePhoto, photo, options = {}, fileOptions = {}) {
+    const opts = {
+      qs: options,
+      formData: {},
+    };
+    opts.qs.chat_id = chatId;
+    try {
+      const liveData = this._formatSendData('live_photo', livePhoto, fileOptions);
+      if (liveData[0]) Object.assign(opts.formData, liveData[0]);
+      opts.qs.live_photo = liveData[1];
+
+      const photoData = this._formatSendData('photo', photo, fileOptions);
+      if (photoData[0]) Object.assign(opts.formData, photoData[0]);
+      opts.qs.photo = photoData[1];
+    } catch (ex) {
+      return Promise.reject(ex);
+    }
+    return this._request('sendLivePhoto', opts);
+  }
+
+  /**
   * Send audio
   *
   * **Your audio must be in the .MP3 or .M4A format.**
@@ -1653,6 +1690,39 @@ class TelegramBot extends EventEmitter {
       form.reaction = stringify(form.reaction);
     }
     return this._request('setMessageReaction', { form });
+  }
+
+  /**
+   * Use this method to remove a reaction from a message in a group or a supergroup chat.
+   *
+   * The bot **must have the `can_delete_messages` administrator right** in the chat.
+   *
+   * @param {Number|String} chatId Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`)
+   * @param {Number} messageId Identifier of the target message
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise<Boolean>} True on success
+   * @see https://core.telegram.org/bots/api#deletemessagereaction
+   */
+  deleteMessageReaction(chatId, messageId, form = {}) {
+    form.chat_id = chatId;
+    form.message_id = messageId;
+    return this._request('deleteMessageReaction', { form });
+  }
+
+  /**
+   * Use this method to remove up to 10000 recent reactions in a group or a supergroup chat
+   * added by a given user or chat.
+   *
+   * The bot **must have the `can_delete_messages` administrator right** in the chat.
+   *
+   * @param {Number|String} chatId Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`)
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise<Boolean>} True on success
+   * @see https://core.telegram.org/bots/api#deleteallmessagereactions
+   */
+  deleteAllMessageReactions(chatId, form = {}) {
+    form.chat_id = chatId;
+    return this._request('deleteAllMessageReactions', { form });
   }
 
   /**
@@ -2213,6 +2283,22 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Use this method to get the last messages from the personal chat
+   * (i.e., the chat currently added to their profile) of a given user.
+   *
+   * @param {Number} userId Unique identifier for the target user
+   * @param {Number} limit The maximum number of messages to return; 1-20
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise} On success, returns an Array of [Message](https://core.telegram.org/bots/api#message) objects
+   * @see https://core.telegram.org/bots/api#getuserpersonalchatmessages
+   */
+  getUserPersonalChatMessages(userId, limit, form = {}) {
+    form.user_id = userId;
+    form.limit = limit;
+    return this._request('getUserPersonalChatMessages', { form });
+  }
+
+  /**
    * Use this method to set a new group sticker set for a supergroup.
    *
    * The bot **must be an administrator in the chat** for this to work and must have the appropriate administrator rights.
@@ -2490,6 +2576,21 @@ class TelegramBot extends EventEmitter {
   }
 
   /**
+   * Use this method to reply to a received guest message.
+   *
+   * @param {String} guestQueryId Unique identifier for the query to be answered
+   * @param {Object} result A JSON-serialized object describing the message to be sent ([InlineQueryResult](https://core.telegram.org/bots/api#inlinequeryresult))
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise} On success, a [SentGuestMessage](https://core.telegram.org/bots/api#sentguestmessage) object is returned
+   * @see https://core.telegram.org/bots/api#answerguestquery
+   */
+  answerGuestQuery(guestQueryId, result, form = {}) {
+    form.guest_query_id = guestQueryId;
+    form.result = stringify(result);
+    return this._request('answerGuestQuery', { form });
+  }
+
+  /**
    * Use this method to stores a message that can be sent by a user of a Mini App.
    *
    * @param {Number} userId Unique identifier of the target user
@@ -2572,6 +2673,39 @@ class TelegramBot extends EventEmitter {
   replaceManagedBotToken(userId, form = {}) {
     form.user_id = userId;
     return this._request('replaceManagedBotToken', { form });
+  }
+
+  /**
+   * Use this method to get the access settings of a managed bot.
+   *
+   * @param {Number} userId User identifier of the managed bot whose access settings will be returned
+   * @param {Object} [options] Additional Telegram query options
+   * @return {Promise} On success, returns a [BotAccessSettings](https://core.telegram.org/bots/api#botaccesssettings) object
+   * @see https://core.telegram.org/bots/api#getmanagedbotaccesssettings
+   */
+  getManagedBotAccessSettings(userId, form = {}) {
+    form.user_id = userId;
+    return this._request('getManagedBotAccessSettings', { form });
+  }
+
+  /**
+   * Use this method to change the access settings of a managed bot.
+   *
+   * @param {Number} userId User identifier of the managed bot whose access settings will be changed
+   * @param {Boolean} isAccessRestricted Pass `True`, if only selected users can access the bot. The bot's owner can always access it.
+   * @param {Object} [options] Additional Telegram query options
+   * @param {Array<Number>} [options.added_user_ids] A JSON-serialized list of up to 10 identifiers of users who will have access to the bot
+   *   in addition to its owner. Ignored if `is_access_restricted` is `false`.
+   * @return {Promise<Boolean>} True on success
+   * @see https://core.telegram.org/bots/api#setmanagedbotaccesssettings
+   */
+  setManagedBotAccessSettings(userId, isAccessRestricted, form = {}) {
+    form.user_id = userId;
+    form.is_access_restricted = isAccessRestricted;
+    if (form.added_user_ids) {
+      form.added_user_ids = stringify(form.added_user_ids);
+    }
+    return this._request('setManagedBotAccessSettings', { form });
   }
 
   /**

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1577,7 +1577,7 @@ class TelegramBot extends EventEmitter {
    *
    * @param {Number|String} chatId  Unique identifier for the group/channel
    * @param {String} question Poll question, 1-300 characters
-   * @param {Array} pollOptions Poll options, between 2-10 options (only 1-100 characters each)
+   * @param {Array} pollOptions Poll options, between 1-10 options (only 1-100 characters each)
    * @param {Object} [options] Additional Telegram query options
    * @return {Promise} On success, the sent [Message](https://core.telegram.org/bots/api#message) object is returned
    * @see https://core.telegram.org/bots/api#sendpoll

--- a/test/telegram.js
+++ b/test/telegram.js
@@ -1799,6 +1799,20 @@ describe('TelegramBot', function telegramSuite() {
 
   describe.skip('#declineSuggestedPost', function declineSuggestedPostSuite() { });
 
+  describe.skip('#answerGuestQuery', function answerGuestQuerySuite() { });
+
+  describe.skip('#deleteMessageReaction', function deleteMessageReactionSuite() { });
+
+  describe.skip('#deleteAllMessageReactions', function deleteAllMessageReactionsSuite() { });
+
+  describe.skip('#sendLivePhoto', function sendLivePhotoSuite() { });
+
+  describe.skip('#getManagedBotAccessSettings', function getManagedBotAccessSettingsSuite() { });
+
+  describe.skip('#setManagedBotAccessSettings', function setManagedBotAccessSettingsSuite() { });
+
+  describe.skip('#getUserPersonalChatMessages', function getUserPersonalChatMessagesSuite() { });
+
   describe('#deleteMessage', function deleteMessageSuite() {
     let messageId;
     before(function before() {


### PR DESCRIPTION
## Summary

Adds support for Telegram Bot API v10.0 (May 8, 2026).

### New methods

- `#answerGuestQuery` (Guest Mode)
- `#deleteMessageReaction`
- `#deleteAllMessageReactions`
- `#sendLivePhoto`
- `#getManagedBotAccessSettings`
- `#setManagedBotAccessSettings`
- `#getUserPersonalChatMessages`

### Other

- Bumps Bot API badge in README from v9.6 → v10.0
- Updates CHANGELOG under Unreleased
- Regenerates `doc/api.md` via `npm run doc`
- Adds skipped test stubs for the new methods, matching the existing convention used for similar methods that need a real Telegram environment

### Notes on type-only additions

Bot API 10.0 also introduces several new types that flow through the existing HTTP wrapper without needing dedicated code paths (`SentGuestMessage`, `LivePhoto`, `InputMediaLivePhoto`, `PaidMediaLivePhoto`, `InputPaidMediaLivePhoto`, `PollMedia`, `InputPollMedia`, `InputPollOptionMedia`, `BotAccessSettings`, `InputMediaSticker`, `InputMediaLocation`, `InputMediaVenue`). Existing methods like `sendPoll`, `sendMediaGroup`, `editMessageMedia`, and `getChatAdministrators` accept the new optional parameters via the existing `form` / `options` argument and pass them through.

### Tested

- `npm run eslint` passes
- `npm run build` (babel) passes
- `npm run doc` (jsdoc2md) regenerates cleanly
- All 7 new methods are present on `TelegramBot.prototype`
