### PR TITLE
[codex] docs: add migration before-after examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ bot.catch((err, ctx) => console.error("handler failed", err));
 Structured fields are plain typed objects - pass a literal or use a fluent builder; the pipeline serializes either.
 
 ```ts
-import { InlineKeyboardBuilder, ReplyKeyboardBuilder, EntityBuilder } from "node-telegram-bot-api";
+import { Bot, InlineKeyboardBuilder, ReplyKeyboardBuilder, EntityBuilder } from "node-telegram-bot-api";
+
+const bot = new Bot(process.env.BOT_TOKEN!);
 
 // 🎛️ inline keyboard as reply_markup
-await api.sendMessage({
+await bot.api.sendMessage({
   chat_id,
   text: "Choose:",
   reply_markup: new InlineKeyboardBuilder()
@@ -102,7 +104,7 @@ await api.sendMessage({
 });
 
 // ⌨️ reply keyboard as reply_markup
-await api.sendMessage({
+await bot.api.sendMessage({
   chat_id,
   text: "Yes or no?",
   reply_markup: new ReplyKeyboardBuilder()
@@ -117,10 +119,10 @@ const { text, entities } = new EntityBuilder()
   .bold("world")
   .link("docs", "https://github.com/yagop/node-telegram-bot-api")
   .build();
-await api.sendMessage({ chat_id, text, entities });
+await bot.api.sendMessage({ chat_id, text, entities });
 
 // any structured field is just a plain object - no wrapper needed
-await api.sendMessage({ chat_id, text: "hi", link_preview_options: { is_disabled: true } });
+await bot.api.sendMessage({ chat_id, text: "hi", link_preview_options: { is_disabled: true } });
 ```
 
 ## 📤 Uploads
@@ -130,16 +132,18 @@ A bare string is always a `file_id` or URL. Wrap raw bytes to upload them. Pass 
 what Telegram sees (`fromPath` uses the basename).
 
 ```ts
-import { InputFile, MediaGroupBuilder } from "node-telegram-bot-api";
+import { Bot, InputFile, MediaGroupBuilder } from "node-telegram-bot-api";
 import { fromPath } from "node-telegram-bot-api/node";
 
+const bot = new Bot(process.env.BOT_TOKEN!);
+
 // upload from disk (Node only)
-await api.sendPhoto({ chat_id, photo: await fromPath("./cat.jpg") });
+await bot.api.sendPhoto({ chat_id, photo: await fromPath("./cat.jpg") });
 // upload raw bytes (web-standard, runs anywhere)
-await api.sendDocument({ chat_id, document: new InputFile(bytes, { filename: "report.pdf" }) });
+await bot.api.sendDocument({ chat_id, document: new InputFile(bytes, { filename: "report.pdf" }) });
 
 // a raw InputFile nested in a structure is auto-hoisted to an attach:// part
-await api.sendMediaGroup({
+await bot.api.sendMediaGroup({
   chat_id,
   media: [
     { type: "photo", media: new InputFile(bytesA, { filename: "a.jpg" }), caption: "A" },
@@ -148,7 +152,7 @@ await api.sendMediaGroup({
 });
 
 // MediaGroupBuilder: optional sugar for the same array
-await api.sendMediaGroup({
+await bot.api.sendMediaGroup({
   chat_id,
   media: new MediaGroupBuilder()
     .photo({ media: new InputFile(bytesA, { filename: "a.jpg" }), caption: "A" })
@@ -160,10 +164,18 @@ await api.sendMediaGroup({
 Builders cover the other `attach://` methods; each `.build()` returns the plain shape.
 
 ```ts
-import { StickerSetBuilder, StaticProfilePhotoBuilder, PhotoStoryBuilder } from "node-telegram-bot-api";
+import {
+  Bot,
+  InputFile,
+  StickerSetBuilder,
+  StaticProfilePhotoBuilder,
+  PhotoStoryBuilder,
+} from "node-telegram-bot-api";
+
+const bot = new Bot(process.env.BOT_TOKEN!);
 
 // collect a sticker set
-await api.createNewStickerSet({
+await bot.api.createNewStickerSet({
   user_id,
   name,
   title,
@@ -173,13 +185,23 @@ await api.createNewStickerSet({
 });
 
 // a single sticker is a plain InputSticker - no builder needed
-await api.addStickerToSet({ user_id, name, sticker: { sticker: new InputFile(pngBytes, { filename: "sticker.png" }), format: "static", emoji_list: ["🙂"] } });
+await bot.api.addStickerToSet({
+  user_id,
+  name,
+  sticker: { sticker: new InputFile(pngBytes, { filename: "sticker.png" }), format: "static", emoji_list: ["🙂"] },
+});
 
 // profile photo: Static / AnimatedProfilePhotoBuilder
-await api.setMyProfilePhoto({ photo: new StaticProfilePhotoBuilder({ photo: new InputFile(pngBytes, { filename: "avatar.png" }) }).build() });
+await bot.api.setMyProfilePhoto({
+  photo: new StaticProfilePhotoBuilder({ photo: new InputFile(pngBytes, { filename: "avatar.png" }) }).build(),
+});
 
 // story: Photo / VideoStoryBuilder
-await api.postStory({ business_connection_id, active_period, content: new PhotoStoryBuilder({ photo: new InputFile(pngBytes, { filename: "story.png" }) }).build() });
+await bot.api.postStory({
+  business_connection_id,
+  active_period,
+  content: new PhotoStoryBuilder({ photo: new InputFile(pngBytes, { filename: "story.png" }) }).build(),
+});
 ```
 
 ## 🪝 Webhooks
