### PR TITLE
fix(webhook): authorize the token as a full path segment, not a substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+### Security
+
+- **Webhook path authorization now matches the bot token as a complete path
+  segment** instead of a raw substring. A request is authorized only when the
+  token is a full `/`-delimited segment: the documented `/bot<token>` path, a
+  bare `/<token>`, or either nested under a custom prefix. Paths that merely
+  embed the token (e.g. `/bot<token>extra`) are now rejected with `401`. For
+  stronger authentication, set the `secretToken` option to also validate
+  Telegram's `X-Telegram-Bot-Api-Secret-Token` header.
+
 ## [1.0.0][1.0.0] - 2026-06-12
 
 ### Rewritten in TypeScript

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -130,6 +130,20 @@ export class TelegramBotWebHook {
     this.bot.emit("webhook_error", err);
   }
 
+  /**
+   * Authorize a webhook request by its path. The bot token must appear as a
+   * complete `/`-delimited path segment - either the documented `/bot<token>`
+   * segment or a bare `/<token>` segment (optionally nested under a custom
+   * prefix). Matching whole segments rather than a raw substring means a crafted
+   * path that merely embeds the token (e.g. `/bot<token>extra`) no longer
+   * authorizes. For stronger authentication, set the `secretToken` option to
+   * have Telegram's `X-Telegram-Bot-Api-Secret-Token` header validated as well.
+   */
+  private _isAuthorizedPath(pathname: string): boolean {
+    const token = this.bot.token;
+    return pathname.split("/").some((segment) => segment === token || segment === `bot${token}`);
+  }
+
   private readonly _handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
     debug("WebHook request URL: %s", req.url ?? "");
 
@@ -143,7 +157,7 @@ export class TelegramBotWebHook {
       return;
     }
 
-    if (!pathname.includes(this.bot.token)) {
+    if (!this._isAuthorizedPath(pathname)) {
       debug("WebHook request unauthorized");
       res.statusCode = 401;
       res.end();

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -157,6 +157,29 @@ describe("TelegramBotWebHook (unit)", () => {
       });
     });
 
+    it("accepts a bare /<token> segment, not only /bot<token>", async () => {
+      await withWebHook({}, async ({ port, received }) => {
+        const res = await request(port, {
+          path: `/${TOKEN}`,
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(sampleUpdate),
+        });
+        assert.equal(res.statusCode, 200);
+        assert.equal(received.length, 1);
+      });
+    });
+
+    it("rejects a path that only embeds the token as a substring with 401", async () => {
+      // The token must be a whole path segment: trailing junk inside the segment
+      // (which the old String.includes check accepted) no longer authorizes.
+      await withWebHook({}, async ({ port, received }) => {
+        const res = await request(port, { path: `/bot${TOKEN}extra`, method: "POST", body: "{}" });
+        assert.equal(res.statusCode, 401);
+        assert.equal(received.length, 0);
+      });
+    });
+
     it("rejects non-POST requests on the token path with 418", async () => {
       await withWebHook({}, async ({ port, received }) => {
         const res = await request(port, { path: `/bot${TOKEN}`, method: "GET" });


### PR DESCRIPTION
### Problem

The webhook handler authorized any request whose path **contained** the bot token as a substring (`pathname.includes(this.bot.token)`). That's looser than an exact route check — a crafted path that merely embeds the token anywhere in a segment would authorize. Raised in #1299.

### Change

`src/webhook.ts` now matches the token as a **complete `/`-delimited path segment** (`_isAuthorizedPath`):

- ✅ Still authorizes: the documented `/bot<token>` path, a bare `/<token>`, or either nested under a custom prefix — so existing deployments are unaffected.
- 🔒 Now rejects with `401`: paths that only embed the token, e.g. `/bot<token>extra` or `/prefix<token>`.

`secretToken` (Telegram's `X-Telegram-Bot-Api-Secret-Token`) remains the stronger, recommended authentication and is unchanged.

### Tests

`test/unit/webhook.test.ts` — added two cases: a bare `/<token>` segment is accepted (compat), and a token-embedding-but-not-segment path is rejected with 401 (the hardening).

- `npm run typecheck` — clean
- webhook unit tests — 17 pass / 0 fail
- full unit suite — 93 pass / 0 fail

### Notes

- Behavior change documented under `[Unreleased] → Security` in `CHANGELOG.md`.
- Compatibility: the only setups affected are those whose webhook path embeds the token *within* a larger segment (not as `/bot<token>` or `/<token>`), which is unusual.

### References

- Addresses #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)