### PR TITLE
fix: update createNewStickerSet/addStickerToSet to current Bot API (#1236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,33 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   unaffected.
   ([#1189](https://github.com/yagop/node-telegram-bot-api/issues/1189))
 
+- **Breaking:** `createNewStickerSet` and `addStickerToSet` were still sending the
+  long-removed `png_sticker` / `emojis` fields, which Telegram rejects with
+  `400 Bad Request: invalid sticker emojis`. They now use the current Bot API
+  shape - a single options object carrying `stickers: InputSticker[]` (or a single
+  `sticker: InputSticker`), where each sticker's file (Buffer / stream / local
+  path) is uploaded via an `attach://` part, while a file_id / URL string passes
+  through unchanged.
+  ([#1236](https://github.com/yagop/node-telegram-bot-api/issues/1236))
+
+  ```ts
+  // Before (broken):
+  bot.createNewStickerSet(userId, name, title, pngSticker, "😀");
+
+  // After:
+  bot.createNewStickerSet({
+    user_id: userId,
+    name,
+    title,
+    stickers: [{ sticker: "./a.png", format: "static", emoji_list: ["😀"] }],
+  });
+  bot.addStickerToSet({
+    user_id: userId,
+    name,
+    sticker: { sticker: "./b.webp", format: "static", emoji_list: ["🎈"] },
+  });
+  ```
+
 ## [1.1.0][1.1.0] - 2026-06-13
 
 ### Bot API 10.1 (June 11, 2026)

--- a/doc/api.md
+++ b/doc/api.md
@@ -158,8 +158,8 @@
         * [.getStickerSet(name, [options])](#TelegramBot+getStickerSet) ⇒ <code>Promise</code>
         * [.getCustomEmojiStickers(customEmojiIds, [options])](#TelegramBot+getCustomEmojiStickers) ⇒ <code>Promise</code>
         * [.uploadStickerFile(userId, sticker, [stickerFormat], [options], [fileOptions])](#TelegramBot+uploadStickerFile) ⇒ <code>Promise</code>
-        * [.createNewStickerSet(userId, name, title, pngSticker, emojis, [options], [fileOptions])](#TelegramBot+createNewStickerSet) ⇒ <code>Promise</code>
-        * [.addStickerToSet(userId, name, sticker, emojis, [stickerType], [options], [fileOptions])](#TelegramBot+addStickerToSet) ⇒ <code>Promise</code>
+        * [.createNewStickerSet([params])](#TelegramBot+createNewStickerSet) ⇒ <code>Promise</code>
+        * [.addStickerToSet([params])](#TelegramBot+addStickerToSet) ⇒ <code>Promise</code>
         * [.setStickerPositionInSet(sticker, position, [options])](#TelegramBot+setStickerPositionInSet) ⇒ <code>Promise</code>
         * [.deleteStickerFromSet(sticker, [options])](#TelegramBot+deleteStickerFromSet) ⇒ <code>Promise</code>
         * [.replaceStickerInSet(userId, name, oldSticker, [options])](#TelegramBot+replaceStickerInSet) ⇒ <code>Promise</code>
@@ -2410,7 +2410,11 @@ accepted for the primary `media`.
 
 <a name="TelegramBot+createNewStickerSet"></a>
 
-### telegramBot.createNewStickerSet(userId, name, title, pngSticker, emojis, [options], [fileOptions]) ⇒ <code>Promise</code>
+### telegramBot.createNewStickerSet([params]) ⇒ <code>Promise</code>
+Create a new sticker set owned by a user. Each entry in `stickers` is an
+{@link InputStickerInput} whose `sticker` accepts a file (Buffer / stream /
+local path, uploaded as an `attach://` part) or a file_id / URL string, plus
+the sticker's `format`, `emoji_list`, and optional `mask_position`/`keywords`.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
 
@@ -2420,17 +2424,14 @@ accepted for the primary `media`.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| userId | <code>Number</code> |  |
-| name | <code>String</code> |  |
-| title | <code>String</code> |  |
-| pngSticker | <code>String \| Stream \| Buffer</code> |  |
-| emojis | <code>String</code> |  |
-| [options] | <code>Object</code> |  |
-| [fileOptions] | <code>Object</code> | Additional file options |
+| [params] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+addStickerToSet"></a>
 
-### telegramBot.addStickerToSet(userId, name, sticker, emojis, [stickerType], [options], [fileOptions]) ⇒ <code>Promise</code>
+### telegramBot.addStickerToSet([params]) ⇒ <code>Promise</code>
+Add a sticker to an existing set. The `sticker` is an
+{@link InputStickerInput} whose `sticker` field accepts a file (Buffer /
+stream / local path, uploaded as an `attach://` part) or a file_id / URL string.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
 
@@ -2440,13 +2441,7 @@ accepted for the primary `media`.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| userId | <code>Number</code> |  |
-| name | <code>String</code> |  |
-| sticker | <code>String \| Stream \| Buffer</code> |  |
-| emojis | <code>String</code> |  |
-| [stickerType] | <code>Object</code> |  |
-| [options] | <code>Object</code> |  |
-| [fileOptions] | <code>Object</code> | Additional file options |
+| [params] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+setStickerPositionInSet"></a>
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -47,6 +47,7 @@ import type {
   InputPollOption,
   InputMedia,
   InputFile,
+  InputSticker,
   InputStoryContent,
   InputChecklist,
   KeyboardButton,
@@ -98,6 +99,8 @@ import type {
   PromoteChatMemberParams,
   SetChatMemberTagParams,
   SetChatPermissionsParams,
+  CreateNewStickerSetParams,
+  AddStickerToSetParams,
   CreateChatInviteLinkParams,
   EditChatInviteLinkParams,
   CreateChatSubscriptionInviteLinkParams,
@@ -533,6 +536,14 @@ type SendMediaGroupMedia = Uploadable<SendMediaGroupParams["media"][number]>;
 type SendPaidMediaMedia = Uploadable<SendPaidMediaParams["media"][number]>;
 
 /**
+ * Input for a single sticker in `createNewStickerSet` / `addStickerToSet`: the
+ * docs-faithful {@link InputSticker} but with `sticker` widened to an
+ * {@link InputFile} so a Buffer / stream / local path can be uploaded (resolved
+ * to an `attach://` reference), while a file_id / URL string passes through.
+ */
+type InputStickerInput = Omit<InputSticker, "sticker"> & { sticker: InputFile; fileOptions?: FileMeta };
+
+/**
  * The TelegramBot class is the main entry point of the library. It provides
  * methods that map 1:1 to the Telegram Bot API and emits events for incoming
  * updates received via either long polling or a webhook server.
@@ -791,6 +802,33 @@ export class TelegramBot extends EventEmitter {
       inputMedia.push(payload as ResolvedMedia);
     }
     return { inputMedia, formData };
+  }
+
+  /**
+   * Resolve an array of {@link InputStickerInput} into the docs-faithful
+   * {@link InputSticker}[] wire shape plus the multipart `formData`. A
+   * file-bearing `sticker` (Buffer / stream / local path) is uploaded under a
+   * `sticker<index>` part name and rewritten to an `attach://` reference; a
+   * file_id / URL string passes through unchanged. Shared by
+   * `createNewStickerSet` and `addStickerToSet`.
+   */
+  private async _buildStickerItems(
+    stickers: ReadonlyArray<InputStickerInput>,
+  ): Promise<{ stickers: InputSticker[]; formData: Record<string, PreparedFile> }> {
+    const formData: Record<string, PreparedFile> = {};
+    const resolved: InputSticker[] = [];
+    for (const [index, item] of stickers.entries()) {
+      const { sticker: data, fileOptions, ...rest } = item;
+      const attachName = `sticker${index}`;
+      const { file, fileId } = await prepareFile(data, fileOptions, this.options.filepath);
+      if (file) {
+        formData[attachName] = file;
+        resolved.push({ ...rest, sticker: `attach://${attachName}` });
+      } else {
+        resolved.push({ ...rest, sticker: fileId ?? "" });
+      }
+    }
+    return { stickers: resolved, formData };
   }
 
   // --- High-level lifecycle ----------------------------------------------
@@ -2267,37 +2305,37 @@ export class TelegramBot extends EventEmitter {
       fileOptions,
     );
   }
-  createNewStickerSet(
-    userId: number,
-    name: string,
-    title: string,
-    pngSticker: FileInput,
-    emojis: string,
-    options: { mask_position?: MaskPosition; sticker_type?: string; needs_repainting?: boolean } = {},
-    fileOptions: FileMeta = {},
+  /**
+   * Create a new sticker set owned by a user. Each entry in `stickers` is an
+   * {@link InputStickerInput} whose `sticker` accepts a file (Buffer / stream /
+   * local path, uploaded as an `attach://` part) or a file_id / URL string, plus
+   * the sticker's `format`, `emoji_list`, and optional `mask_position`/`keywords`.
+   * @see https://core.telegram.org/bots/api#createnewstickerset
+   */
+  async createNewStickerSet(
+    params: Omit<CreateNewStickerSetParams, "stickers"> & { stickers: InputStickerInput[] },
   ): Promise<CreateNewStickerSetResult> {
-    const form: { sticker_type?: string; needs_repainting?: boolean; mask_position?: MaskPosition | string; user_id: number; name: string; title: string; emojis: string } =
-      { ...options, user_id: userId, name, title, emojis };
-    if (options.mask_position) form.mask_position = stringify(options.mask_position);
-    return this._sendFile("createNewStickerSet", "png_sticker", pngSticker, form, fileOptions);
+    const { stickers: stickerInputs, ...rest } = params;
+    const { stickers, formData } = await this._buildStickerItems(stickerInputs);
+    const form: Omit<CreateNewStickerSetParams, "stickers"> & { stickers?: string } = { ...rest };
+    form.stickers = stringify(stickers);
+    return this._request("createNewStickerSet", { form, formData });
   }
 
-  addStickerToSet(
-    userId: number,
-    name: string,
-    sticker: FileInput,
-    emojis: string,
-    stickerType: "png_sticker" | "tgs_sticker" | "webm_sticker" = "png_sticker",
-    options: { mask_position?: MaskPosition } = {},
-    fileOptions: FileMeta = {},
+  /**
+   * Add a sticker to an existing set. The `sticker` is an
+   * {@link InputStickerInput} whose `sticker` field accepts a file (Buffer /
+   * stream / local path, uploaded as an `attach://` part) or a file_id / URL string.
+   * @see https://core.telegram.org/bots/api#addstickertoset
+   */
+  async addStickerToSet(
+    params: Omit<AddStickerToSetParams, "sticker"> & { sticker: InputStickerInput },
   ): Promise<AddStickerToSetResult> {
-    if (!["png_sticker", "tgs_sticker", "webm_sticker"].includes(stickerType)) {
-      return Promise.reject(new Error("stickerType must be one of: png_sticker, tgs_sticker, webm_sticker"));
-    }
-    const form: { mask_position?: MaskPosition | string; user_id: number; name: string; emojis: string } =
-      { ...options, user_id: userId, name, emojis };
-    if (options.mask_position) form.mask_position = stringify(options.mask_position);
-    return this._sendFile("addStickerToSet", stickerType, sticker, form, fileOptions);
+    const { sticker, ...rest } = params;
+    const { stickers, formData } = await this._buildStickerItems([sticker]);
+    const form: Omit<AddStickerToSetParams, "sticker"> & { sticker?: string } = { ...rest };
+    form.sticker = stringify(stickers[0]);
+    return this._request("addStickerToSet", { form, formData });
   }
 
   setStickerPositionInSet(sticker: string, position: number, form: {} = {}): Promise<SetStickerPositionInSetResult> {

--- a/test/integration/telegram.test.ts
+++ b/test/integration/telegram.test.ts
@@ -2259,7 +2259,12 @@ describe("Telegram Bot API (integration)", () => {
       assert.ok(uploadedFileId.length > 0);
       await sleep(1100);
 
-      await bot.createNewStickerSet(USER_ID, setName, "Integration Test Set", STICKER_PATH, "😀");
+      await bot.createNewStickerSet({
+        user_id: USER_ID,
+        name: setName,
+        title: "Integration Test Set",
+        stickers: [{ sticker: STICKER_PATH, format: "static", emoji_list: ["😀"] }],
+      });
     });
 
     after(async () => {
@@ -2273,7 +2278,11 @@ describe("Telegram Bot API (integration)", () => {
     });
 
     it("addStickerToSet appends a sticker", async () => {
-      const ok = await bot.addStickerToSet(USER_ID, setName, STICKER_WEBP_PATH, "🎈");
+      const ok = await bot.addStickerToSet({
+        user_id: USER_ID,
+        name: setName,
+        sticker: { sticker: STICKER_WEBP_PATH, format: "static", emoji_list: ["🎈"] },
+      });
       assert.equal(ok, true);
       const set = await bot.getStickerSet(setName);
       assert.ok(set.stickers.length >= 2);
@@ -2338,8 +2347,12 @@ describe("Telegram Bot API (integration)", () => {
       const me = await bot.getMe();
       maskSetName = `m${TIMESTAMP}_by_${me.username}`;
       await sleep(1100);
-      await bot.createNewStickerSet(USER_ID, maskSetName, "Integration Mask Set", STICKER_PATH, "😀", {
+      await bot.createNewStickerSet({
+        user_id: USER_ID,
+        name: maskSetName,
+        title: "Integration Mask Set",
         sticker_type: "mask",
+        stickers: [{ sticker: STICKER_PATH, format: "static", emoji_list: ["😀"] }],
       });
     });
 
@@ -2365,8 +2378,12 @@ describe("Telegram Bot API (integration)", () => {
       const me = await bot.getMe();
       emojiSetName = `e${TIMESTAMP}_by_${me.username}`;
       await sleep(1100);
-      await bot.createNewStickerSet(USER_ID, emojiSetName, "Integration Emoji Set", STICKER_EMOJI_PATH, "😀", {
+      await bot.createNewStickerSet({
+        user_id: USER_ID,
+        name: emojiSetName,
+        title: "Integration Emoji Set",
         sticker_type: "custom_emoji",
+        stickers: [{ sticker: STICKER_EMOJI_PATH, format: "static", emoji_list: ["😀"] }],
       });
     });
 

--- a/test/unit/telegram.test.ts
+++ b/test/unit/telegram.test.ts
@@ -475,6 +475,76 @@ describe("TelegramBot (unit)", () => {
     });
   });
 
+  describe("createNewStickerSet()", () => {
+    it("uploads file-bearing stickers as attach:// parts and serializes the stickers array", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      const a = Buffer.from("\x89PNG-A", "binary");
+      const b = Buffer.from("\x89PNG-B", "binary");
+
+      await bot.createNewStickerSet({
+        user_id: 42,
+        name: "set_by_bot",
+        title: "My Set",
+        sticker_type: "regular",
+        stickers: [
+          { sticker: a, format: "static", emoji_list: ["😀"] },
+          { sticker: b, format: "static", emoji_list: ["🎈"], keywords: ["balloon"] },
+        ],
+      });
+
+      const fd = captured.at(-1)!.init.body as FormData;
+      assert.equal(fd.get("user_id"), "42");
+      assert.equal(fd.get("name"), "set_by_bot");
+      assert.equal(fd.get("title"), "My Set");
+      assert.equal(fd.get("sticker_type"), "regular");
+      const stickers = JSON.parse(String(fd.get("stickers"))) as Array<Record<string, unknown>>;
+      // File-bearing stickers become attach:// references, never serialized Buffers.
+      assert.equal(stickers[0]!.sticker, "attach://sticker0");
+      assert.deepEqual(stickers[0]!.emoji_list, ["😀"]);
+      assert.equal(stickers[1]!.sticker, "attach://sticker1");
+      assert.deepEqual(stickers[1]!.keywords, ["balloon"]);
+      // ...and the files are attached as real multipart parts.
+      assert.ok(fd.get("sticker0") instanceof Blob);
+      assert.ok(fd.get("sticker1") instanceof Blob);
+    });
+
+    it("passes file_id / URL stickers through without uploading (urlencoded body)", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      await bot.createNewStickerSet({
+        user_id: 1,
+        name: "s",
+        title: "t",
+        stickers: [{ sticker: "sticker-file-id", format: "static", emoji_list: ["😀"] }],
+      });
+      // No uploads -> urlencoded body, not multipart FormData.
+      const params = new URLSearchParams(String(captured.at(-1)!.init.body));
+      const stickers = JSON.parse(String(params.get("stickers"))) as Array<Record<string, unknown>>;
+      assert.equal(stickers[0]!.sticker, "sticker-file-id");
+    });
+  });
+
+  describe("addStickerToSet()", () => {
+    it("uploads the sticker file and serializes a single InputSticker object", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      const buf = Buffer.from("\x89PNG-X", "binary");
+      await bot.addStickerToSet({
+        user_id: 7,
+        name: "set_by_bot",
+        sticker: { sticker: buf, format: "static", emoji_list: ["🎈"] },
+      });
+      const fd = captured.at(-1)!.init.body as FormData;
+      assert.equal(fd.get("user_id"), "7");
+      assert.equal(fd.get("name"), "set_by_bot");
+      const sticker = JSON.parse(String(fd.get("sticker"))) as Record<string, unknown>;
+      assert.equal(sticker.sticker, "attach://sticker0");
+      assert.deepEqual(sticker.emoji_list, ["🎈"]);
+      assert.ok(fd.get("sticker0") instanceof Blob);
+    });
+  });
+
   describe("setMyProfilePhoto()", () => {
     it("posts static photo with InputProfilePhoto struct and file in formData", async () => {
       stubFetch(() => ({ ok: true, result: true }));


### PR DESCRIPTION
## Problem

`createNewStickerSet` and `addStickerToSet` were hand-ported from the pre-6.6 Bot API and still send the long-removed `png_sticker` / `emojis` fields. Telegram rejects that with `400 Bad Request: invalid sticker emojis`, so both methods are unusable on the current API.

Refs #1236

## Fix

Rewrite both to the current API, using the single options-object shape (matches the generated `CreateNewStickerSetParams` / `AddStickerToSetParams`):

```js
bot.createNewStickerSet({
  user_id, name, title, sticker_type: 'regular',
  stickers: [{ sticker: './a.png', format: 'static', emoji_list: ['😀'] }],
});

bot.addStickerToSet({
  user_id, name,
  sticker: { sticker: './b.webp', format: 'static', emoji_list: ['🎈'] },
});
```

- Each sticker's `sticker` accepts a file (Buffer / stream / local path) which is uploaded as an `attach://sticker<i>` multipart part, or a file_id / URL string which passes through unchanged.
- New private helper `_buildStickerItems()` mirrors the existing `_buildMediaItems()` (`sendMediaGroup` / `sendPaidMedia`).
- New internal input type `InputStickerInput` (the docs-faithful `InputSticker` with `sticker` widened to `InputFile`), following the same unexported pattern as `SendMediaGroupMedia`.

## Breaking change

Both public method signatures change from the old positional form (`createNewStickerSet(userId, name, title, pngSticker, emojis, ...)`) to a single options object. Documented under **Breaking** in the CHANGELOG. Under semver this warrants a major bump.

## Tests / verification

- `npm run typecheck` clean; `npm run build` clean (declarations reference the new type correctly).
- Unit (`test/unit/telegram.test.ts`): **45/45 pass**, incl. 3 new (attach:// wiring, file_id passthrough -> urlencoded, single-object serialization).
- **Live API** (the real proof, since the bug was a Telegram 400):
  - full sticker lifecycle create -> add -> title -> thumbnail -> position -> emoji -> keywords -> replace -> delete = **9/9 pass**
  - mask-set create = **1/1**; custom_emoji-set create = **1/1**

## Notes / follow-up (out of scope)

`replaceStickerInSet` still routes through `_form` and does **not** upload a file-bearing `InputSticker.sticker` via `attach://` (only file_id / URL works there). Same root cause; could be fixed with the same `_buildStickerItems` helper in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)