@@ -205,7 +227,7 @@ By default the callback awaits your handler before `200`. For slow handlers, opt
 export default {
   // ✅ return 200 immediately, then finish the handler in the background
   // waitUntil keeps the platform alive until it settles (fastAck: true = fire-and-forget)
-  fetch: (req, env, ctx) =>
+  fetch: (req: Request, _env: unknown, ctx: { waitUntil(promise: Promise<unknown>): void }) =>
     webhookCallback(bot, { secretToken: SECRET, waitUntil: (p) => ctx.waitUntil(p) })(req),
 };
 ```

--- a/examples/08-uploads.ts
+++ b/examples/08-uploads.ts
@@ -11,23 +11,23 @@
  *
  * Run: BOT_TOKEN=123:abc CHAT_ID=12345 bun examples/08-uploads.ts
  */
-import { Api, InputFile, MediaGroupBuilder } from "node-telegram-bot-api";
+import { Bot, InputFile, MediaGroupBuilder } from "node-telegram-bot-api";
 import { fromPath } from "node-telegram-bot-api/node";
 
-const api = new Api(process.env.BOT_TOKEN!);
+const bot = new Bot(process.env.BOT_TOKEN!);
 const chatId = Number(process.env.CHAT_ID ?? "0");
 
 if (chatId !== 0) {
   // 1) In-memory bytes → a tiny text document.
   const bytes = new TextEncoder().encode("hello from a Uint8Array\n");
-  await api.sendDocument({
+  await bot.api.sendDocument({
     chat_id: chatId,
     document: new InputFile(bytes, { filename: "hello.txt", contentType: "text/plain" }),
     caption: "Sent from memory",
   });
 
   // 2) A photo by URL (a plain string is a file_id or URL, sent as-is).
-  await api.sendPhoto({
+  await bot.api.sendPhoto({
     chat_id: chatId,
     photo: "https://picsum.photos/seed/ntba/600/400",
     caption: "Sent by URL",
@@ -35,7 +35,7 @@ if (chatId !== 0) {
 
   // 3) A file from disk via `fromPath` (uncomment once you have a real path):
   //    const local = await fromPath("./avatar.png");
-  //    await api.sendPhoto({ chat_id: chatId, photo: local });
+  //    await bot.api.sendPhoto({ chat_id: chatId, photo: local });
   void fromPath; // referenced so the import is exercised in the example
 
   // 4) An album. `new MediaGroupBuilder().build()` mints attach:// refs for any InputFile.
@@ -44,7 +44,7 @@ if (chatId !== 0) {
     .photo({ media: "https://picsum.photos/seed/b/400" })
     .photo({ media: new InputFile(bytes, { filename: "note.txt" }) }) // mixes uploads + URLs freely
     .build();
-  await api.sendMediaGroup({ chat_id: chatId, media: album });
+  await bot.api.sendMediaGroup({ chat_id: chatId, media: album });
 
   console.log("Uploads sent.");
 } else {

--- a/redesign/MIGRATION.md
+++ b/redesign/MIGRATION.md
@@ -2,30 +2,180 @@
 
 v2 is a from-scratch redesign with **no backward compatibility** (see `ARCHITECTURE.md`). There is no shim - this table is the migration path.
 
-| v1 | v2 |
-|----|----|
+| Before (v1) | After (v2) |
+|-------------|------------|
 | `const TelegramBot = require('node-telegram-bot-api')` | `import { Bot } from 'node-telegram-bot-api'` (ESM-only) |
 | `new TelegramBot(token, { polling: true })` | `const bot = new Bot(token); bot.startPolling()` |
-| `new TelegramBot(token)` (for one-off calls) | `import { Api } from 'node-telegram-bot-api'; const api = new Api(token)` |
-| `request.fetchOptions.dispatcher` / proxy options | inject a custom Undici `fetch`: `new Api(token, { fetch: (url, init) => fetch(url, { ...init, dispatcher }) })` |
+| `new TelegramBot(token)` (for raw API calls) | `const bot = new Bot(token); await bot.api.getMe()` |
+| `request.fetchOptions.dispatcher` / proxy options | inject a custom Undici `fetch`: `new Bot(token, { fetch: (url, init) => fetch(url, { ...init, dispatcher }) })` |
 | `bot.on('message', msg => ...)` | `bot.on('message', ctx => ...)` - a router over `Context`, not an `EventEmitter` |
 | `bot.onText(/\/echo (.+)/, (msg, m) => ...)` | `bot.hears(/\/echo (.+)/, ctx => { ctx.match[1] })` |
 | `bot.onReplyToMessage(chatId, msgId, ...)` | middleware reading `ctx.message.reply_to_message` |
-| `bot.sendMessage(chatId, text, opts)` | `api.sendMessage({ chat_id, text, ...opts })` or, in a handler, `ctx.reply(text, opts)` |
+| `bot.sendMessage(chatId, text, opts)` | `bot.api.sendMessage({ chat_id, text, ...opts })` or, in a handler, `ctx.reply(text, opts)` |
 | `bot.sendMessage(id, t, { reply_markup: { inline_keyboard: [...] } })` | `ctx.reply(t, { reply_markup: new InlineKeyboardBuilder().text('A','a').build() })` |
 | `{ reply_markup: JSON.stringify(markup) }` (manual) | a plain object `{ inline_keyboard: [...] }` or a builder `.build()` - the field is a plain typed object; the pipeline serializes it |
-| `bot.sendPhoto(id, '/path/to/p.jpg')` | `api.sendPhoto({ chat_id, photo: await fromPath('/path/to/p.jpg') })` (from `'node-telegram-bot-api/node'`) |
-| `bot.sendPhoto(id, fs.createReadStream(...))` | `api.sendPhoto({ chat_id, photo: new InputFile(bytes) })` |
+| `bot.sendPhoto(id, '/path/to/p.jpg')` | `bot.api.sendPhoto({ chat_id, photo: await fromPath('/path/to/p.jpg') })` (from `'node-telegram-bot-api/node'`) |
+| `bot.sendPhoto(id, fs.createReadStream(...))` | `bot.api.sendPhoto({ chat_id, photo: new InputFile(bytes) })` |
 | bare string = path **or** file_id (via `options.filepath`) | a bare string is **always** a `file_id`/URL; bytes go through `new InputFile()`/`fromPath()` |
-| `bot.sendMediaGroup(id, [{ type:'photo', media: stream }])` | `api.sendMediaGroup({ chat_id, media: [{ type:'photo', media: new InputFile(bytes) }] })` (or the `MediaGroupBuilder`) |
+| `bot.sendMediaGroup(id, [{ type:'photo', media: stream }])` | `bot.api.sendMediaGroup({ chat_id, media: [{ type:'photo', media: new InputFile(bytes) }] })` (or the `MediaGroupBuilder`) |
 | webhook via `new TelegramBot(token, { webHook: { port } })` | `createWebhookServer(bot, { path })` (`/node`) or `webhookCallback(bot)` on any runtime |
-| `bot.setWebHook(url)` | `api.setWebhook({ url })` |
-| `bot.startPolling()` / `bot.stopPolling()` / `bot.isPolling()` | `bot.startPolling()` / `bot.stop()` / `bot.isRunning()`, or `longPoll(api, opts, signal)` directly |
+| `bot.setWebHook(url)` | `bot.api.setWebhook({ url })` |
+| `bot.startPolling()` / `bot.stopPolling()` / `bot.isPolling()` | `bot.startPolling()` / `bot.stop()` / `bot.isRunning()`, or `longPoll(bot.api, opts, signal)` directly |
 | `error.code === 'ETELEGRAM'`, message substring matching | `catch (e) { if (e instanceof TelegramApiError && e.errorCode === 429) e.retryAfter }` |
 | `EFATAL` | split into `NetworkError` (`EFETCH`) and `TimeoutError` (`ETIMEOUT`) |
 | `update.message` always `Message \| undefined` | `Update` is a discriminated union - `if ('message' in update) update.message` narrows |
-| `bot.getMe(...)` etc. (positional + options) | every method takes a single params object: `api.getMe()`, `api.getChat({ chat_id })` |
+| `bot.getMe(...)` etc. (positional + options) | every method takes a single params object: `bot.api.getMe()`, `bot.api.getChat({ chat_id })` |
 | CommonJS, Node-only | ESM-only, web-standard core; runs on Node 18+, Bun, Deno, Workers, edge |
+
+## Longer examples
+
+<table>
+<thead>
+<tr>
+<th>Before (v1)</th>
+<th>After (v2)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">
+<p><strong>Polling handlers</strong></p>
+
+<pre lang="js">
+const TelegramBot = require("node-telegram-bot-api");
+
+const bot = new TelegramBot(process.env.BOT_TOKEN, { polling: true });
+
+bot.onText(/\/start/, (msg) => {
+  bot.sendMessage(msg.chat.id, "Hi");
+});
+
+bot.onText(/\/echo (.+)/, (msg, match) => {
+  bot.sendMessage(msg.chat.id, match[1]);
+});
+
+bot.on("callback_query", (query) => {
+  bot.answerCallbackQuery(query.id, { text: "ok" });
+});
+</pre>
+
+</td>
+<td valign="top">
+<p><strong>Polling handlers</strong></p>
+
+<pre lang="ts">
+import { Bot } from "node-telegram-bot-api";
+import { run } from "node-telegram-bot-api/node";
+
+const bot = new Bot(process.env.BOT_TOKEN!);
+
+bot.command("start", (ctx) => {
+  return ctx.reply("Hi");
+});
+
+bot.hears(/\/echo (.+)/, (ctx) => {
+  return ctx.reply(ctx.match![1]!);
+});
+
+bot.on("callback_query", (ctx) => {
+  return ctx.answerCallbackQuery({ text: "ok" });
+});
+
+await run(bot);
+</pre>
+
+</td>
+</tr>
+<tr>
+<td valign="top">
+<p><strong>Uploads</strong></p>
+
+<pre lang="js">
+const TelegramBot = require("node-telegram-bot-api");
+const fs = require("node:fs");
+
+const bot = new TelegramBot(token);
+
+await bot.sendPhoto(chatId, "./cat.jpg");
+await bot.sendDocument(chatId, fs.createReadStream("./report.pdf"));
+await bot.sendMediaGroup(chatId, [
+  { type: "photo", media: fs.createReadStream("./a.jpg") },
+  { type: "photo", media: "https://example.com/b.jpg" },
+]);
+</pre>
+
+</td>
+<td valign="top">
+<p><strong>Uploads</strong></p>
+
+<pre lang="ts">
+import { Bot, InputFile } from "node-telegram-bot-api";
+import { fromPath } from "node-telegram-bot-api/node";
+import { readFile } from "node:fs/promises";
+
+const bot = new Bot(token);
+
+await bot.api.sendPhoto({ chat_id: chatId, photo: await fromPath("./cat.jpg") });
+
+const report = await readFile("./report.pdf");
+await bot.api.sendDocument({
+  chat_id: chatId,
+  document: new InputFile(report, { filename: "report.pdf" }),
+});
+
+await bot.api.sendMediaGroup({
+  chat_id: chatId,
+  media: [
+    { type: "photo", media: await fromPath("./a.jpg") },
+    { type: "photo", media: "https://example.com/b.jpg" },
+  ],
+});
+</pre>
+
+</td>
+</tr>
+<tr>
+<td valign="top">
+<p><strong>Proxy request options</strong></p>
+
+<pre lang="js">
+const TelegramBot = require("node-telegram-bot-api");
+const { ProxyAgent } = require("undici");
+
+const dispatcher = new ProxyAgent("http://127.0.0.1:8080");
+
+const bot = new TelegramBot(token, {
+  request: {
+    fetchOptions: { dispatcher },
+  },
+});
+</pre>
+
+</td>
+<td valign="top">
+<p><strong>Proxy request options</strong></p>
+
+<pre lang="ts">
+import { fetch as undiciFetch, ProxyAgent, type Dispatcher } from "undici";
+import { Bot } from "node-telegram-bot-api";
+
+const dispatcher = new ProxyAgent("http://127.0.0.1:8080");
+
+const bot = new Bot(token, {
+  fetch: (url, init) =>
+    undiciFetch(url, {
+      ...init,
+      dispatcher,
+    } as RequestInit &amp; { dispatcher: Dispatcher }),
+});
+
+await bot.api.getMe();
+</pre>
+
+</td>
+</tr>
+</tbody>
+</table>
 
 ## Runtime & module format
 

--- a/redesign/MIGRATION.md
+++ b/redesign/MIGRATION.md
@@ -7,6 +7,7 @@ v2 is a from-scratch redesign with **no backward compatibility** (see `ARCHITECT
 | `const TelegramBot = require('node-telegram-bot-api')` | `import { Bot } from 'node-telegram-bot-api'` (ESM-only) |
 | `new TelegramBot(token, { polling: true })` | `const bot = new Bot(token); bot.startPolling()` |
 | `new TelegramBot(token)` (for one-off calls) | `import { Api } from 'node-telegram-bot-api'; const api = new Api(token)` |
