### PR TITLE
feat: Support Telegram Bot API v10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+## [1.1.0][1.1.0] - 2026-06-13
+
+### Bot API 10.1 (June 11, 2026)
+
+#### Rich Messages
+
+- Added the method `sendRichMessage(chatId, richMessage, form?)` → `Message`.
+- Added the method `sendRichMessageDraft(chatId, draftId, richMessage, form?)` → `boolean`.
+- Added the parameter `rich_message` to `editMessageText`, alongside a new
+  single-object overload:
+  ```ts
+  // New (preferred) — text or rich_message:
+  editMessageText({ chat_id, message_id, text: "…" })
+  editMessageText({ chat_id, message_id, rich_message: { … } })
+
+  // Old (deprecated, still works):
+  editMessageText("text", { chat_id, message_id })
+  ```
+- Added the type `InputRichMessage` (with `html` / `markdown` / `is_rtl` /
+  `skip_entity_detection` fields), which is JSON-serialized automatically.
+- Regenerated `src/types/schemas.ts` with all new RichMessage, RichText,
+  RichBlock, and related types.
+
+#### Join Request Queries
+
+- Added the method `answerChatJoinRequestQuery(queryId, result, form?)` → `boolean`.
+- Added the method `sendChatJoinRequestWebApp(queryId, webAppUrl, form?)` → `boolean`.
+- Added the fields `supports_join_request_queries` to `User`, `guard_bot` to
+  `ChatFullInfo`, and `query_id` to `ChatJoinRequest` (in the generated types).
+
+#### Polls
+
+- Added the types `Link` and `InputMediaLink` (generated).
+
 ## [1.0.0][1.0.0] - 2026-06-12
 
 ### Rewritten in TypeScript
