### PR TITLE
fix: support Buffer/stream/path uploads in editMessageMedia (#1189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   });
   ```
 
+### Fixed
+
+- `editMessageMedia` now accepts a Buffer / stream / local file path for the new
+  `media` (and its `thumbnail` / `cover`), uploading it via an `attach://` part -
+  previously only a file_id / URL or the legacy `attach://<local-path>` form
+  worked. Resolved through the same `_buildMediaItems` pipeline as
+  `sendMediaGroup`; string callers and the old `attach://<local-path>` form are
+  unaffected.
+  ([#1189](https://github.com/yagop/node-telegram-bot-api/issues/1189))
+
 ## [1.1.0][1.1.0] - 2026-06-13
 
 ### Bot API 10.1 (June 11, 2026)

--- a/doc/api.md
+++ b/doc/api.md
@@ -825,8 +825,8 @@ Send a group of photos / videos / etc as an album. Each item's file fields are
 widened to accept uploads: the primary `media` plus any `thumbnail` / `cover`
 (video) or `photo` (live photo) may be a Buffer / stream / local path (uploaded
 as a multipart part) or a file_id / URL string (passed through).
-{@link _buildMediaItems} resolves every file field of every item - unlike
-{@link editMessageMedia}, whose secondary fields are string-only.
+{@link _buildMediaItems} resolves every file field of every item, shared with
+{@link sendPaidMedia} and {@link editMessageMedia}.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
 
@@ -2245,14 +2245,11 @@ JPEG before calling.
 <a name="TelegramBot+editMessageMedia"></a>
 
 ### telegramBot.editMessageMedia(media, [options]) ⇒ <code>Promise</code>
-Edit a message's media. Unlike {@link sendMediaGroup} / {@link sendPaidMedia},
-the `media` argument is the docs-faithful `InputMedia`, so every file field is
-typed `string` and NOT widened to accept uploads:
-  - Secondary fields (`thumbnail` / `cover` / `photo`) must be file_id / URL
-    strings; they pass through untouched. Uploading a *new* secondary file is
-    not supported here (the method attaches only the single primary part).
-  - The primary `media` is uploaded only when given as `attach://<local-path>`;
-    a plain file_id / URL is sent as-is.
+Edit a message's media. The `media` (and its `thumbnail` / `cover`) accept a
+file (Buffer / stream / local path, uploaded via an `attach://` part) or a
+file_id / URL string (passed through), resolved by {@link _buildMediaItems}
+like {@link sendMediaGroup}. The legacy `attach://<local-path>` form is still
+accepted for the primary `media`.
 
 **Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -757,7 +757,7 @@ export class TelegramBot extends EventEmitter {
    * into the request's `media` field.
    */
   private async _buildMediaItems(
-    media: ReadonlyArray<SendMediaGroupMedia | SendPaidMediaMedia>,
+    media: ReadonlyArray<SendMediaGroupMedia | SendPaidMediaMedia | Uploadable<InputMedia>>,
   ): Promise<{ inputMedia: ResolvedMedia[]; formData: Record<string, PreparedFile> }> {
     const formData: Record<string, PreparedFile> = {};
     const inputMedia: ResolvedMedia[] = [];
@@ -1275,8 +1275,8 @@ export class TelegramBot extends EventEmitter {
    * widened to accept uploads: the primary `media` plus any `thumbnail` / `cover`
    * (video) or `photo` (live photo) may be a Buffer / stream / local path (uploaded
    * as a multipart part) or a file_id / URL string (passed through).
-   * {@link _buildMediaItems} resolves every file field of every item - unlike
-   * {@link editMessageMedia}, whose secondary fields are string-only.
+   * {@link _buildMediaItems} resolves every file field of every item, shared with
+   * {@link sendPaidMedia} and {@link editMessageMedia}.
    */
   async sendMediaGroup(
     chatId: ChatId,
@@ -2140,38 +2140,28 @@ export class TelegramBot extends EventEmitter {
     } satisfies EditMessageCaptionParams);
   }
   /**
-   * Edit a message's media. Unlike {@link sendMediaGroup} / {@link sendPaidMedia},
-   * the `media` argument is the docs-faithful `InputMedia`, so every file field is
-   * typed `string` and NOT widened to accept uploads:
-   *   - Secondary fields (`thumbnail` / `cover` / `photo`) must be file_id / URL
-   *     strings; they pass through untouched. Uploading a *new* secondary file is
-   *     not supported here (the method attaches only the single primary part).
-   *   - The primary `media` is uploaded only when given as `attach://<local-path>`;
-   *     a plain file_id / URL is sent as-is.
+   * Edit a message's media. The `media` (and its `thumbnail` / `cover`) accept a
+   * file (Buffer / stream / local path, uploaded via an `attach://` part) or a
+   * file_id / URL string (passed through), resolved by {@link _buildMediaItems}
+   * like {@link sendMediaGroup}. The legacy `attach://<local-path>` form is still
+   * accepted for the primary `media`.
    */
   async editMessageMedia(
-    media: InputMedia & { fileOptions?: FileMeta },
+    media: Uploadable<InputMedia>,
     form: Omit<EditMessageMediaParams, "media"> = {},
   ): Promise<EditMessageMediaResult> {
-    const regexAttach = /^attach:\/\/.+/;
-    // `attach://<local-path>` => upload that one file as part "0"; any thumbnail /
-    // cover / photo on the item are already strings and ride along in the payload.
-    if (typeof media.media === "string" && regexAttach.test(media.media)) {
-      const out: Omit<EditMessageMediaParams, "media"> & { media?: string } = { ...form };
-      const payload: Record<string, unknown> = { ...media };
-      delete payload.media;
-      delete payload.fileOptions;
-      const attachName = "0";
-      const data = (media.media as string).replace("attach://", "");
-      const { file } = await prepareFile(data, media.fileOptions, this.options.filepath);
-      if (!file) throw new FatalError(`Failed to process the replacement action for your ${media.type}`);
-      payload.media = `attach://${attachName}`;
-      out.media = stringify(payload);
-      return this._request("editMessageMedia", { form: out, formData: { [attachName]: file } });
+    const item = { ...media };
+    // Back-compat: the old API took the new file as `attach://<local-path>`. Strip
+    // the prefix so the path is uploaded like any other file input.
+    if (typeof item.media === "string" && item.media.startsWith("attach://")) {
+      item.media = item.media.slice("attach://".length);
     }
-    // Plain file_id / URL: no upload, just JSON-serialize the whole InputMedia.
-    const out: Omit<EditMessageMediaParams, "media"> & { media: string } = { ...form, media: stringify(media) };
-    return this._form("editMessageMedia", out);
+    const { inputMedia, formData } = await this._buildMediaItems([item]);
+    const out: Omit<EditMessageMediaParams, "media"> & { media: string } = {
+      ...form,
+      media: stringify(inputMedia[0]!),
+    };
+    return this._request("editMessageMedia", { form: out, formData });
   }
 
   editMessageChecklist(

--- a/test/integration/telegram.test.ts
+++ b/test/integration/telegram.test.ts
@@ -1419,6 +1419,16 @@ describe("Telegram Bot API (integration)", () => {
       assert.ok(edited === true || typeof edited === "object");
     });
 
+    it("replaces a photo using a Buffer upload", async () => {
+      const sent = await bot.sendPhoto(GROUP_ID, STICKER_THUMB_PATH);
+      const buf = fs.readFileSync(PHOTO_PATH);
+      const edited = await bot.editMessageMedia(
+        { type: "photo", media: buf, fileOptions: { filename: "photo.png", contentType: "image/png" } },
+        { chat_id: GROUP_ID, message_id: sent.message_id },
+      );
+      assert.ok(edited === true || typeof edited === "object");
+    });
+
     it("replaces a photo using a Telegram file_id (with caption + reply_markup)", async () => {
       // Send a different image first so swapping in `photoFileId` is a real change.
       const sent = await bot.sendPhoto(GROUP_ID, STICKER_THUMB_PATH);

--- a/test/unit/telegram.test.ts
+++ b/test/unit/telegram.test.ts
@@ -429,6 +429,52 @@ describe("TelegramBot (unit)", () => {
     });
   });
 
+  describe("editMessageMedia()", () => {
+    it("uploads a Buffer as an attach:// part", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      const buf = Buffer.from("\xff\xd8\xff\xe0NEW", "binary");
+      await bot.editMessageMedia(
+        { type: "photo", media: buf, caption: "x" },
+        { chat_id: 1, message_id: 2 },
+      );
+      const fd = captured.at(-1)!.init.body as FormData;
+      const inputMedia = JSON.parse(String(fd.get("media"))) as Record<string, unknown>;
+      assert.equal(inputMedia.media, "attach://0_media");
+      assert.equal(inputMedia.caption, "x");
+      assert.ok(fd.get("0_media") instanceof Blob);
+    });
+
+    it("uploads a video's thumbnail Buffer alongside the media", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      const video = Buffer.from("FAKE-MP4");
+      const thumb = Buffer.from("\xff\xd8\xff\xe0THUMB", "binary");
+      await bot.editMessageMedia(
+        { type: "video", media: video, thumbnail: thumb },
+        { chat_id: 1, message_id: 2 },
+      );
+      const fd = captured.at(-1)!.init.body as FormData;
+      const inputMedia = JSON.parse(String(fd.get("media"))) as Record<string, unknown>;
+      assert.equal(inputMedia.media, "attach://0_media");
+      assert.equal(inputMedia.thumbnail, "attach://0_thumbnail");
+      assert.ok(fd.get("0_media") instanceof Blob);
+      assert.ok(fd.get("0_thumbnail") instanceof Blob);
+    });
+
+    it("passes a file_id through without uploading (urlencoded body)", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      await bot.editMessageMedia(
+        { type: "photo", media: "photo-file-id" },
+        { chat_id: 1, message_id: 2 },
+      );
+      const params = new URLSearchParams(String(captured.at(-1)!.init.body));
+      const inputMedia = JSON.parse(String(params.get("media"))) as Record<string, unknown>;
+      assert.equal(inputMedia.media, "photo-file-id");
+    });
+  });
+
   describe("setMyProfilePhoto()", () => {
     it("posts static photo with InputProfilePhoto struct and file in formData", async () => {
       stubFetch(() => ({ ok: true, result: true }));


### PR DESCRIPTION
## Problem

`editMessageMedia` could only upload a *new* file when `media` was passed as `attach://<local-path>`. A **Buffer / stream**, or even a plain local path, was unsupported (the field was typed `string`), and the secondary fields (`thumbnail` / `cover`) were string-only. Every other send method accepts a Buffer/stream/path, so this was an inconsistency.

Refs #1189

## Fix

Route `media` through the same `_buildMediaItems` pipeline used by `sendMediaGroup` / `sendPaidMedia`:

- The primary `media` and its `thumbnail` / `cover` now accept a **Buffer / stream / local path** (uploaded as an `attach://` multipart part) or a **file_id / URL** string (passed through).
- `media` is widened from `InputMedia` to `Uploadable<InputMedia>` (the existing helper that widens file fields to `InputFile`).
- `_buildMediaItems`'s parameter type is broadened to also accept `Uploadable<InputMedia>`.

```js
// Now works (previously a type error / unsupported):
await bot.editMessageMedia(
  { type: 'photo', media: fs.readFileSync('new.png') },
  { chat_id, message_id },
);
```

## Non-breaking

- `string` callers are unaffected (`string` is assignable to `InputFile`).
- The legacy `attach://<local-path>` form is still accepted (the prefix is stripped and the path uploaded).
- `file_id` / URL callers still produce a urlencoded body (no multipart).

## Tests / verification

- `npm run typecheck` clean; `npm run build` clean.
- Unit (`test/unit/telegram.test.ts`): **45/45 pass**, incl. 3 new (Buffer -> `attach://0_media`; video `thumbnail` Buffer -> `attach://0_thumbnail`; file_id -> urlencoded passthrough).
- **Live API**: `editMessageMedia` scoped run = **3/3 pass** (attach:// path, **Buffer upload**, file_id with caption + reply_markup).
- Regenerated `doc/api.md`; corrected a now-stale `sendMediaGroup` doc comment that claimed editMessageMedia's secondary fields were string-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)