### PR TITLE
feat(http): per-instance request.fetch and request.fetchOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+### Added
+
+- `request.fetch` and `request.fetchOptions` options (on the `TelegramBot`
+  constructor / `HttpClient`), for per-instance transport customization. Pass a
+  custom `fetch` implementation (e.g. undici's `fetch` bound to a `ProxyAgent`),
+  or extra fetch init such as an undici `dispatcher`, scoped to a single bot
+  instance - no `setGlobalDispatcher`, so other clients in the process are
+  unaffected. This restores the per-instance proxy capability that the legacy
+  `request.agent` provided before the move to the built-in `fetch`. (#1319)
+
+  ```ts
+  import TelegramBot from "node-telegram-bot-api";
+  import { ProxyAgent } from "undici";
+
+  const bot = new TelegramBot(token, {
+    polling: true,
+    request: { fetchOptions: { dispatcher: new ProxyAgent("http://127.0.0.1:8080") } },
+  });
+  ```
+
 ## [1.1.0][1.1.0] - 2026-06-13
 
 ### Bot API 10.1 (June 11, 2026)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ bot.on('message', (msg) => {
 
 More runnable examples live in the [`examples/`](./examples) directory.
 
+## 🌐 Proxy / custom transport
+
+Requests use the built-in `fetch`. To route a **single bot instance** through a
+proxy (without affecting the rest of the process), pass an undici `dispatcher` via
+`request.fetchOptions`:
+
+```ts
+import TelegramBot from 'node-telegram-bot-api';
+import { ProxyAgent } from 'undici';
+
+const bot = new TelegramBot(token, {
+  polling: true,
+  request: { fetchOptions: { dispatcher: new ProxyAgent('http://127.0.0.1:8080') } },
+});
+```
+
+For full control you can supply your own `fetch` implementation instead via
+`request.fetch` (useful for custom proxying, instrumentation, or tests). Both are
+scoped to that bot instance, so different bots can use different proxies.
+
 ## 📚 Documentation
 
 * [Usage][usage]

--- a/src/http.ts
+++ b/src/http.ts
@@ -56,6 +56,28 @@ export interface HttpClientOptions {
      * to opt out. Defaults to `2`.
      */
     maxRetriesOn429?: number;
+    /**
+     * Custom `fetch` implementation, used in place of the global `fetch` for
+     * every request from this client. The seam for per-instance proxying,
+     * instrumentation, or test doubles - e.g. wrap undici's `fetch` bound to a
+     * `ProxyAgent` dispatcher (no `setGlobalDispatcher`, so other clients in the
+     * process are unaffected). Defaults to `globalThis.fetch`.
+     */
+    fetch?: typeof fetch;
+    /**
+     * Extra `fetch` init merged into every request - the place to pass options
+     * the standard `RequestInit` does not type, most notably an undici
+     * `dispatcher` for a per-instance proxy:
+     *
+     * ```ts
+     * import { ProxyAgent } from "undici";
+     * new TelegramBot(token, { request: { fetchOptions: { dispatcher: new ProxyAgent(proxyUrl) } } });
+     * ```
+     *
+     * The client's own `method`/`body`/`headers`/`signal` always win over these,
+     * so they cannot be overridden here. `dispatcher` is Node-only (undici).
+     */
+    fetchOptions?: RequestInit & { dispatcher?: unknown };
   };
 }
 
@@ -193,14 +215,22 @@ export class HttpClient {
     }
     const timer = timeoutMs ? setTimeout(() => controller.abort(new Error("HTTP timeout")), timeoutMs) : null;
 
+    // Per-instance fetch seam: a caller-supplied `fetch` (e.g. undici bound to a
+    // ProxyAgent) replaces the global; `fetchOptions` are merged in first so the
+    // controlled fields below always win and a caller cannot clobber the
+    // method/body/headers/abort signal.
+    const fetchImpl = this.options.request?.fetch ?? fetch;
+    const extraInit = this.options.request?.fetchOptions;
+
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await fetchImpl(url, {
+        ...extraInit,
         method: "POST",
         body: body as BodyInit | undefined,
         headers,
         signal: controller.signal,
-      });
+      } as RequestInit);
     } catch (err) {
       throw new FatalError(err as Error);
     } finally {

--- a/test/unit/http.test.ts
+++ b/test/unit/http.test.ts
@@ -73,3 +73,51 @@ describe("HttpClient 429 handling", () => {
     assert.equal(calls, 1);
   });
 });
