### PR TITLE
[codex] build: add zshy dual module output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+## [1.1.2][1.1.2] - 2026-06-24
+
+### Added
+
+- **CommonJS consumption restored.** The package now ships a dual ESM + CJS
+  build (produced by `zshy`): the `package.json` `exports` map exposes both an
+  `import` and a `require` condition (with their own `.d.ts` / `.d.cts` typings),
+  so the library can be loaded with either syntax —
+
+  ```js
+  // CommonJS
+  const { TelegramBot } = require("node-telegram-bot-api");
+
+  // ESM (unchanged)
+  import TelegramBot from "node-telegram-bot-api";
+  ```
+
+  The v1.0.0 dynamic-import workaround
+  (`const { default: TelegramBot } = await import("node-telegram-bot-api")`) is
+  no longer required. Source maps are emitted for both module formats, and each
+  CJS artifact references its own map.
+
 ## [1.1.1][1.1.1] - 2026-06-22
 
 ### Added
@@ -817,4 +839,5 @@ Fixed:
 [1.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.0.0
 [1.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.0
 [1.1.1]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.1
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.1.1...master
+[1.1.2]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.2
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.1.2...master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run build            # tsc -p tsconfig.build.json → dist/ (src only)
+npm run build            # zshy --project tsconfig.build.json → dist/ dual ESM+CJS (*.js/*.d.ts + *.cjs/*.d.cts); a postbuild step repairs the CJS source-map refs
 npm run typecheck        # tsc --noEmit over BOTH src/ and test/
 npm run generate:types   # bun scripts/api-parser.ts → regenerate src/types/schemas.ts
 ```
@@ -22,7 +22,7 @@ There is **no separate lint step** — `npm run typecheck` under `strict` is the
 
 ## Module system gotchas
 
-- **ESM-only, `NodeNext`.** Every relative import inside `src/` and `test/` must carry a `.js` extension (e.g. `import { ... } from "./errors.js"`) even though the source is `.ts`. Omitting it breaks the build.
+- **Source tree is ESM, `NodeNext`.** Every relative import inside `src/` and `test/` must carry a `.js` extension (e.g. `import { ... } from "./errors.js"`) even though the source is `.ts`. Omitting it breaks the build. The **published package**, though, is dual-module: `zshy` emits both ESM (`*.js` / `*.d.ts`) and CJS (`*.cjs` / `*.d.cts`), and the `package.json` `exports` map exposes both `import` and `require` conditions — so consumers can `require()` the library as well as `import` it (see `scripts/fix-cjs-sourcemaps.mjs` for the postbuild that points the CJS artifacts at their own source maps).
 - Tests execute TypeScript directly through `tsx` (esbuild under the hood). esbuild ships a **platform-specific native binary** — if `node_modules` was populated on a different OS/arch the test runner fails with a "you installed esbuild for another platform" error; fix with `npm install` on this machine.
 - The suite is written against `node:test` + `node:assert/strict` so it runs identically on Node and Bun.
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,12 @@ Node.js module to interact with the official [Telegram Bot API](https://core.tel
 npm i node-telegram-bot-api
 ```
 
-> ✍️ **Note:** This package provides both **ESM** and **CommonJS (CJS)** builds and
-> requires **Node.js ≥ 18**. Use `import` in ESM projects or destructured
-> `require` in CommonJS projects. **TypeScript types are bundled** — do **not** install
-> `@types/node-telegram-bot-api` (it would shadow the bundled, more accurate
-> types). Upgrading from `0.6x`? See the [migration notes in the changelog][migration].
-
 ## 🚀 Usage
 
 ```ts
 import TelegramBot from 'node-telegram-bot-api';
+// For CommonJS use:
+// const { TelegramBot } = require('node-telegram-bot-api');
 
 // replace the value below with the Telegram token you receive from @BotFather
 const token = 'YOUR_TELEGRAM_BOT_TOKEN';
@@ -59,13 +55,6 @@ bot.on('message', (msg) => {
   // send a message to the chat acknowledging receipt of their message
   bot.sendMessage(chatId, 'Received your message');
 });
-```
-
-```js
-const { TelegramBot } = require('node-telegram-bot-api');
-
-const token = 'YOUR_TELEGRAM_BOT_TOKEN';
-const bot = new TelegramBot(token, { polling: true });
 ```
 
 More runnable examples live in the [`examples/`](./examples) directory.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Node.js module to interact with the official [Telegram Bot API](https://core.tel
 npm i node-telegram-bot-api
 ```
 
-> ✍️ **Note:** This package is **ESM-only** and requires **Node.js ≥ 18**. Use
-> `import` (not `require`). **TypeScript types are bundled** — do **not** install
+> ✍️ **Note:** This package provides both **ESM** and **CommonJS (CJS)** builds and
+> requires **Node.js ≥ 18**. Use `import` in ESM projects or destructured
+> `require` in CommonJS projects. **TypeScript types are bundled** — do **not** install
 > `@types/node-telegram-bot-api` (it would shadow the bundled, more accurate
 > types). Upgrading from `0.6x`? See the [migration notes in the changelog][migration].
 
@@ -58,6 +59,13 @@ bot.on('message', (msg) => {
   // send a message to the chat acknowledging receipt of their message
   bot.sendMessage(chatId, 'Received your message');
 });
+```
+
+```js
+const { TelegramBot } = require('node-telegram-bot-api');
+
+const token = 'YOUR_TELEGRAM_BOT_TOKEN';
+const bot = new TelegramBot(token, { polling: true });
 ```
 
 More runnable examples live in the [`examples/`](./examples) directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-telegram-bot-api",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
         "tsx": "^4.22.3",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "zshy": "^0.7.3"
       },
       "engines": {
         "node": ">=18"
@@ -459,6 +460,44 @@
         "node": ">=18"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -468,6 +507,106 @@
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -511,6 +650,70 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -524,6 +727,255 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tsx": {
@@ -565,6 +1017,28 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zshy": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zshy/-/zshy-0.7.3.tgz",
+      "integrity": "sha512-MLCAh1mwonX25z58SJEAvHGY8j4xSMsNGM1XCgYwYZgBWEO/4YeH1u+EejJlUbHbz21N2YQ0Dgg8WznKMEU26w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arg": "^5.0.2",
+        "fast-glob": "^3.3.2",
+        "table": "^6.9.0"
+      },
+      "bin": {
+        "zshy": "dist/index.cjs"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/colinhacks"
+      },
+      "peerDependencies": {
+        "typescript": ">5.5.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "scripts": {
     "build": "zshy --project tsconfig.build.json",
+    "postbuild": "node scripts/fix-cjs-sourcemaps.mjs",
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "generate:types": "bun scripts/api-parser.ts",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,21 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Telegram Bot API — modern TypeScript rewrite with generated types",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -28,7 +35,7 @@
     "typescript"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "zshy --project tsconfig.build.json",
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "generate:types": "bun scripts/api-parser.ts",
@@ -46,7 +53,12 @@
   "devDependencies": {
     "@types/node": "^25.6.2",
     "tsx": "^4.22.3",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "zshy": "^0.7.3"
+  },
+  "zshy": {
+    "exports": "./src/index.ts",
+    "noEdit": true
   },
   "repository": {
     "type": "git",

--- a/scripts/fix-cjs-sourcemaps.mjs
+++ b/scripts/fix-cjs-sourcemaps.mjs
@@ -1,0 +1,58 @@
+// Postbuild: repair source-map references in the CommonJS build output.
+//
+// zshy emits dual ESM + CJS, but the CJS artifacts (`*.cjs` / `*.d.cts`) copy
+// the ESM `//# sourceMappingURL=` comment verbatim, so they point at the ESM
+// map (`*.js.map` / `*.d.ts.map`) instead of their own companion map
+// (`*.cjs.map` / `*.d.cts.map`). The two maps have different `mappings`, so
+// every CJS consumer — Node `--enable-source-maps`, source-map-support,
+// ts-node/tsx, Jest/Mocha, IDE "go to definition" — would misreport positions.
+// The companion `*.cjs.map` / `*.d.cts.map` files also carry the wrong `file`
+// field (the ESM name).
+//
+// This walks dist/ and rewrites both the comment and the map `file` field so
+// each CJS artifact references its own map. It is idempotent: once corrected,
+// none of the patterns match again. Runs under plain Node (no bun) because it
+// executes via `npm run build` / `prepare`, which consumers run on install.
+import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const distDir = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+
+// Longest suffix first so `.cjs.map` / `.d.cts.map` win over `.cjs` / `.d.cts`.
+/** @type {Array<{ suffix: string, find: RegExp, replace: string }>} */
+const RULES = [
+  // map `file` field must name the artifact the map belongs to
+  { suffix: ".cjs.map", find: /("file":"[^"]+)\.js"/, replace: '$1.cjs"' },
+  { suffix: ".d.cts.map", find: /("file":"[^"]+)\.d\.ts"/, replace: '$1.d.cts"' },
+  // CJS declarations → their own .d.cts.map
+  { suffix: ".d.cts", find: /(\/\/# sourceMappingURL=\S+)\.d\.ts\.map$/m, replace: "$1.d.cts.map" },
+  // CJS code → its own .cjs.map
+  { suffix: ".cjs", find: /(\/\/# sourceMappingURL=\S+)\.js\.map$/m, replace: "$1.cjs.map" },
+];
+
+function ruleFor(name) {
+  return RULES.find((r) => name.endsWith(r.suffix));
+}
+
+let patched = 0;
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full);
+      continue;
+    }
+    const rule = ruleFor(entry);
+    if (!rule) continue;
+    const original = readFileSync(full, "utf8");
+    const fixed = original.replace(rule.find, rule.replace);
+    if (fixed !== original) {
+      writeFileSync(full, fixed);
+      patched += 1;
+    }
+  }
+}
+
+walk(distDir);
+console.log(`fix-cjs-sourcemaps: patched ${patched} file(s) in dist/`);


### PR DESCRIPTION
## Summary

- Switch the v1 build to zshy so the package emits both ESM and CommonJS artifacts from the TypeScript entrypoint.
- Add conditional `exports` entries for ESM and CJS, with CJS pointing at `dist/index.cjs` and ESM at `dist/index.js`.
- Keep the supported CommonJS usage as destructuring: `const { TelegramBot } = require('node-telegram-bot-api');`.
- Bump the package version and lockfile metadata to `1.1.2`.

Closes #1322.

## Validation

- `npm run build`
- `node -e "const { TelegramBot } = require('node-telegram-bot-api'); if (typeof TelegramBot !== 'function') process.exit(1);"`
- `node --input-type=module -e "import TelegramBot, { TelegramBot as NamedTelegramBot } from 'node-telegram-bot-api'; if (typeof TelegramBot !== 'function' || typeof NamedTelegramBot !== 'function') process.exit(1);"`
- CommonJS TypeScript temp consumer compile with `module: CommonJS`
- ESM TypeScript temp consumer compile with `module: NodeNext`
- `npm run typecheck`
- `npm run test:node:unit`
- `npm pack --dry-run`