@@ -722,4 +756,5 @@ Fixed:
 [0.67.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v0.67.0
 [0.68.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v0.68.0
 [1.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.0.0
+[1.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.0
 [Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.0.0...master

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node.js module to interact with the official [Telegram Bot API](https://core.telegram.org/bots/api).
 
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-v.9.6-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-v.10.1-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
 [![Coverage Status](https://img.shields.io/codecov/c/github/yagop/node-telegram-bot-api?style=flat-square&logo=codecov)](https://codecov.io/gh/yagop/node-telegram-bot-api)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -43,6 +43,7 @@
         * [.logOut([options])](#TelegramBot+logOut) ⇒ <code>Promise</code>
         * [.close([options])](#TelegramBot+close) ⇒ <code>Promise</code>
         * [.sendMessage(chatId, text, [options])](#TelegramBot+sendMessage) ⇒ <code>Promise</code>
+        * [.sendRichMessage(chatId, richMessage, [options])](#TelegramBot+sendRichMessage) ⇒ <code>Promise</code>
         * [.forwardMessage(chatId, fromChatId, messageId, [options])](#TelegramBot+forwardMessage) ⇒ <code>Promise</code>
         * [.forwardMessages(chatId, fromChatId, messageIds, [options])](#TelegramBot+forwardMessages) ⇒ <code>Promise</code>
         * [.copyMessage(chatId, fromChatId, messageId, [options])](#TelegramBot+copyMessage) ⇒ <code>Promise</code>
@@ -64,6 +65,7 @@
         * [.sendChecklist(businessConnectionId, chatId, checklist, [options])](#TelegramBot+sendChecklist) ⇒ <code>Promise</code>
         * [.sendDice(chatId, [options])](#TelegramBot+sendDice) ⇒ <code>Promise</code>
         * [.sendMessageDraft(chatId, draftId, text, [options])](#TelegramBot+sendMessageDraft) ⇒ <code>Promise</code>
+        * [.sendRichMessageDraft(chatId, draftId, richMessage, [options])](#TelegramBot+sendRichMessageDraft) ⇒ <code>Promise</code>
         * [.sendChatAction(chatId, action, [options])](#TelegramBot+sendChatAction) ⇒ <code>Promise</code>
         * [.setMessageReaction(chatId, messageId, [options])](#TelegramBot+setMessageReaction) ⇒ <code>Promise</code>
         * [.editMessageLiveLocation(latitude, longitude, [options])](#TelegramBot+editMessageLiveLocation) ⇒ <code>Promise</code>
@@ -90,6 +92,8 @@
         * [.revokeChatInviteLink(chatId, inviteLink, [options])](#TelegramBot+revokeChatInviteLink) ⇒ <code>Promise</code>
         * [.approveChatJoinRequest(chatId, userId, [options])](#TelegramBot+approveChatJoinRequest) ⇒ <code>Promise</code>
         * [.declineChatJoinRequest(chatId, userId, [options])](#TelegramBot+declineChatJoinRequest) ⇒ <code>Promise</code>
+        * [.answerChatJoinRequestQuery(chatJoinRequestQueryId, result, [options])](#TelegramBot+answerChatJoinRequestQuery) ⇒ <code>Promise</code>
+        * [.sendChatJoinRequestWebApp(chatJoinRequestQueryId, webAppUrl, [options])](#TelegramBot+sendChatJoinRequestWebApp) ⇒ <code>Promise</code>
         * [.setChatPhoto(chatId, photo, [options], [fileOptions])](#TelegramBot+setChatPhoto) ⇒ <code>Promise</code>
         * [.deleteChatPhoto(chatId, [options])](#TelegramBot+deleteChatPhoto) ⇒ <code>Promise</code>
         * [.setChatTitle(chatId, title, [options])](#TelegramBot+setChatTitle) ⇒ <code>Promise</code>
@@ -142,7 +146,7 @@
         * [.getChatMenuButton([options])](#TelegramBot+getChatMenuButton) ⇒ <code>Promise</code>
         * [.setMyDefaultAdministratorRights([options])](#TelegramBot+setMyDefaultAdministratorRights) ⇒ <code>Promise</code>
         * [.getMyDefaultAdministratorRights([options])](#TelegramBot+getMyDefaultAdministratorRights) ⇒ <code>Promise</code>
-        * [.editMessageText(text, [options])](#TelegramBot+editMessageText) ⇒ <code>Promise</code>
+        * [.editMessageText([textOrForm], [options])](#TelegramBot+editMessageText) ⇒ <code>Promise</code>
         * [.editMessageCaption(caption, [options])](#TelegramBot+editMessageCaption) ⇒ <code>Promise</code>
         * [.editMessageMedia(media, [options])](#TelegramBot+editMessageMedia) ⇒ <code>Promise</code>
         * [.editMessageChecklist(businessConnectionId, chatId, messageId, checklist, [options])](#TelegramBot+editMessageChecklist) ⇒ <code>Promise</code>
@@ -574,6 +578,22 @@ Download a Telegram file to a local directory and resolve to the resulting path.
 | text | <code>String</code> |  |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
+<a name="TelegramBot+sendRichMessage"></a>
+
+### telegramBot.sendRichMessage(chatId, richMessage, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#sendrichmessage
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| richMessage | <code>Object</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
 <a name="TelegramBot+forwardMessage"></a>
 
 ### telegramBot.forwardMessage(chatId, fromChatId, messageId, [options]) ⇒ <code>Promise</code>
@@ -937,6 +957,23 @@ as a multipart part) or a file_id / URL string (passed through).
 | chatId | <code>Number \| String</code> |  |
 | draftId | <code>Number</code> |  |
 | text | <code>String</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+sendRichMessageDraft"></a>
+
+### telegramBot.sendRichMessageDraft(chatId, draftId, richMessage, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#sendrichmessagedraft
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| draftId | <code>Number</code> |  |
+| richMessage | <code>Object</code> |  |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+sendChatAction"></a>
@@ -1347,6 +1384,38 @@ as a multipart part) or a file_id / URL string (passed through).
 | --- | --- | --- |
 | chatId | <code>Number \| String</code> |  |
 | userId | <code>Number</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+answerChatJoinRequestQuery"></a>
+
+### telegramBot.answerChatJoinRequestQuery(chatJoinRequestQueryId, result, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#answerchatjoinrequestquery
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatJoinRequestQueryId | <code>String</code> |  |
+| result | <code>Object</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+sendChatJoinRequestWebApp"></a>
+
+### telegramBot.sendChatJoinRequestWebApp(chatJoinRequestQueryId, webAppUrl, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#sendchatjoinrequestwebapp
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatJoinRequestQueryId | <code>String</code> |  |
+| webAppUrl | <code>String</code> |  |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+setChatPhoto"></a>
@@ -2145,7 +2214,7 @@ JPEG before calling.
 
 <a name="TelegramBot+editMessageText"></a>
 
-### telegramBot.editMessageText(text, [options]) ⇒ <code>Promise</code>
+### telegramBot.editMessageText([textOrForm], [options]) ⇒ <code>Promise</code>
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
 
@@ -2155,7 +2224,7 @@ JPEG before calling.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| text | <code>String</code> |  |
+| [textOrForm] | <code>Object</code> | Additional Telegram query options |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+editMessageCaption"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Telegram Bot API — modern TypeScript rewrite with generated types",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -14,6 +14,7 @@ import { MESSAGE_TYPES, UPDATE_TYPES } from "./types/schemas.js";
 import type {
   // Library helpers + data objects (generated)
   ChatId,
+  InputRichMessage,
   MessageType,
   Update,
   Message,
@@ -81,6 +82,10 @@ import type {
   SendInvoiceParams,
   SendChecklistParams,
   SendMessageDraftParams,
+  SendRichMessageParams,
+  SendRichMessageDraftParams,
+  AnswerChatJoinRequestQueryParams,
+  SendChatJoinRequestWebAppParams,
   SetMessageReactionParams,
   GetUserProfilePhotosParams,
   GetUserProfileAudiosParams,
@@ -339,6 +344,10 @@ import type {
   SendLocationResult,
   SendMediaGroupResult,
   SendMessageDraftResult,
+  SendRichMessageResult,
+  SendRichMessageDraftResult,
+  AnswerChatJoinRequestQueryResult,
+  SendChatJoinRequestWebAppResult,
   SendMessageResult,
   SendPaidMediaResult,
   SendPhotoResult,
@@ -688,6 +697,7 @@ export class TelegramBot extends EventEmitter {
       "mask_position",
       "results",
       "sticker",
+      "rich_message",
     ] as const) {
       const value = obj[key];
       if (value !== undefined && value !== null && typeof value !== "string") {
@@ -1044,6 +1054,18 @@ export class TelegramBot extends EventEmitter {
     } satisfies SendMessageParams);
   }
 
+  sendRichMessage(
+    chatId: ChatId,
+    richMessage: InputRichMessage,
+    form: Omit<SendRichMessageParams, "chat_id" | "rich_message"> = {},
+  ): Promise<SendRichMessageResult> {
+    return this._form("sendRichMessage", {
+      ...form,
+      chat_id: chatId,
+      rich_message: richMessage,
+    } satisfies SendRichMessageParams);
+  }
+
   forwardMessage(
     chatId: ChatId,
     fromChatId: ChatId,
@@ -1346,6 +1368,20 @@ export class TelegramBot extends EventEmitter {
     });
   }
 
+  sendRichMessageDraft(
+    chatId: ChatId,
+    draftId: number,
+    richMessage: InputRichMessage,
+    form: Omit<SendRichMessageDraftParams, "chat_id" | "draft_id" | "rich_message"> = {},
+  ): Promise<SendRichMessageDraftResult> {
+    return this._form("sendRichMessageDraft", {
+      ...form,
+      chat_id: chatId,
+      draft_id: draftId,
+      rich_message: richMessage,
+    });
+  }
+
   sendChatAction(chatId: ChatId, action: string, form: Omit<SendChatActionParams, "chat_id" | "action"> = {}): Promise<SendChatActionResult> {
     return this._form("sendChatAction", {
       ...form,
@@ -1622,6 +1658,30 @@ export class TelegramBot extends EventEmitter {
       chat_id: chatId,
       user_id: userId,
     } satisfies DeclineChatJoinRequestParams);
+  }
+
+  answerChatJoinRequestQuery(
+    chatJoinRequestQueryId: string,
+    result: "approve" | "decline" | "queue",
+    form: Omit<AnswerChatJoinRequestQueryParams, "chat_join_request_query_id" | "result"> = {},
+  ): Promise<AnswerChatJoinRequestQueryResult> {
+    return this._form("answerChatJoinRequestQuery", {
+      ...form,
+      chat_join_request_query_id: chatJoinRequestQueryId,
+      result,
+    } satisfies AnswerChatJoinRequestQueryParams);
+  }
+
+  sendChatJoinRequestWebApp(
+    chatJoinRequestQueryId: string,
+    webAppUrl: string,
+    form: Omit<SendChatJoinRequestWebAppParams, "chat_join_request_query_id" | "web_app_url"> = {},
+  ): Promise<SendChatJoinRequestWebAppResult> {
+    return this._form("sendChatJoinRequestWebApp", {
+      ...form,
+      chat_join_request_query_id: chatJoinRequestQueryId,
+      web_app_url: webAppUrl,
+    } satisfies SendChatJoinRequestWebAppParams);
   }
 
   // --- Chat metadata ---------------------------------------------------
@@ -2046,14 +2106,29 @@ export class TelegramBot extends EventEmitter {
 
   // --- Editing messages -------------------------------------------------
 
+  /**
+   * Edit text or rich messages. On success, if the edited message is not an
+   * inline message, the edited {@link Message} is returned, otherwise `true`.
+   *
+   * **Call with a single object** (preferred):
+   *   - Text edit: `editMessageText({ chat_id, message_id, text: "…" })`
+   *   - Rich edit: `editMessageText({ chat_id, message_id, rich_message: { … } })`
+   *
+   * **`(text, form)` signature** (deprecated — kept for backward compatibility):
+   *   - `editMessageText("new text", { chat_id, message_id })`
+   *
+   * @deprecated The two-argument form is deprecated; prefer the single-object call.
+   */
+  editMessageText(text: string, form: Omit<EditMessageTextParams, "text">): Promise<EditMessageTextResult>;
+  editMessageText(form: EditMessageTextParams): Promise<EditMessageTextResult>;
   editMessageText(
-    text: string,
+    textOrForm: string | EditMessageTextParams,
     form: Omit<EditMessageTextParams, "text"> = {},
   ): Promise<EditMessageTextResult> {
-    return this._form("editMessageText", {
-      ...form,
-      text,
-    } satisfies EditMessageTextParams);
+    if (typeof textOrForm === "string") {
+      return this._form("editMessageText", { ...form, text: textOrForm });
+    }
+    return this._form("editMessageText", textOrForm);
   }
   editMessageCaption(
     caption: string,

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -177,6 +177,7 @@ export type User = {
   has_topics_enabled?: boolean;
   allows_users_to_create_topics?: boolean;
   can_manage_bots?: boolean;
+  supports_join_request_queries?: boolean;
 };
 
 export type Chat = {
@@ -242,6 +243,7 @@ export type ChatFullInfo = {
   first_profile_audio?: Audio;
   unique_gift_colors?: UniqueGiftColors;
   paid_message_star_count?: number;
+  guard_bot?: User;
 };
 
 export type Message = {
@@ -281,6 +283,7 @@ export type Message = {
   link_preview_options?: LinkPreviewOptions;
   suggested_post_info?: SuggestedPostInfo;
   effect_id?: string;
+  rich_message?: RichMessage;
   animation?: Animation;
   audio?: Audio;
   document?: Document;
@@ -596,10 +599,15 @@ export type Dice = {
   value: number;
 };
 
+export type Link = {
+  url: string;
+};
+
 export type PollMedia = {
   animation?: Animation;
   audio?: Audio;
   document?: Document;
+  link?: Link;
   live_photo?: LivePhoto;
   location?: Location;
   photo?: PhotoSize[];
@@ -1236,6 +1244,7 @@ export type ChatJoinRequest = {
   date: number;
   bio?: string;
   invite_link?: ChatInviteLink;
+  query_id?: string;
 };
 
 export type ChatPermissions = {
@@ -1747,6 +1756,11 @@ export type InputMediaDocument = {
   disable_content_type_detection?: boolean;
 };
 
+export type InputMediaLink = {
+  type: string;
+  url: string;
+};
+
 export type InputMediaLivePhoto = {
   type: string;
   media: string;
@@ -1896,6 +1910,308 @@ export type InputSticker = {
   emoji_list: string[];
   mask_position?: MaskPosition;
   keywords?: string[];
+};
+
+export type RichMessage = {
+  blocks: RichBlock[];
+  is_rtl?: boolean;
+};
+
+export type InputRichMessage = {
+  html?: string;
+  markdown?: string;
+  is_rtl?: boolean;
+  skip_entity_detection?: boolean;
+};
+
+export type RichTextBold = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextItalic = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextUnderline = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextStrikethrough = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextSpoiler = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextDateTime = {
+  type: string;
+  text: RichText;
+  unix_time: number;
+  date_time_format: string;
+};
+
+export type RichTextTextMention = {
+  type: string;
+  text: RichText;
+  user: User;
+};
+
+export type RichTextSubscript = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextSuperscript = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextMarked = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextCode = {
+  type: string;
+  text: RichText;
+};
+
+export type RichTextCustomEmoji = {
+  type: string;
+  custom_emoji_id: string;
+  alternative_text: string;
+};
+
+export type RichTextMathematicalExpression = {
+  type: string;
+  expression: string;
+};
+
+export type RichTextUrl = {
+  type: string;
+  text: RichText;
+  url: string;
+};
+
+export type RichTextEmailAddress = {
+  type: string;
+  text: RichText;
+  email_address: string;
+};
+
+export type RichTextPhoneNumber = {
+  type: string;
+  text: RichText;
+  phone_number: string;
+};
+
+export type RichTextBankCardNumber = {
+  type: string;
+  text: RichText;
+  bank_card_number: string;
+};
+
+export type RichTextMention = {
+  type: string;
+  text: RichText;
+  username: string;
+};
+
+export type RichTextHashtag = {
+  type: string;
+  text: RichText;
+  hashtag: string;
+};
+
+export type RichTextCashtag = {
+  type: string;
+  text: RichText;
+  cashtag: string;
+};
+
+export type RichTextBotCommand = {
+  type: string;
+  text: RichText;
+  bot_command: string;
+};
+
+export type RichTextAnchor = {
+  type: string;
+  name: string;
+};
+
+export type RichTextAnchorLink = {
+  type: string;
+  text: RichText;
+  anchor_name: string;
+};
+
+export type RichTextReference = {
+  type: string;
+  text: RichText;
+  name: string;
+};
+
+export type RichTextReferenceLink = {
+  type: string;
+  text: RichText;
+  reference_name: string;
+};
+
+export type RichBlockCaption = {
+  text: RichText;
+  credit?: RichText;
+};
+
+export type RichBlockTableCell = {
+  text?: RichText;
+  is_header?: true;
+  colspan?: number;
+  rowspan?: number;
+  align: string;
+  valign: string;
+};
+
+export type RichBlockListItem = {
+  label: string;
+  blocks: RichBlock[];
+  has_checkbox?: true;
+  is_checked?: true;
+  value?: number;
+  type?: string;
+};
+
+export type RichBlockParagraph = {
+  type: string;
+  text: RichText;
+};
+
+export type RichBlockSectionHeading = {
+  type: string;
+  text: RichText;
+  size: number;
+};
+
+export type RichBlockPreformatted = {
+  type: string;
+  text: RichText;
+  language?: string;
+};
+
+export type RichBlockFooter = {
+  type: string;
+  text: RichText;
+};
+
+export type RichBlockDivider = {
+  type: string;
+};
+
+export type RichBlockMathematicalExpression = {
+  type: string;
+  expression: string;
+};
+
+export type RichBlockAnchor = {
+  type: string;
+  name: string;
+};
+
+export type RichBlockList = {
+  type: string;
+  items: RichBlockListItem[];
+};
+
+export type RichBlockBlockQuotation = {
+  type: string;
+  blocks: RichBlock[];
+  credit?: RichText;
+};
+
+export type RichBlockPullQuotation = {
+  type: string;
+  text: RichText;
+  credit?: RichText;
+};
+
+export type RichBlockCollage = {
+  type: string;
+  blocks: RichBlock[];
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockSlideshow = {
+  type: string;
+  blocks: RichBlock[];
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockTable = {
+  type: string;
+  cells: RichBlockTableCell[][];
+  is_bordered?: true;
+  is_striped?: true;
+  caption?: RichText;
+};
+
+export type RichBlockDetails = {
+  type: string;
+  summary: RichText;
+  blocks: RichBlock[];
+  is_open?: true;
+};
+
+export type RichBlockMap = {
+  type: string;
+  location: Location;
+  zoom: number;
+  width: number;
+  height: number;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockAnimation = {
+  type: string;
+  animation: Animation;
+  has_spoiler?: true;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockAudio = {
+  type: string;
+  audio: Audio;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockPhoto = {
+  type: string;
+  photo: PhotoSize[];
+  has_spoiler?: true;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockVideo = {
+  type: string;
+  video: Video;
+  has_spoiler?: true;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockVoiceNote = {
+  type: string;
+  voice_note: Voice;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockThinking = {
+  type: string;
+  text: RichText;
 };
 
 export type InlineQuery = {
@@ -2201,6 +2517,10 @@ export type InputTextMessageContent = {
   parse_mode?: string;
   entities?: MessageEntity[];
   link_preview_options?: LinkPreviewOptions;
+};
+
+export type InputRichMessageContent = {
+  rich_message: InputRichMessage;
 };
 
 export type InputLocationMessageContent = {
@@ -2555,7 +2875,7 @@ export type PaidMedia = PaidMediaLivePhoto | PaidMediaPhoto | PaidMediaPreview |
 
 export type InputPollMedia = InputMediaAnimation | InputMediaAudio | InputMediaDocument | InputMediaLivePhoto | InputMediaLocation | InputMediaPhoto | InputMediaVenue | InputMediaVideo;
 
-export type InputPollOptionMedia = InputMediaAnimation | InputMediaLivePhoto | InputMediaLocation | InputMediaPhoto | InputMediaSticker | InputMediaVenue | InputMediaVideo;
+export type InputPollOptionMedia = InputMediaAnimation | InputMediaLink | InputMediaLivePhoto | InputMediaLocation | InputMediaPhoto | InputMediaSticker | InputMediaVenue | InputMediaVideo;
 
 export type BackgroundFill = BackgroundFillSolid | BackgroundFillGradient | BackgroundFillFreeformGradient;
 
@@ -2583,9 +2903,13 @@ export type InputProfilePhoto = InputProfilePhotoStatic | InputProfilePhotoAnima
 
 export type InputStoryContent = InputStoryContentPhoto | InputStoryContentVideo;
 
+export type RichText = RichTextBold | RichTextItalic | RichTextUnderline | RichTextStrikethrough | RichTextSpoiler | RichTextDateTime | RichTextTextMention | RichTextSubscript | RichTextSuperscript | RichTextMarked | RichTextCode | RichTextCustomEmoji | RichTextMathematicalExpression | RichTextUrl | RichTextEmailAddress | RichTextPhoneNumber | RichTextBankCardNumber | RichTextMention | RichTextHashtag | RichTextCashtag | RichTextBotCommand | RichTextAnchor | RichTextAnchorLink | RichTextReference | RichTextReferenceLink;
+
+export type RichBlock = RichBlockParagraph | RichBlockSectionHeading | RichBlockPreformatted | RichBlockFooter | RichBlockDivider | RichBlockMathematicalExpression | RichBlockAnchor | RichBlockList | RichBlockBlockQuotation | RichBlockPullQuotation | RichBlockCollage | RichBlockSlideshow | RichBlockTable | RichBlockDetails | RichBlockMap | RichBlockAnimation | RichBlockAudio | RichBlockPhoto | RichBlockVideo | RichBlockVoiceNote | RichBlockThinking;
+
 export type InlineQueryResult = InlineQueryResultCachedAudio | InlineQueryResultCachedDocument | InlineQueryResultCachedGif | InlineQueryResultCachedMpeg4Gif | InlineQueryResultCachedPhoto | InlineQueryResultCachedSticker | InlineQueryResultCachedVideo | InlineQueryResultCachedVoice | InlineQueryResultArticle | InlineQueryResultAudio | InlineQueryResultContact | InlineQueryResultGame | InlineQueryResultDocument | InlineQueryResultGif | InlineQueryResultLocation | InlineQueryResultMpeg4Gif | InlineQueryResultPhoto | InlineQueryResultVenue | InlineQueryResultVideo | InlineQueryResultVoice;
 
-export type InputMessageContent = InputTextMessageContent | InputLocationMessageContent | InputVenueMessageContent | InputContactMessageContent | InputInvoiceMessageContent;
+export type InputMessageContent = InputTextMessageContent | InputRichMessageContent | InputLocationMessageContent | InputVenueMessageContent | InputContactMessageContent | InputInvoiceMessageContent;
 
 export type RevenueWithdrawalState = RevenueWithdrawalStatePending | RevenueWithdrawalStateSucceeded | RevenueWithdrawalStateFailed;
 
@@ -3243,6 +3567,18 @@ export type DeclineChatJoinRequestParams = {
 };
 export type DeclineChatJoinRequestResult = boolean;
 
+export type AnswerChatJoinRequestQueryParams = {
+  chat_join_request_query_id: string;
+  result: string;
+};
+export type AnswerChatJoinRequestQueryResult = boolean;
+
+export type SendChatJoinRequestWebAppParams = {
+  chat_join_request_query_id: string;
+  web_app_url: string;
+};
+export type SendChatJoinRequestWebAppResult = boolean;
+
 export type SetChatPhotoParams = {
   chat_id: number | string;
   photo: InputFile;
@@ -3775,10 +4111,11 @@ export type EditMessageTextParams = {
   chat_id?: number | string;
   message_id?: number;
   inline_message_id?: string;
-  text: string;
+  text?: string;
   parse_mode?: string;
   entities?: MessageEntity[];
   link_preview_options?: LinkPreviewOptions;
+  rich_message?: InputRichMessage;
   reply_markup?: InlineKeyboardMarkup;
 };
 export type EditMessageTextResult = Message | boolean;
@@ -4009,6 +4346,30 @@ export type DeleteStickerSetParams = {
   name: string;
 };
 export type DeleteStickerSetResult = boolean;
+
+export type SendRichMessageParams = {
+  business_connection_id?: string;
+  chat_id: number | string;
+  message_thread_id?: number;
+  direct_messages_topic_id?: number;
+  rich_message: InputRichMessage;
+  disable_notification?: boolean;
+  protect_content?: boolean;
+  allow_paid_broadcast?: boolean;
+  message_effect_id?: string;
+  suggested_post_parameters?: SuggestedPostParameters;
+  reply_parameters?: ReplyParameters;
+  reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply;
+};
+export type SendRichMessageResult = Message;
+
+export type SendRichMessageDraftParams = {
+  chat_id: number;
+  message_thread_id?: number;
+  draft_id: number;
+  rich_message: InputRichMessage;
+};
+export type SendRichMessageDraftResult = boolean;
 
 export type AnswerInlineQueryParams = {
   inline_query_id: string;

--- a/test/integration/telegram.test.ts
+++ b/test/integration/telegram.test.ts
@@ -489,6 +489,41 @@ describe("Telegram Bot API (integration)", () => {
     });
   });
 
+  describe("sendRichMessage", () => {
+    it("sends a markdown rich message and returns a Message carrying rich_message blocks", async () => {
+      const sent = await bot.sendRichMessage(GROUP_ID, { markdown: "**bold** and _italic_" });
+      assert.equal(typeof sent.message_id, "number");
+      assert.ok(sent.rich_message, "expected the returned Message to carry rich_message");
+      assert.ok(
+        Array.isArray(sent.rich_message!.blocks) && sent.rich_message!.blocks.length > 0,
+        "expected rich_message.blocks to be a non-empty array",
+      );
+    });
+
+    it("structures HTML formatting into rich text runs", async () => {
+      const sent = await bot.sendRichMessage(GROUP_ID, { html: "<b>bold</b> and <i>italic</i>" });
+      assert.ok(sent.rich_message);
+      // The server parses the HTML into typed runs; both words survive the round-trip.
+      const json = JSON.stringify(sent.rich_message);
+      assert.ok(json.includes("bold") && json.includes("italic"));
+    });
+  });
+
+  describe("sendRichMessageDraft", () => {
+    // Drafts target a *private* chat only; a group/supergroup peer is rejected with
+    // TEXTDRAFT_PEER_INVALID. The bot cannot open a private chat unprompted, so we
+    // assert the documented rejection rather than a happy path.
+    it("rejects with ETELEGRAM for a non-private peer", async () => {
+      await assert.rejects(
+        bot.sendRichMessageDraft(GROUP_ID, 1, { markdown: "draft" }),
+        (err: unknown) => {
+          assert.equal((err as { code?: string }).code, "ETELEGRAM");
+          return true;
+        },
+      );
+    });
+  });
+
   describe("sendChatAction", () => {
     it("returns true", async () => {
       const ok = await bot.sendChatAction(GROUP_ID, "typing");
@@ -1295,6 +1330,22 @@ describe("Telegram Bot API (integration)", () => {
           msg.entities.some((e) => e.type === "bold" && e.offset === 0 && e.length === 4),
       );
     });
+
+    it("accepts a rich_message option and returns the edited rich Message", async () => {
+      const sent = await bot.sendMessage(GROUP_ID, `rich-edit-me ${TIMESTAMP}`);
+      const edited = await bot.editMessageText("fallback text", {
+        chat_id: GROUP_ID,
+        message_id: sent.message_id,
+        rich_message: { markdown: "**now rich**" },
+      });
+      assert.ok(edited !== true, "expected a Message back when editing an owned message");
+      const msg = edited as Message;
+      assert.ok(msg.rich_message, "expected the edited Message to carry rich_message");
+      assert.ok(
+        Array.isArray(msg.rich_message!.blocks) && msg.rich_message!.blocks.length > 0,
+        "expected rich_message.blocks to be a non-empty array",
+      );
+    });
   });
 
   describe("editMessageCaption", () => {
@@ -1895,6 +1946,32 @@ describe("Telegram Bot API (integration)", () => {
         assert.equal((err as { code?: string }).code, "ETELEGRAM");
         return true;
       });
+    });
+  });
+
+  describe("answerChatJoinRequestQuery", () => {
+    // No live join-request query is available in the test chat and the test bot is
+    // not a guard bot, so the API rejects with BOT_GUARD_NOT_SUPPORTED.
+    it("rejects with ETELEGRAM for an unknown query id", async () => {
+      await assert.rejects(
+        bot.answerChatJoinRequestQuery("nonexistent-query-id", "approve"),
+        (err: unknown) => {
+          assert.equal((err as { code?: string }).code, "ETELEGRAM");
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("sendChatJoinRequestWebApp", () => {
+    it("rejects with ETELEGRAM for an unknown query id", async () => {
+      await assert.rejects(
+        bot.sendChatJoinRequestWebApp("nonexistent-query-id", "https://example.com/app"),
+        (err: unknown) => {
+          assert.equal((err as { code?: string }).code, "ETELEGRAM");
+          return true;
+        },
+      );
     });
   });
 

--- a/test/unit/telegram.test.ts
+++ b/test/unit/telegram.test.ts
@@ -590,13 +590,95 @@ describe("TelegramBot (unit)", () => {
     });
   });
 
-  describe("polling vs webhook safety", () => {
-    it("rejects startPolling() while a webhook is open", async () => {
+  describe("sendRichMessage()", () => {
+    it("posts to /sendRichMessage with chat_id and rich_message", async () => {
+      stubFetch(() => ({ ok: true, result: { message_id: 1, date: 0, chat: { id: 1, type: "private" } } }));
       const bot = new TelegramBot("TOKEN");
-      // Stub _webHook to look open
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (bot as any)._webHook = { isOpen: () => true, open: async () => {}, close: async () => {} };
-      await assert.rejects(bot.startPolling(), /mutually exclusive/);
+      await bot.sendRichMessage(123, { markdown: "# Hello" });
+      const last = captured.at(-1)!;
+      assert.equal(last.url, "https://api.telegram.org/botTOKEN/sendRichMessage");
+      const params = new URLSearchParams(String(last.init.body));
+      assert.equal(params.get("chat_id"), "123");
+      const raw = params.get("rich_message");
+      assert.ok(raw);
+      const parsed = JSON.parse(raw!);
+      assert.equal(parsed.markdown, "# Hello");
+    });
+
+    it("JSON-serializes rich_message with html", async () => {
+      stubFetch(() => ({ ok: true, result: { message_id: 1, date: 0, chat: { id: 1, type: "private" } } }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.sendRichMessage(1, { html: "<h1>Title</h1>", is_rtl: true, skip_entity_detection: true });
+      const params = new URLSearchParams(String(captured[0]!.init.body));
+      const raw = params.get("rich_message");
+      assert.ok(raw);
+      const parsed = JSON.parse(raw!);
+      assert.equal(parsed.html, "<h1>Title</h1>");
+      assert.equal(parsed.is_rtl, true);
+      assert.equal(parsed.skip_entity_detection, true);
     });
   });
+
+  describe("sendRichMessageDraft()", () => {
+    it("posts to /sendRichMessageDraft with chat_id, draft_id, and rich_message", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.sendRichMessageDraft(123, 42, { markdown: "streaming..." });
+      const last = captured.at(-1)!;
+      assert.equal(last.url, "https://api.telegram.org/botTOKEN/sendRichMessageDraft");
+      const params = new URLSearchParams(String(last.init.body));
+      assert.equal(params.get("chat_id"), "123");
+      assert.equal(params.get("draft_id"), "42");
+      const raw = params.get("rich_message");
+      assert.ok(raw);
+      const parsed = JSON.parse(raw!);
+      assert.equal(parsed.markdown, "streaming...");
+    });
+  });
+
+  describe("answerChatJoinRequestQuery()", () => {
+    it("posts to /answerChatJoinRequestQuery with query_id and result", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.answerChatJoinRequestQuery("query_abc", "approve");
+      const last = captured.at(-1)!;
+      assert.equal(last.url, "https://api.telegram.org/botTOKEN/answerChatJoinRequestQuery");
+      const params = new URLSearchParams(String(last.init.body));
+      assert.equal(params.get("chat_join_request_query_id"), "query_abc");
+      assert.equal(params.get("result"), "approve");
+    });
+  });
+
+  describe("sendChatJoinRequestWebApp()", () => {
+    it("posts to /sendChatJoinRequestWebApp with query_id and web_app_url", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.sendChatJoinRequestWebApp("query_xyz", "https://example.com/miniapp");
+      const last = captured.at(-1)!;
+      assert.equal(last.url, "https://api.telegram.org/botTOKEN/sendChatJoinRequestWebApp");
+      const params = new URLSearchParams(String(last.init.body));
+      assert.equal(params.get("chat_join_request_query_id"), "query_xyz");
+      assert.equal(params.get("web_app_url"), "https://example.com/miniapp");
+    });
+  });
+
+  describe("editMessageText() with rich_message", () => {
+    it("JSON-serializes rich_message via the new single-object form", async () => {
+      stubFetch(() => ({ ok: true, result: { message_id: 1, date: 0, chat: { id: 1, type: "private" } } }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.editMessageText({
+        chat_id: 1,
+        message_id: 42,
+        rich_message: { html: "<b>updated</b>" },
+      });
+      const params = new URLSearchParams(String(captured[0]!.init.body));
+      // text should not be present
+      assert.equal(params.has("text"), false);
+      const raw = params.get("rich_message");
+      assert.ok(raw);
+      const parsed = JSON.parse(raw!);
+      assert.equal(parsed.html, "<b>updated</b>");
+    });
+  });
+
 });

--- a/test/unit/telegram.test.ts
+++ b/test/unit/telegram.test.ts
@@ -681,4 +681,14 @@ describe("TelegramBot (unit)", () => {
     });
   });
 
+  describe("polling vs webhook safety", () => {
+    it("rejects startPolling() while a webhook is open", async () => {
+      const bot = new TelegramBot("TOKEN");
+      // Stub _webHook to look open
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (bot as any)._webHook = { isOpen: () => true, open: async () => {}, close: async () => {} };
+      await assert.rejects(bot.startPolling(), /mutually exclusive/);
+    });
+  });
+
 });


### PR DESCRIPTION
- Add sendRichMessage, sendRichMessageDraft methods
- Add answerChatJoinRequestQuery, sendChatJoinRequestWebApp methods
- Update editMessageText with new single-object overload (old signature deprecated)
- Add InputRichMessage type with automatic JSON serialization
- Regenerate src/types/schemas.ts with all v10.1 types (RichMessage, RichText, RichBlock, etc.)
- Add unit tests for all new methods
- Bump version to 1.1.0

- [x] All unit tests pass (`npm run test:node:unit`)
- [x] All integration tests pass (`npm run test:node:integration`)
- [x] `npm run typecheck` is clean
- [x] `doc/api.md` is up to date (`bun run generate:docs` leaves no diff — required when a `TelegramBot` method signature changed)

### Description

Support new Telegram Bot API

### References

- Telegram Bot API : https://core.telegram.org/bots/api#june-11-2026

