### PR TITLE
1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
-## [1.1.2][1.1.2] - 2026-06-24
+## [1.1.2][1.1.2] - 2026-06-25
 
 ### Added
 


### PR DESCRIPTION
## Summary

- Correct the 1.1.2 changelog release date to 2026-06-25.

## Validation

- `bun run generate:docs`
- `git diff --exit-code doc/api.md`
- `npm run typecheck`
- `npm run test:bun:unit`
- `npm run build`