### PR TITLE
docs(examples): anchor onText command regexes to message start

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ const token = 'YOUR_TELEGRAM_BOT_TOKEN';
 // Create a bot that uses 'polling' to fetch new updates
 const bot = new TelegramBot(token, { polling: true });
 
-// Matches "/echo [whatever]"
-bot.onText(/\/echo (.+)/, (msg, match) => {
+// Matches "/echo [whatever]" - the leading ^ anchors the command to the start of
+// the message, so it won't match "/echo" embedded in a URL or mid-sentence.
+bot.onText(/^\/echo (.+)/, (msg, match) => {
   // 'msg' is the received Message from Telegram
   // 'match' is the result of executing the regexp above on the text content
   // of the message

--- a/examples/game/game.ts
+++ b/examples/game/game.ts
@@ -17,7 +17,7 @@ const bot = new TelegramBot(TOKEN, { polling: true });
 const app = express();
 
 // Matches /start
-bot.onText(/\/start/, (msg) => {
+bot.onText(/^\/start/, (msg) => {
   bot.sendGame(msg.chat.id, gameName);
 });
 

--- a/examples/polling.ts
+++ b/examples/polling.ts
@@ -11,22 +11,23 @@ import TelegramBot, { type CallbackQuery, type Message } from 'node-telegram-bot
 const TOKEN = process.env.TELEGRAM_TOKEN || 'YOUR_TELEGRAM_BOT_TOKEN';
 const bot = new TelegramBot(TOKEN, { polling: true });
 
-// Matches /photo
-bot.onText(/\/photo/, (msg) => {
+// Matches /photo - the leading ^ anchors the command to the start of the message,
+// so it won't match "/photo" embedded in a URL or mid-sentence.
+bot.onText(/^\/photo/, (msg) => {
   // From a file path (resolved relative to this module — ESM has no __dirname).
   const photo = fileURLToPath(new URL('../test/data/photo.gif', import.meta.url));
   bot.sendPhoto(msg.chat.id, photo, { caption: "I'm a bot!" });
 });
 
 // Matches /audio
-bot.onText(/\/audio/, (msg) => {
+bot.onText(/^\/audio/, (msg) => {
   // From an HTTP URL — Telegram downloads it for us, no local upload needed.
   const url = 'https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg';
   bot.sendAudio(msg.chat.id, url);
 });
 
 // Matches /love
-bot.onText(/\/love/, (msg) => {
+bot.onText(/^\/love/, (msg) => {
   bot.sendMessage(msg.chat.id, 'Do you love me?', {
     reply_parameters: { message_id: msg.message_id },
     reply_markup: {
@@ -39,13 +40,13 @@ bot.onText(/\/love/, (msg) => {
 });
 
 // Matches /echo [whatever]
-bot.onText(/\/echo (.+)/, (msg, match) => {
+bot.onText(/^\/echo (.+)/, (msg, match) => {
   const resp = match?.[1] ?? '';
   bot.sendMessage(msg.chat.id, resp);
 });
 
 // Matches /editable
-bot.onText(/\/editable/, (msg) => {
+bot.onText(/^\/editable/, (msg) => {
   bot.sendMessage(msg.chat.id, 'Original Text', {
     reply_markup: {
       inline_keyboard: [


### PR DESCRIPTION
### Description

The `onText` examples used unanchored command regexes such as `/\/echo (.+)/`, which match the command **anywhere** in a message — including inside a URL or mid-sentence (e.g. `http://help.google.com/` or `I found a file under /bin/echo ...` would trigger the `/echo` handler). This anchors every example command with a leading `^` so the handler only fires on an actual command at the **start** of the message, and adds a short comment in the two most-visible spots (README + `examples/polling.ts`) explaining why.

Files:
- `README.md` — `/echo` quick-start example
- `examples/polling.ts` — `/photo`, `/audio`, `/love`, `/echo`, `/editable`
- `examples/game/game.ts` — `/start`

### Credit

Freshly reimplements the fix originally reported by @seadog007 in #1006. That patch predated the TypeScript rewrite (it targeted the old example files) and no longer applied, so this redoes it against the current `examples/` + `README.md`. Closing #1006 in favor of this.

### References

- Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)