+| `request.fetchOptions.dispatcher` / proxy options | inject a custom Undici `fetch`: `new Api(token, { fetch: (url, init) => fetch(url, { ...init, dispatcher }) })` |
 | `bot.on('message', msg => ...)` | `bot.on('message', ctx => ...)` - a router over `Context`, not an `EventEmitter` |
 | `bot.onText(/\/echo (.+)/, (msg, m) => ...)` | `bot.hears(/\/echo (.+)/, ctx => { ctx.match[1] })` |
 | `bot.onReplyToMessage(chatId, msgId, ...)` | middleware reading `ctx.message.reply_to_message` |


### PR DESCRIPTION
## Summary

- Add a proxy request migration row for v2 custom `fetch` injection.
- Rename the migration quick map columns to `Before (v1)` / `After (v2)`.
- Add longer side-by-side before/after migration examples for polling handlers, uploads, and proxy request options.
- Use `bot.api` in v2 migration examples so docs showcase the normal Bot composition root.
- Update README `Keyboards & formatting` and `Uploads` examples to use `bot.api`.
- Update `examples/08-uploads.ts` to use `Bot` plus `bot.api`.
- Type the README early-ACK webhook callback params so README TypeScript snippets compile under strict settings.

## Validation

- `git diff --check origin/feat/v2-core..HEAD`
- `npm run typecheck:examples`
- Compiled all 15 README TypeScript code fences with TypeScript using local package path mapping and ambient placeholders for intentionally omitted values.
- Rendered `redesign/MIGRATION.md` through GitHub's Markdown API and verified the longer examples render as a table with highlighted `<pre lang="js">` / `<pre lang="ts">` blocks.
- Verified rendered migration output contains `bot.api` and no standalone `new Api` / `const api` examples.