### PR TITLE
2.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "Telegram Bot API - runtime-agnostic TypeScript client (v2).",
   "type": "module",
   "main": "./dist/core/index.cjs",


### PR DESCRIPTION
Release 2.0.0-alpha.1 (second v2 prerelease, publishes under npm dist-tag \`next\`).

- Bumps \`package.json\` 2.0.0-alpha.0 -> 2.0.0-alpha.1.
- No CHANGELOG change: per repo convention prereleases are not logged; the v2 migration narrative stays in \`[Unreleased]\` for the eventual stable 2.0.0.

Sanity gate green locally: \`npm run check\` (typecheck x3 + lint:core + check:edge + 104 unit tests) and \`npm run build\` (dual ESM+CJS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)