### PR TITLE
1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
-## [1.0.0] — 2026-05-10
+## [1.0.0][1.0.0] - 2026-06-12
 
 ### Rewritten in TypeScript
 
@@ -721,4 +721,5 @@ Fixed:
 [0.66.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v0.66.0
 [0.67.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v0.67.0
 [0.68.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v0.68.0
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v0.68.0...master
+[1.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.0.0
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.0.0...master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-telegram-bot-api",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "description": "Telegram Bot API — modern TypeScript rewrite with generated types",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release 1.0.0 — promotes the `1.0.0-rc.0` TypeScript rewrite to a stable release.

## Changes
- Bump version `1.0.0-rc.0` → `1.0.0` (`package.json`, `package-lock.json`).
- Normalize the CHANGELOG `1.0.0` entry to match the repo's convention (`[1.0.0][1.0.0] - 2026-06-12` header + `[1.0.0]:` tag link-def) and set the release date to 2026-06-12; point the `[Unreleased]` compare link at `v1.0.0...master`.

## Verification
- `npm run typecheck` — clean
- `npm run test:bun:unit` — 91/91 pass
- `npm run build` — clean, `dist/` entrypoints present
- `npm run generate:docs` — no diff (`doc/api.md` already current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)