+
+describe("HttpClient custom fetch / fetchOptions", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses request.fetch instead of the global fetch", async () => {
+    // The global must NOT be called when a custom fetch is supplied.
+    globalThis.fetch = (async () => {
+      throw new Error("global fetch should not be called");
+    }) as typeof fetch;
+
+    let used = 0;
+    const custom: typeof fetch = async () =>
+      new Response(JSON.stringify(ok), { status: 200, headers: { "content-type": "application/json" } });
+    const spy: typeof fetch = (input, init) => {
+      used++;
+      return custom(input, init);
+    };
+
+    const client = new HttpClient("TOKEN", { request: { fetch: spy } });
+    const result = await client.request<{ id: number }>("getMe");
+    assert.deepEqual(result, { id: 1 });
+    assert.equal(used, 1, "the injected fetch should be used");
+  });
+
+  it("merges fetchOptions (e.g. dispatcher) into the init, controlled fields win", async () => {
+    let seen: (RequestInit & { dispatcher?: unknown }) | undefined;
+    const dispatcher = { marker: "proxy-agent" };
+    const spy: typeof fetch = async (_input, init) => {
+      seen = init as RequestInit & { dispatcher?: unknown };
+      return new Response(JSON.stringify(ok), { status: 200, headers: { "content-type": "application/json" } });
+    };
+
+    const client = new HttpClient("TOKEN", {
+      request: {
+        fetch: spy,
+        // method must NOT be overridable; dispatcher must pass through.
+        fetchOptions: { dispatcher, method: "GET" } as RequestInit & { dispatcher?: unknown },
+      },
+    });
+    await client.request("getMe");
+
+    assert.equal(seen?.dispatcher, dispatcher, "dispatcher is forwarded to fetch");
+    assert.equal(seen?.method, "POST", "the client's method wins over fetchOptions");
+    assert.ok(seen?.signal, "the client's abort signal is preserved");
+  });
+});


### PR DESCRIPTION
Add a transport seam to the HttpClient `request` options so a single bot instance can be proxied or otherwise customized without touching the process-wide fetch:

- `request.fetch`: a custom fetch implementation (e.g. undici bound to a ProxyAgent), used in place of the global fetch.
- `request.fetchOptions`: extra fetch init merged into every request - the place to pass an undici `dispatcher` (per-instance proxy) or other options RequestInit does not type. The client's method/body/headers/signal always win, so they cannot be overridden.

Both flow through `TelegramBot` options unchanged (BotOptionsBase.request is HttpClientOptions["request"]). Restores the per-instance proxy capability the legacy `request.agent` offered before the move to fetch. Adds unit tests, a README section, and a CHANGELOG entry.

Closes #1319


Claude-Session: https://claude.ai/code/session_01AnPey2K6jboXqYDwCLbYfL

<!--
Mark whichever option below applies to this PR.
For example, if your PR passes all tests, you would mark the option as so:
- [x] All tests pass
Note the 'x' in between the square brackets '[]'
-->
- [x] All unit tests pass (`bun run test:bun:unit`)
- [] All integration tests pass (`bun run test:bun:integration`)
- [x] `npm run typecheck` is clean
- [x] `doc/api.md` is up to date (`bun run generate:docs` leaves no diff — required when a `TelegramBot` method signature changed)

### Description

<!-- Explain what you are trying to achieve with this PR -->

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.

For example,
* Issue #1: https://github.com/yagop/node-telegram-bot-api/issues/1
* Telegram Bot API - Getting updates: https://core.telegram.org/bots/api#getting-updates
-->

---

### Running the test suite

The project ships two test layers and supports both the Node.js native test
runner and Bun. All scripts assume `npm install` (or `bun install`) has been
run first.

#### Unit tests

Pure unit tests with no network. Safe to run anywhere — no token required.

```bash
npm run test:node:unit     # Node — node:test runner via tsx
npm run test:bun:unit      # Bun — bun:test runner
```

#### Integration tests

Hit `api.telegram.org` directly. Tests that would mutate irreversible bot
configuration (e.g. `logOut`, `close`, `deleteWebHook`, `setMyName`,
`setMyProfilePhoto`, `deleteStickerSet`, …) are deliberately skipped.

**Required environment variables**

| Var | Purpose |
| --- | --- |
| `NODE_TELEGRAM_TOKEN` | Bot token (or `TEST_TELEGRAM_TOKEN` as fallback). Create one via [@BotFather](https://t.me/BotFather). |
| `TEST_GROUP_ID` | Chat id where the bot can send messages (group or private). |
| `TEST_USER_ID` | A user id the bot can resolve in `TEST_GROUP_ID`. |

**Optional**

| Var | Default | Purpose |
| --- | --- | --- |
| `TEST_STICKER_SET_NAME` | `pusheen` | Name of a public sticker set used in sticker tests. |
| `TEST_CUSTOM_EMOJI_ID` | `5368324170671202286` | A custom emoji id used by `getCustomEmojiStickers()`. |

```bash
NODE_TELEGRAM_TOKEN="<your-bot-token>" \
TEST_GROUP_ID="-1001234567890" \
TEST_USER_ID="123456789" \
  npm run test:node:integration

# Bun equivalent
NODE_TELEGRAM_TOKEN="<your-bot-token>" \
TEST_GROUP_ID="-1001234567890" \
TEST_USER_ID="123456789" \
  npm run test:bun:integration
```

> **Tip:** add the bot to a private test group, grab its id with
> [`@RawDataBot`](https://t.me/RawDataBot) (or any update logger), and
> use that id for `TEST_GROUP_ID`. `TEST_GROUP_ID` accepts the canonical
> negative form (`-100…`) or a positive number — the suite normalizes it.

#### Typecheck

```bash
npm run typecheck          # tsc --noEmit
```
