### PR TITLE
chore: add CommonJS export and main; bump version to 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Node.js module to interact with the official [Telegram Bot API](https://core.tel
 npm i node-telegram-bot-api
 ```
 
-> ✍️ **Note:** This package is **ESM-only** and requires **Node.js ≥ 18**. Use
-> `import` (not `require`). **TypeScript types are bundled** — do **not** install
+> ✍️ **Note:** This package provides both **ESM** and **CommonJS (CJS)** builds and
+> works with **Node.js ≥ 18**. Use `import` in ESM environments and `require` in
+> CommonJS environments. **TypeScript types are bundled** — do **not** install
 > `@types/node-telegram-bot-api` (it would shadow the bundled, more accurate
 > types). Upgrading from `0.6x`? See the [migration notes in the changelog][migration].
 
@@ -57,6 +58,20 @@ bot.on('message', (msg) => {
 
   // send a message to the chat acknowledging receipt of their message
   bot.sendMessage(chatId, 'Received your message');
+});
+```
+
+```js
+// CommonJS (require)
+const TelegramBot = require('node-telegram-bot-api');
+
+const token = 'YOUR_TELEGRAM_BOT_TOKEN';
+
+const botCjs = new TelegramBot(token, { polling: true });
+
+botCjs.on('message', (msg) => {
+  const chatId = msg.chat.id;
+  botCjs.sendMessage(chatId, 'Received your message');
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Telegram Bot API — modern TypeScript rewrite with generated types",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
- [x] All unit tests pass (`npm run test:node:unit`)
- [x] All integration tests pass (`npm run test:node:integration`)
- [x] `npm run typecheck` is clean
- [ ] `doc/api.md` is up to date (`bun run generate:docs` leaves no diff — required when a `TelegramBot` method signature changed)

### Description

Adds a CommonJS build entry (`./dist/index.cjs`) and a `require` condition to the `exports` field, so the package works as a dual ESM/CJS module. Also sets `main` to the CJS build for legacy tooling compatibility and bumps the version to `1.1.2`.

This unblocks NestJS users and any other CJS consumer (e.g. Jest with default config) from upgrading to v1, who currently hit `ERR_PACKAGE_PATH_NOT_EXPORTED` at runtime.

### References

* Closes #1322

---
### Running the test suite
...