### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -757,4 +757,4 @@ Fixed:
 [0.68.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v0.68.0
 [1.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.0.0
 [1.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.0
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.0.0...master
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.1.0...master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-telegram-bot-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",


### PR DESCRIPTION
Release finalization for **v1.1.0** (Bot API 10.1, already merged via #1308).

#1308 bumped `package.json` to 1.1.0 but left two things inconsistent; this fixes them so the release is clean:

- **`package-lock.json`** version (root + `packages[""]`) was still `1.0.0` → bumped to `1.1.0`.
- **CHANGELOG `[Unreleased]` compare link** still pointed at `v1.0.0...master` → updated to `v1.1.0...master`.

Gate: `typecheck` clean, 97/97 unit tests pass, `build` succeeds. After merge: npm publish 1.1.0 (latest) + tag `v1.1.0` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)