### PR TITLE
chore(skills): add release and update-bot-api Claude Code skills

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -97,13 +97,11 @@ git push -u origin version/X.Y.Z
 
 ## 7. PR to master, wait for green CI, merge
 
-`gh` is **not installed** here - use the GitHub MCP tools (`mcp__github__*`):
+`gh` may not be available here, and the GitHub MCP toolset for this environment is read/list-only. Create/merge the PR via the GitHub web UI (or the GitHub REST API if you have a `GITHUB_TOKEN`).
 
-1. `create_pull_request` head=`version/X.Y.Z` base=`master`, title `X.Y.Z`.
-2. Poll `pull_request_read` method=`get_check_runs` until all checks pass. Expect:
-   Typecheck, Unit tests (Node 20/22/24/26 + Bun), Build (dist); Integration is **skipped**
-   on PRs (no secrets). They finish in well under a minute.
-3. `merge_pull_request` method=`merge`, commit_title `Merge pull request #N from yagop/version/X.Y.Z`.
+1. Open a PR head=`version/X.Y.Z` base=`master`, title `X.Y.Z`.
+2. Wait for all checks to pass. Expect: Typecheck, Unit tests (Node 20/22/24/26 + Bun), Build (dist); Integration is **skipped** on PRs (no secrets).
+3. Merge the PR (merge commit).
 
 ## 8. Pull master
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: release
+description: How to cut and publish a release of node-telegram-bot-api (version bump, CHANGELOG, docs, PR to master, npm publish, git tag, GitHub Release, optional Telegram announcement). Use whenever asked to release, publish a new version, bump the version, or "do the X.Y.Z release". Covers the exact step order, the CHANGELOG entry convention, the sanity gate, and the credential gotchas (read-only NPM_TOKEN, missing gh CLI, no create-release MCP tool).
+---
+
+# Releasing node-telegram-bot-api
+
+End-to-end release flow. Replace `X.Y.Z` with the target version (example below uses `1.0.0`).
+Releases ship from `master`; work happens on a short-lived `version/X.Y.Z` branch.
+
+## 0. Orient first (don't assume)
+
+```bash
+git status                                   # must be clean
+node -p "require('./package.json').version"  # current version
+npm view node-telegram-bot-api dist-tags     # what 'latest' / 'next' point at
+```
+
+Decide the new version and whether it should become npm `latest` (a stable release does;
+a prerelease like `-rc.0` should publish under a different tag with `--tag next`).
+
+## 1. Branch
+
+```bash
+git checkout -b version/X.Y.Z
+```
+
+## 2. README + CHANGELOG
+
+- **README** rarely needs changes (the version comes from an npm badge, not hard-coded). Only
+  touch it if a documented fact changed.
+- **CHANGELOG.md** must have an entry that matches the existing convention exactly. Every
+  released version uses:
+
+  ```
+  ## [X.Y.Z][X.Y.Z] - YYYY-MM-DD
+  ```
+
+  with a matching link-def at the very bottom of the file:
+
+  ```
+  [X.Y.Z]:https://github.com/yagop/node-telegram-bot-api/releases/tag/vX.Y.Z
+  ```
+
+  and the `[Unreleased]` compare link bumped to the new tag:
+
+  ```
+  [Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/vX.Y.Z...master
+  ```
+
+  Use the actual release date (today), `- ` (ASCII hyphen, not an em dash), and keep an empty
+  `## [Unreleased][Unreleased]` section at the top.
+
+## 3. Bump version (both files, no git tag yet)
+
+```bash
+npm version X.Y.Z --no-git-tag-version
+```
+
+This updates `package.json` AND `package-lock.json` (root + `packages[""]`). Verify:
+
+```bash
+node -p "require('./package.json').version"
+node -p "require('./package-lock.json').version"
+```
+
+## 4. Regenerate docs
+
+```bash
+bun run generate:docs
+git diff --exit-code doc/api.md   # usually no diff if no method signatures changed
+```
+
+See the `generate-docs` skill for details. Commit `doc/api.md` only if it actually changed.
+
+## 5. Sanity gate (must pass before publishing)
+
+```bash
+npm run typecheck            # src + test, strict
+npm run test:bun:unit        # ~91 unit tests, no network/token
+npm run build                # this is what `prepare` runs on publish - must succeed
+```
+
+`dist/` is gitignored (built on publish via `prepare`), so it is NOT committed.
+See the `run-tests` skill for runner details.
+
+## 6. Commit + push
+
+Only three files change: `CHANGELOG.md`, `package.json`, `package-lock.json`. The repo's
+release commits use the **bare version** as the message (e.g. `336ae2e 1.0.0-rc.0`):
+
+```bash
+git add CHANGELOG.md package.json package-lock.json
+git commit -m "X.Y.Z"
+git push -u origin version/X.Y.Z
+```
+
+## 7. PR to master, wait for green CI, merge
+
+`gh` is **not installed** here - use the GitHub MCP tools (`mcp__github__*`):
+
+1. `create_pull_request` head=`version/X.Y.Z` base=`master`, title `X.Y.Z`.
+2. Poll `pull_request_read` method=`get_check_runs` until all checks pass. Expect:
+   Typecheck, Unit tests (Node 20/22/24/26 + Bun), Build (dist); Integration is **skipped**
+   on PRs (no secrets). They finish in well under a minute.
+3. `merge_pull_request` method=`merge`, commit_title `Merge pull request #N from yagop/version/X.Y.Z`.
+
+## 8. Pull master
+
+```bash
+git checkout master && git pull origin master
+node -p "require('./package.json').version"   # == X.Y.Z
+```
+
+## 9. npm publish
+
+Auth from `NPM_TOKEN` (env). Write it without printing the value, dry-run first, then publish:
+
+```bash
+printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > "$HOME/.npmrc"
+npm whoami                 # should print: yagop
+npm publish --dry-run      # inspect the tarball (expect README, LICENSE, dist/, package.json)
+npm publish                # stable -> latest; for a prerelease add: --tag next
+npm view node-telegram-bot-api version   # confirm == X.Y.Z
+```
+
+> ⚠️ **Read-only-token gotcha.** `npm whoami` succeeding does NOT mean the token can publish.
+> If `npm publish` returns `E403 ... You may not perform that action with these credentials`
+> (and `npm profile get` also 403s), the token is read-only / too narrowly scoped. A 403 is a
+> clean failure - nothing was uploaded. Fix: use an npm **Automation** token, or a **Granular**
+> token with *Read and write* that includes this package. If you can't get one, the maintainer
+> publishes manually with their OTP: `! cd /workspace && npm publish`.
+
+## 10. Tag the release
+
+The CHANGELOG link-def points at `releases/tag/vX.Y.Z`, and every prior release has a matching
+**annotated** tag. Tag the released `master` HEAD and push:
+
+```bash
+git tag -a vX.Y.Z -m "X.Y.Z" $(git rev-parse master)
+git push origin vX.Y.Z
+```
+
+## 11. GitHub Release
+
+There is **no create-release path via local tooling**: `gh` isn't installed, and the GitHub MCP
+server only exposes **read-only** release tools (`get_latest_release`, `get_release_by_tag`,
+`list_releases`) - no create/update. Two options:
+
+- **REST API (needs a token).** If `GITHUB_TOKEN` is in the session env (a PAT with `repo`, or
+  fine-grained with *Contents: write*), POST to the releases endpoint. Build the JSON body from
+  a notes file so newlines/quotes are escaped safely (see snippet below). Note: setting the var
+  in a separate terminal won't reach the session - it must be injected the same way `NPM_TOKEN`
+  is. Body = the CHANGELOG `X.Y.Z` section verbatim (it's self-contained, no reference links),
+  with a `compare/<prev>...vX.Y.Z` line appended. Use `make_latest: "true"`, `prerelease: false`.
+- **Web UI (no token).** `https://github.com/yagop/node-telegram-bot-api/releases/new?tag=vX.Y.Z`
+  -> title `X.Y.Z`, paste the notes, check *Set as the latest release*.
+
+REST snippet (run with `node`, token from env, never printed):
+
+```js
+// create-release.mjs
+import { readFile } from "node:fs/promises";
+const token = process.env.GITHUB_TOKEN;
+if (!token) { console.error("GITHUB_TOKEN not set"); process.exit(2); }
+const body = await readFile(new URL("./RELEASE_NOTES.md", import.meta.url), "utf8");
+const res = await fetch("https://api.github.com/repos/yagop/node-telegram-bot-api/releases", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "ntba-release-script",
+  },
+  body: JSON.stringify({ tag_name: "vX.Y.Z", name: "X.Y.Z", body, make_latest: "true", prerelease: false }),
+});
+console.log(res.status, (await res.json()).html_url ?? "");
+```
+
+## 12. (Optional) Announce on Telegram
+
+Draft a short channel post (emojis, Telegram markdown `*bold*` / inline `` `code` ``) with the
+few most relevant changes + the migration link + `npm i node-telegram-bot-api`. Keep it short.
+
+## Done-checklist
+
+- [ ] `npm view node-telegram-bot-api version` == X.Y.Z (correct dist-tag)
+- [ ] `master` at the release commit, version X.Y.Z
+- [ ] annotated tag `vX.Y.Z` pushed (CHANGELOG link resolves)
+- [ ] GitHub Release published, marked latest

--- a/.claude/skills/update-bot-api/SKILL.md
+++ b/.claude/skills/update-bot-api/SKILL.md
@@ -28,6 +28,7 @@ trusting a class/method/field list:
 curl -s https://core.telegram.org/bots/api-changelog -o /tmp/changelog.html
 node -e 'const t=require("fs").readFileSync("/tmp/changelog.html","utf8");
   const i=t.indexOf("<VERSION DATE>");                       // e.g. "January 1, 2026"
+  if (i < 0) throw new Error("changelog: <VERSION DATE> heading not found - check the exact text");
   let s=t.slice(i-50,i+6000).replace(/<[^>]+>/g," ").replace(/&amp;/g,"&");
   console.log(s.replace(/[ \t]+/g," "));'
 ```

--- a/.claude/skills/update-bot-api/SKILL.md
+++ b/.claude/skills/update-bot-api/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: update-bot-api
+description: How to add support for a new Telegram Bot API version to node-telegram-bot-api. Use whenever asked to "add support for Bot API X.Y", "update to the latest Bot API", "implement the <month> Bot API changelog", or wire up new Telegram methods/types. Covers reading the changelog authoritatively, regenerating types with scripts/api-parser.ts, hand-adding the new TelegramBot methods, serializing structured fields through the _fix* pipeline, testing (unit + live e2e), and the docs/CHANGELOG steps. Defers test-running to the run-tests skill, doc regen to generate-docs, and publishing to the release skill.
+---
+
+# Adding support for a new Bot API version
+
+The split that makes this fast: **types are generated, methods are hand-written.**
+`scripts/api-parser.ts` regenerates the entire type surface from the live docs in
+one command, so the only real work is adding the new public `TelegramBot` methods
+in `src/telegram.ts` and wiring any new structured fields into the request
+pipeline. It is version-agnostic - use placeholders (`<method>`, `<Method>Params`,
+`<field>`) as the names for whatever the target changelog introduces.
+
+## 0. Inputs
+
+- The changelog section for the target version:
+  <https://core.telegram.org/bots/api-changelog> (anchor like `#january-1-2026`).
+- The main reference for per-method params/returns: <https://core.telegram.org/bots/api>.
+
+## 1. Read the changelog from the RAW page, not a summary
+
+WebFetch (and other LLM summarizers) **hallucinate** here - they have invented
+classes that do not exist on the page. Always confirm against the raw HTML before
+trusting a class/method/field list:
+
+```bash
+curl -s https://core.telegram.org/bots/api-changelog -o /tmp/changelog.html
+node -e 'const t=require("fs").readFileSync("/tmp/changelog.html","utf8");
+  const i=t.indexOf("<VERSION DATE>");                       // e.g. "January 1, 2026"
+  let s=t.slice(i-50,i+6000).replace(/<[^>]+>/g," ").replace(/&amp;/g,"&");
+  console.log(s.replace(/[ \t]+/g," "));'
+```
+
+Inventory the section into four buckets - this drives the rest of the work:
+
+| Changelog item | Where it lands | Hand-work? |
+| --- | --- | --- |
+| New **object / union type** | `src/types/schemas.ts` | **Generated** - none |
+| New **method** | `src/telegram.ts` public method | **Yes** - add it (step 3) |
+| New **field on a method** (a request parameter) | flows via the `Omit<...Params>` options bag | none, **unless** it is structured (step 4) |
+| New **field on an object** (a response/struct field) | `src/types/schemas.ts` | **Generated** - none |
+
+## 2. Regenerate the types
+
+```bash
+bun scripts/api-parser.ts        # == npm run generate:types -> src/types/schemas.ts
+```
+
+This fetches the live docs and emits every documented object, the "one of" unions,
+and per method `<Method>Params` / `<Method>Result`. It is **strict on purpose**:
+
+- An **unmapped type string** is a hard error (non-zero exit) - it never falls back
+  to `unknown`. If Telegram introduces a new scalar spelling, extend `mapScalar` /
+  `mapType` in the parser.
+- An **unresolved return type** falls back to `boolean` and is listed in the run
+  summary (`reply type fell back to boolean for N method(s)`). If that is wrong,
+  add the method to `RETURN_OVERRIDES` in `scripts/api-parser.ts` with the verbatim
+  documented return type.
+
+Do **not** hand-edit `src/types/schemas.ts`. New types are re-exported publicly for
+free (`src/index.ts` -> `src/types/index.ts` -> `export * from "./schemas.js"`).
+
+### Sanity-check the diff
+
+```bash
+git diff --stat src/types/schemas.ts
+git diff src/types/schemas.ts | grep '^-' | grep -v '^---'   # inspect every deletion
+```
+
+Pure additions are expected. A handful of **deletions are normal and benign** -
+they are almost always one of two shapes: a union gaining a member, or a field
+going from required to optional (`x:` -> `x?:`). If a deletion is *not* one of
+those shapes, investigate before continuing.
+
+## 3. Add each new method to `src/telegram.ts`
+
+Match the surrounding methods exactly (see CLAUDE.md "Request pipeline"). The
+canonical shape is: positional args first, then an options bag typed
+`Omit<<Method>Params, "<the positional fields>">`, spread into the payload, with a
+`satisfies <Method>Params` check, delegating to `_form` (or `_sendFile` for uploads):
+
+```ts
+// 1) import the new types: any new object type used in the signature, plus the
+//    method's <Method>Params / <Method>Result in the Params/Result import blocks.
+
+// 2) the method, placed next to related ones (sends near sendMessage, etc.)
+<method>(
+  chatId: ChatId,
+  <primaryArg>: <PrimaryArgType>,
+  form: Omit<<Method>Params, "chat_id" | "<primary_arg>"> = {},
+): Promise<<Method>Result> {
+  return this._form("<method>", {
+    ...form,
+    chat_id: chatId,
+    <primary_arg>: <primaryArg>,
+  } satisfies <Method>Params);
+}
+```
+
+Notes:
+- Decide the positional/options split by which fields are documented `Required: Yes`;
+  required fields become positional args, the rest live in the `form` bag.
+- **Required-only methods** (no optional params) take just the positional args and
+  skip the `form` bag entirely.
+- ESM rule: every relative import carries a **`.js`** extension even though the
+  source is `.ts`. Omitting it breaks the build.
+- A **modified existing method** (a new optional request field) usually needs **no
+  code change** - the field rides in automatically once `<Method>Params` regenerates
+  and the method already passes `Omit<<Method>Params, ...>`. The one exception is
+  serialization (step 4).
+
+## 4. Serialize new structured fields through the `_fix*` pipeline
+
+The Bot API expects nested objects as **JSON strings** on the form body. `_request()`
+in `src/telegram.ts` normalizes them via a series of `_fix*` helpers. If a new field
+is a structured object (an object/array, not a scalar), make sure it goes out
+serialized - for most fields that means appending the key to the list in
+`_fixJsonFields`. One entry there covers **every** method carrying that field.
+
+Fields with bespoke handling (`reply_markup`, `reply_parameters`, the `*_entities`
+family, `message_ids`, `areas`, `link_preview_options`, `suggested_post_parameters`)
+already have their own `_fix*` step - extend those only if a new field is similar in
+spirit. The unit tests in step 5 assert this serialization.
+
+## 5. Unit tests (wire format)
+
+Add a `describe` block per new method in `test/unit/telegram.test.ts`. Unit tests
+stub `globalThis.fetch` and assert the outgoing URL + body params, including that
+structured fields were JSON-stringified. No token, no network. Run with
+`bun test test/unit` (see the **run-tests** skill for detail).
+
+## 6. Integration / e2e tests (probe first, then assert)
+
+**Probe the live API before writing assertions** so each test reflects real
+behavior instead of a guess. A throwaway script that calls each new method against
+`api.telegram.org` tells you which methods happy-path in the test chat and which
+only reject. Then write, for each method, the assertion that matches what you saw:
+
+- **Happy path** when the method works in the test chat - assert the real result.
+- **`ETELEGRAM` rejection** when the method needs a live fixture that cannot be
+  synthesized (a real query id, a private-chat peer, a capability the test bot
+  lacks) - assert `err.code === "ETELEGRAM"`, the same pattern the suite already
+  uses for methods like `approve`/`declineChatJoinRequest`.
+
+Add the blocks to `test/integration/telegram.test.ts`, then run **scoped** to your
+methods (the full suite is slow and flood-limits - see the **run-tests** skill):
+
+```bash
+bun test --timeout 300000 -t '<method1>|<method2>' test/integration/telegram.test.ts
+```
+
+Watch for `-t` substring overlap (a shorter method name can match a longer one).
+
+## 7. Docs and coverage
+
+- Regenerate the API reference whenever a public method was added/changed - see the
+  **generate-docs** skill: `bun run generate:docs` (rewrites `doc/api.md`, commit it).
+- Optionally refresh the coverage audit: `node scripts/coverage-audit.mjs`
+  (rewrites `doc/integration-coverage.md`). Its output uses em dashes, which the
+  commit hook rejects (step 10) - only commit it if you are also resolving that.
+
+## 8. CHANGELOG
+
+Add an entry under `## [Unreleased][Unreleased]` summarizing the new methods, the
+modified method(s), and the headline new types, grouped by the changelog's own
+section headings.
+
+## 9. Verify gate
+
+```bash
+npm run typecheck      # tsc --noEmit over src AND test - the static-analysis gate
+npm run build          # tsc -p tsconfig.build.json -> dist/
+bun test test/unit     # full unit suite
+```
+
+All three must be clean before shipping.
+
+## 10. Ship
+
+Branch off `master`, commit, push, open a PR to `master`.
+
+**ASCII-only commit hook:** a pre-commit hook rejects non-ASCII "smart" punctuation
+(em dash U+2014, curly quotes, invisible spaces) in staged changes - emoji are
+allowed. Hand-written prose (CHANGELOG, comments) must use `-`, `->`, `...`. If a
+**generated** file carries em dashes, do not hand-edit it to satisfy the hook (that
+diverges from the generator and reverts on the next run) - leave it out of the
+commit or fix the generator separately.
+
+Bumping the version and publishing is a **separate** step - use the **release** skill.
+
+## Gotchas checklist
+
+- [ ] Trusted the **raw** changelog, not a WebFetch/LLM summary (hallucinated classes).
+- [ ] Generator exited 0 - no unmapped type strings, no unintended `boolean` fallbacks.
+- [ ] Reviewed the `schemas.ts` diff; every deletion is a union-member add or a
+      field-optional change.
+- [ ] New structured fields added to a `_fix*` step (usually `_fixJsonFields`).
+- [ ] `.js` extensions on all new relative imports.
+- [ ] Integration assertions pinned to **probed** live behavior (happy vs ETELEGRAM).
+- [ ] `typecheck` + `build` + unit suite green.
+- [ ] CHANGELOG and all prose are ASCII.


### PR DESCRIPTION
Adds two Claude Code agent skills under `.claude/skills/` documenting repeatable maintainer workflows (joining the existing `generate-docs` and `run-tests` skills). Docs only - no source, test, or build changes.

### `release/SKILL.md`
End-to-end release runbook: version bump, CHANGELOG entry convention, doc regen, PR to `master`, `npm publish`, git tag, GitHub Release, optional Telegram announcement. Captures the exact step order, the sanity gate, and the credential gotchas (read-only `NPM_TOKEN`, missing `gh` CLI, no create-release MCP tool). Uses env-var references only - no secrets.

### `update-bot-api/SKILL.md`
How to add support for a new Telegram Bot API version:
- Read the changelog from the **raw** page (summaries hallucinate classes).
- Regenerate the type surface with `scripts/api-parser.ts` (strict generator; `RETURN_OVERRIDES` for unresolved returns).
- Inventory the changelog into generated-vs-hand-written work.
- Hand-add the new `TelegramBot` methods (the `Omit<...Params> + satisfies` pattern).
- Serialize new structured fields through the `_fix*` request pipeline.
- Unit (wire-format) + live e2e tests (probe-first; happy-path vs `ETELEGRAM`).
- Docs, CHANGELOG, the verify gate, and the ASCII commit-hook gotcha.

Defers to the existing skills: `run-tests` for running tests, `generate-docs` for `doc/api.md`, `release` for publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)