### PR TITLE
2.0.0-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Telegram Bot API - runtime-agnostic TypeScript client (v2).",
   "type": "module",
   "main": "./dist/core/index.cjs",


### PR DESCRIPTION
Version bump for the third v2 prerelease (publishes under the `next` dist-tag).

Ships the streaming multipart upload encoder (#1332): flat-memory uploads on Node/Deno/edge (and Bun >= 1.4.0), `InputFileStreamFactory`, stream-factory `fromPath`, the version-gated Bun proxy guard (oven-sh/bun#33918), content-type hardening, and the 5-minute default `timeoutMs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)