### PR TITLE
fix(v2): stream multipart file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ const bot = new Bot(process.env.BOT_TOKEN!);
 await bot.api.sendPhoto({ chat_id, photo: await fromPath("./cat.jpg") });
 // upload raw bytes (web-standard, runs anywhere)
 await bot.api.sendDocument({ chat_id, document: new InputFile(bytes, { filename: "report.pdf" }) });
+// stream a large file without buffering it; the factory makes transport retries possible
+await bot.api.sendVideo({
+  chat_id,
+  video: new InputFile(() => createVideoStream(), { filename: "video.mp4", contentType: "video/mp4" }),
+});
 
 // a raw InputFile nested in a structure is auto-hoisted to an attach:// part
 await bot.api.sendMediaGroup({
@@ -160,6 +165,10 @@ await bot.api.sendMediaGroup({
     .build(),
 });
 ```
+
+A bare `ReadableStream` is sent once because it cannot be replayed. Pass a factory
+that returns a fresh stream to retain automatic retries. The Node-only `fromPath`
+helper does this automatically and does not read the full file into memory.
 
 Builders cover the other `attach://` methods; each `.build()` returns the plain shape.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -650,16 +650,16 @@ Build a `FormPart` from a serialized JSON string and the files its refs point at
 
 ### `fromPath()`
 
-Read `path` off disk and wrap it as an `InputFile`. The default filename is the
+Stream `path` off disk and wrap it as an `InputFile`. The default filename is the
 path's basename; pass `meta.filename` / `meta.contentType` to override.
 
-`readFile` returns a `Buffer`, which is a `Uint8Array` - accepted by `InputFile`
-directly, no copy.
+The stream factory reopens the file for each transport retry without buffering
+the full contents in memory.
 
 | Param | Type |
 | --- | --- |
 | `path` | string |
-| `meta?` | { contentType?: string; filename?: string } |
+| `meta?` | [InputFileMeta](#inputfilemeta) |
 
 **Returns:** Promise<[InputFile](#inputfile)>
 
@@ -875,8 +875,9 @@ Subset of Telegram's `ResponseParameters` carried on API errors.
 
 | Property | Type |
 | --- | --- |
-| `body` | URLSearchParams \| FormData |
+| `body` | ReadableStream<Uint8Array<ArrayBufferLike>> \| URLSearchParams \| FormData |
 | `headers` | Record<string, string> |
+| `replayable` | boolean |
 
 ### `FormPart`
 
@@ -4063,7 +4064,15 @@ sets the string under the field name and attaches each part. The encoder still
 stringifies nothing.
 
 ```ts
-type InputFileData = Blob | Uint8Array | ReadableStream<Uint8Array>;
+type InputFileData = Blob | Uint8Array | ReadableStream<Uint8Array> | [InputFileStreamFactory](#inputfilestreamfactory);
+```
+
+### `InputFileStreamFactory`
+
+A replayable upload source. Return a fresh, unread stream on every call.
+
+```ts
+type InputFileStreamFactory = () => ReadableStream<Uint8Array> | Promise<ReadableStream<Uint8Array>>;
 ```
 
 ### `InputInvoiceMessageContent`

--- a/src/core/encode.ts
+++ b/src/core/encode.ts
@@ -12,15 +12,19 @@
  * `JSON.stringify` here and no field map.
  */
 
-import { type InputFile, inputFileToBlob, isFormPart, isInputFile } from "./files.js";
+import { type InputFile, type InputFileData, inputFileToBlob, isFormPart, isInputFile } from "./files.js";
 import type { WireValue } from "./serialize.js";
 
 export interface EncodedRequest {
-  /** Always a `URLSearchParams` (urlencoded) or `FormData` (multipart). */
-  body: URLSearchParams | FormData;
-  /** Headers to merge into the fetch init. Empty for multipart (fetch sets the boundary). */
+  /** URL-encoded, native multipart, or streaming multipart request body. */
+  body: URLSearchParams | FormData | ReadableStream<Uint8Array>;
+  /** Headers to merge into the fetch init. */
   headers: Record<string, string>;
+  /** Whether a fresh request body can be encoded for a retry. */
+  replayable: boolean;
 }
+
+const encoder = new TextEncoder();
 
 export async function encodeForm(fields: Record<string, WireValue>): Promise<EncodedRequest> {
   const strings: Array<[string, string]> = [];
@@ -43,7 +47,12 @@ export async function encodeForm(fields: Record<string, WireValue>): Promise<Enc
     return {
       body: new URLSearchParams(strings),
       headers: { "content-type": "application/x-www-form-urlencoded" },
+      replayable: true,
     };
+  }
+
+  if (files.some(([, file]) => isStreamData(file.data))) {
+    return encodeStreamingMultipart(strings, files);
   }
 
   const form = new FormData();
@@ -52,5 +61,104 @@ export async function encodeForm(fields: Record<string, WireValue>): Promise<Enc
     form.set(key, await inputFileToBlob(file), file.meta?.filename ?? key);
   }
   // No explicit content-type: fetch derives `multipart/form-data` + boundary.
-  return { body: form, headers: {} };
+  return { body: form, headers: {}, replayable: true };
+}
+
+function encodeStreamingMultipart(
+  strings: Array<[string, string]>,
+  files: Array<readonly [string, InputFile]>,
+): EncodedRequest {
+  const boundary = `----node-telegram-bot-api-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  const chunks = multipartChunks(boundary, strings, files);
+
+  return {
+    body: readableFrom(chunks),
+    headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+    replayable: files.every(([, file]) => !(file.data instanceof ReadableStream)),
+  };
+}
+
+async function* multipartChunks(
+  boundary: string,
+  strings: Array<[string, string]>,
+  files: Array<readonly [string, InputFile]>,
+): AsyncGenerator<Uint8Array> {
+  for (const [key, value] of strings) {
+    yield encoder.encode(
+      `--${boundary}\r\nContent-Disposition: form-data; name="${escapeHeaderValue(key)}"\r\n\r\n${value}\r\n`,
+    );
+  }
+
+  for (const [key, file] of files) {
+    const filename = file.meta?.filename ?? key;
+    const contentType = safeContentType(file.meta?.contentType);
+    yield encoder.encode(
+      `--${boundary}\r\nContent-Disposition: form-data; name="${escapeHeaderValue(key)}"; filename="${escapeHeaderValue(filename)}"\r\nContent-Type: ${contentType}\r\n\r\n`,
+    );
+    yield* inputFileChunks(file.data);
+    yield encoder.encode("\r\n");
+  }
+
+  yield encoder.encode(`--${boundary}--\r\n`);
+}
+
+async function* inputFileChunks(data: InputFileData): AsyncGenerator<Uint8Array> {
+  if (data instanceof Uint8Array) {
+    yield data;
+    return;
+  }
+
+  if (data instanceof Blob) {
+    yield* readableChunks(data.stream());
+    return;
+  }
+
+  yield* readableChunks(typeof data === "function" ? await data() : data);
+}
+
+async function* readableChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  let complete = false;
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) {
+        complete = true;
+        return;
+      }
+      yield result.value;
+    }
+  } finally {
+    if (!complete) await reader.cancel();
+    reader.releaseLock();
+  }
+}
+
+function readableFrom(iterator: AsyncGenerator<Uint8Array>): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await iterator.next();
+        if (result.done) controller.close();
+        else controller.enqueue(result.value);
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    async cancel() {
+      await iterator.return(undefined);
+    },
+  });
+}
+
+function isStreamData(data: InputFileData): boolean {
+  return data instanceof ReadableStream || typeof data === "function";
+}
+
+function escapeHeaderValue(value: string): string {
+  return value.replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/"/g, "%22");
+}
+
+function safeContentType(value: string | undefined): string {
+  return value && !value.includes("\r") && !value.includes("\n") ? value : "application/octet-stream";
 }

--- a/src/core/encode.ts
+++ b/src/core/encode.ts
@@ -91,7 +91,7 @@ async function* multipartChunks(
 
   for (const [key, file] of files) {
     const filename = file.meta?.filename ?? key;
-    const contentType = safeContentType(file.meta?.contentType);
+    const contentType = safeContentType(file.meta?.contentType ?? (file.data instanceof Blob ? file.data.type : undefined));
     yield encoder.encode(
       `--${boundary}\r\nContent-Disposition: form-data; name="${escapeHeaderValue(key)}"; filename="${escapeHeaderValue(filename)}"\r\nContent-Type: ${contentType}\r\n\r\n`,
     );

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -15,7 +15,10 @@
  * stringifies nothing.
  */
 
-export type InputFileData = Blob | Uint8Array | ReadableStream<Uint8Array>;
+export type InputFileData = Blob | Uint8Array | ReadableStream<Uint8Array> | InputFileStreamFactory;
+
+/** A replayable upload source. Return a fresh, unread stream on every call. */
+export type InputFileStreamFactory = () => ReadableStream<Uint8Array> | Promise<ReadableStream<Uint8Array>>;
 
 export interface InputFileMeta {
   filename?: string;
@@ -83,7 +86,7 @@ export async function inputFileToBlob(file: InputFile): Promise<Blob> {
     // Cast away the `ArrayBufferLike` generic (Blob wants `Uint8Array<ArrayBuffer>`).
     return new Blob([data as Uint8Array<ArrayBuffer>], type ? { type } : undefined);
   }
-  // ReadableStream<Uint8Array>
-  const blob = await new Response(data).blob();
+  // ReadableStream<Uint8Array> or a replayable stream source.
+  const blob = await new Response(typeof data === "function" ? await data() : data).blob();
   return type ? new Blob([blob], { type }) : blob;
 }

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -133,24 +133,23 @@ export class Transport {
       await this.limiter.acquire(params?.chat_id as string | number | undefined, signal);
     }
 
-    // Encode ONCE: the body is reused across every retry. Re-encoding per attempt
-    // would re-consume a one-shot `ReadableStream` `InputFile`, so a retry of a
-    // streamed upload would fail on an already-drained stream. A `FormData` /
-    // `URLSearchParams` body is safe to send repeatedly.
-    const { body, headers } = await encodeForm(params ?? {});
-
     // Bounded: at most `maxRetries + 1` attempts (the first send plus one retry
     // per allowed retry). `attempt` doubles as the loop counter and the retry
     // count; every error path either retries via `continue` or throws, so the
     // bound is a hard ceiling rather than the termination condition.
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      // Re-encode for each attempt. Stream factories return a fresh body; a bare
+      // ReadableStream is one-shot and therefore disables retries for this call.
+      const { body, headers, replayable } = await encodeForm(params ?? {});
       const timeoutSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
       const { signal: composed, cleanup } = combineSignals([signal, timeoutSignal]);
+      const init: RequestInit & { duplex?: "half" } = { method: "POST", body, headers, signal: composed };
+      if (body instanceof ReadableStream) init.duplex = "half";
 
       let response: Response;
       let text: string;
       try {
-        response = await this.fetchImpl(url, { method: "POST", body, headers, signal: composed });
+        response = await this.fetchImpl(url, init);
         // Read the body inside the try so a mid-stream read failure (connection
         // dropped after the headers) is classified and retried like any other
         // transient transport error, not thrown raw past the error hierarchy.
@@ -158,7 +157,7 @@ export class Transport {
       } catch (err) {
         if (signal?.aborted) throw err; // caller cancelled - propagate verbatim
         // Transient throws (fetch reject / body-read failure / our timeout): retry.
-        if (attempt < this.maxRetries) {
+        if (replayable && attempt < this.maxRetries) {
           const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
           log("%s transient error; retry %d/%d in %dms", method, attempt + 1, this.maxRetries, wait);
           await delay(wait, signal);
@@ -172,7 +171,7 @@ export class Transport {
 
       // Server-side 5xx is transient: retry without parsing the body.
       if (response.status >= 500) {
-        if (attempt < this.maxRetries) {
+        if (replayable && attempt < this.maxRetries) {
           const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
           log("%s HTTP %d; retry %d/%d in %dms", method, response.status, attempt + 1, this.maxRetries, wait);
           await delay(wait, signal);
@@ -201,7 +200,7 @@ export class Transport {
         return json.result;
       }
 
-      if (json.error_code === HTTP_STATUS_TOO_MANY_REQUESTS && attempt < this.maxRetries) {
+      if (json.error_code === HTTP_STATUS_TOO_MANY_REQUESTS && replayable && attempt < this.maxRetries) {
         const retryAfter = json.parameters?.retry_after ?? 1;
         // Honor `retry_after` only up to the cap (0 = no cap). A longer flood-wait is
         // surfaced immediately (caller reads err.retryAfter) rather than hanging the

--- a/src/node/from-path.ts
+++ b/src/node/from-path.ts
@@ -1,25 +1,27 @@
 /**
- * `fromPath` - read a local file into an `InputFile` (ADR-006, §6.4).
+ * `fromPath` - stream a local file through an `InputFile` (ADR-006, §6.4).
  *
  * The sole Node-only file-input helper. The core `InputFile` wraps web-standard
  * data only (no `fs`, no path-guessing), so reading from disk lives here, under
  * the one folder allowed to import `node:*`.
  */
 
-import { readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
 import { basename } from "node:path";
-import { InputFile } from "../core/files.js";
+import { Readable } from "node:stream";
+import { InputFile, type InputFileMeta } from "../core/files.js";
 
 /**
- * Read `path` off disk and wrap it as an `InputFile`. The default filename is the
+ * Stream `path` off disk and wrap it as an `InputFile`. The default filename is the
  * path's basename; pass `meta.filename` / `meta.contentType` to override.
  *
- * `readFile` returns a `Buffer`, which is a `Uint8Array` - accepted by `InputFile`
- * directly, no copy.
+ * The stream factory reopens the file for each transport retry without buffering
+ * the full contents in memory.
  */
-export async function fromPath(path: string, meta?: { filename?: string; contentType?: string }): Promise<InputFile> {
-  const bytes = await readFile(path);
-  return new InputFile(bytes, {
+export async function fromPath(path: string, meta?: InputFileMeta): Promise<InputFile> {
+  await stat(path);
+  return new InputFile(() => Readable.toWeb(createReadStream(path)) as ReadableStream<Uint8Array>, {
     filename: meta?.filename ?? basename(path),
     contentType: meta?.contentType,
   });

--- a/test/unit/encode.test.ts
+++ b/test/unit/encode.test.ts
@@ -63,6 +63,7 @@ describe("encodeForm", () => {
     const { body, headers, replayable } = await encodeForm({
       chat_id: 1,
       document: new InputFile(stream, { contentType: "text/plain", filename: "report.txt" }),
+      photo: new InputFile(new Blob(["image bytes"], { type: "image/png" }), { filename: "photo.png" }),
     });
 
     assert.ok(body instanceof ReadableStream);
@@ -76,5 +77,6 @@ describe("encodeForm", () => {
     assert.match(multipart, /name="document"; filename="report.txt"/);
     assert.match(multipart, /Content-Type: text\/plain/);
     assert.match(multipart, /\r\n\r\nstreamed bytes\r\n/);
+    assert.match(multipart, /filename="photo.png"\r\nContent-Type: image\/png\r\n\r\nimage bytes\r\n/);
   });
 });

--- a/test/unit/encode.test.ts
+++ b/test/unit/encode.test.ts
@@ -24,12 +24,13 @@ describe("encodeForm", () => {
   });
 
   test("with file -> FormData with string field + Blob/File part, empty headers", async () => {
-    const { body, headers } = await encodeForm({
+    const { body, headers, replayable } = await encodeForm({
       chat_id: 1,
       photo: new InputFile(new Uint8Array([1, 2, 3]), { filename: "p.png" }),
     });
     assert.ok(body instanceof FormData);
     assert.deepStrictEqual(headers, {});
+    assert.strictEqual(replayable, true);
     const form = body as FormData;
     assert.strictEqual(form.get("chat_id"), "1");
     const photo = form.get("photo");
@@ -45,5 +46,35 @@ describe("encodeForm", () => {
     assert.strictEqual(form.get("media"), '[{"type":"photo","media":"attach://media_0"}]');
     assert.ok(form.get("media_0") instanceof Blob);
     assert.strictEqual((form.get("media_0") as File).name, "m.bin");
+  });
+
+  test("ReadableStream file -> lazy streaming multipart body", async () => {
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          pulls += 1;
+          controller.enqueue(new TextEncoder().encode("streamed bytes"));
+          controller.close();
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const { body, headers, replayable } = await encodeForm({
+      chat_id: 1,
+      document: new InputFile(stream, { contentType: "text/plain", filename: "report.txt" }),
+    });
+
+    assert.ok(body instanceof ReadableStream);
+    assert.match(headers["content-type"] ?? "", /^multipart\/form-data; boundary=/);
+    assert.strictEqual(replayable, false);
+    assert.strictEqual(pulls, 0, "encoding must not read the upload into memory");
+
+    const multipart = await new Response(body).text();
+    assert.strictEqual(pulls, 1);
+    assert.match(multipart, /name="chat_id"\r\n\r\n1/);
+    assert.match(multipart, /name="document"; filename="report.txt"/);
+    assert.match(multipart, /Content-Type: text\/plain/);
+    assert.match(multipart, /\r\n\r\nstreamed bytes\r\n/);
   });
 });

--- a/test/unit/from-path.test.ts
+++ b/test/unit/from-path.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { describe, test } from "node:test";
+import { fromPath } from "../../src/node/from-path.js";
+
+describe("fromPath", () => {
+  test("returns a replayable stream without reading the whole file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "ntba-from-path-"));
+    const path = join(directory, "fixture.txt");
+    await writeFile(path, "streamed from disk");
+
+    try {
+      const file = await fromPath(path, { contentType: "text/plain" });
+      assert.strictEqual(file.meta?.filename, basename(path));
+      assert.strictEqual(typeof file.data, "function");
+      if (typeof file.data !== "function") assert.fail("expected a stream factory");
+
+      const first = await file.data();
+      const second = await file.data();
+      assert.strictEqual(await new Response(first).text(), "streamed from disk");
+      assert.strictEqual(await new Response(second).text(), "streamed from disk");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -175,16 +175,15 @@ describe("Transport", () => {
     assert.strictEqual(calls.length, 2);
   });
 
-  test("retried streamed upload re-sends the buffered body (no stream re-consumption)", async () => {
-    // The body is encoded once and reused; a ReadableStream-backed InputFile is
-    // drained to a Blob a single time, so the 502 retry must still carry the bytes.
-    let i = 0;
-    const sizes: number[] = [];
+  test("one-shot streamed upload is not buffered or retried", async () => {
+    let calls = 0;
+    let multipart = "";
     const flakyFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
-      i += 1;
-      sizes.push(((init?.body as FormData).get("photo") as Blob).size);
-      if (i === 1) return new Response("upstream error", { status: 502 });
-      return new Response(JSON.stringify({ ok: true, result: true }));
+      calls += 1;
+      assert.strictEqual((init as RequestInit & { duplex?: string }).duplex, "half");
+      assert.ok(init?.body instanceof ReadableStream);
+      multipart = await new Response(init.body).text();
+      return new Response("upstream error", { status: 502 });
     }) as unknown as typeof fetch;
     const stream = new ReadableStream<Uint8Array>({
       start(c) {
@@ -193,9 +192,40 @@ describe("Transport", () => {
       },
     });
     const tr = new Transport(TOKEN, { fetch: flakyFetch, maxRetries: 2, retryBackoffMs: 0 });
-    const result = await tr.request<boolean>("sendPhoto", { chat_id: 1, photo: new InputFile(stream) });
+    await assert.rejects(
+      tr.request<boolean>("sendPhoto", { chat_id: 1, photo: new InputFile(stream) }),
+      NetworkError,
+    );
+    assert.strictEqual(calls, 1);
+    assert.ok(multipart.includes(String.fromCharCode(1, 2, 3, 4, 5)));
+  });
+
+  test("retried streamed upload opens a fresh stream from its factory", async () => {
+    let calls = 0;
+    let opens = 0;
+    const bodies: string[] = [];
+    const flakyFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      calls += 1;
+      assert.ok(init?.body instanceof ReadableStream);
+      bodies.push(await new Response(init.body).text());
+      if (calls === 1) return new Response("upstream error", { status: 502 });
+      return new Response(JSON.stringify({ ok: true, result: true }));
+    }) as unknown as typeof fetch;
+    const source = () => {
+      opens += 1;
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("retryable bytes"));
+          controller.close();
+        },
+      });
+    };
+    const tr = new Transport(TOKEN, { fetch: flakyFetch, maxRetries: 2, retryBackoffMs: 0 });
+    const result = await tr.request<boolean>("sendPhoto", { chat_id: 1, photo: new InputFile(source) });
     assert.strictEqual(result, true);
-    assert.deepStrictEqual(sizes, [5, 5]); // both attempts saw the full 5-byte body
+    assert.strictEqual(opens, 2);
+    assert.strictEqual(calls, 2);
+    assert.ok(bodies.every((body) => body.includes("retryable bytes")));
   });
 
   test("a body-read failure is transient: retried, then wrapped as NetworkError", async () => {


### PR DESCRIPTION
- [x] `npm run check` is clean (typecheck src + test + examples, `lint:core`, `check:edge`, unit suite)
- [x] `npm run build` is clean
- [x] Generated files are untouched / regenerated (`doc/api.md` was regenerated; generated API sources are untouched)

### Description

Stream v2 multipart file uploads instead of converting every `ReadableStream` to a full in-memory `Blob` before calling `fetch`.

The old conversion made request bodies replayable, but a large upload temporarily required memory proportional to the whole file. This change adds a runtime-agnostic multipart stream encoder and passes the Web `ReadableStream` directly to `fetch`.

Retry behavior is explicit:

- A bare `ReadableStream` is one-shot and is not retried.
- An `InputFileStreamFactory` returns a fresh stream for each attempt and remains retryable.
- The Node-only `fromPath()` helper now uses a stream factory, so disk uploads are both bounded-memory and retryable.
- `Blob` and `Uint8Array` inputs keep using native `FormData`.

Node fetch receives `duplex: "half"` for streaming request bodies. The core remains free of Node imports and still passes the edge bundle check.

Validation:

- `npm run check` (112 Bun unit tests)
- `npm run test:node:unit` (112 Node unit tests)
- `npm run build`
- Real local HTTP uploads through Node fetch and Bun fetch
- Synthetic 512 MiB upload: about 2 MiB RSS growth while consuming the complete multipart body

### References

The failure was reproduced with a 731 MiB Telegram upload that exhausted the container while `inputFileToBlob()` called `new Response(stream).blob()`.
