### PR TITLE
ci: drop the AppVeyor Node matrix - one Windows job, shallow clone

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,13 @@ version: "{build}"
 # optionalDependency package (@esbuild/win32-x64), not from its postinstall.
 # Node 21+ only: `test:node:unit` passes the `test/unit/*.test.ts` glob to
 # `node --test`, which Windows shells do not expand and Node only globs itself
-# since v21. Node 20 would receive the literal pattern and find no tests. This
-# matches the Actions matrix (22/24/26).
+# since v21. Node 20 would receive the literal pattern and find no tests.
+#
+# Single Node version, deliberately no matrix: this job exists for Windows
+# coverage only - the Node version matrix (22/24/26) is Actions' job. The free
+# AppVeyor plan runs 1 concurrent job, so a matrix serializes (each entry pays
+# its own VM provision on top of the shared queue wait) and roughly triples the
+# wall-clock for zero extra signal. Keep one LTS line.
 #
 # `image`: the default AppVeyor image is Windows Server 2012 R2, on which Node 24
 # refuses to run ("supported on Windows 10 / Server 2016 or higher"). Pin the
@@ -22,11 +27,11 @@ version: "{build}"
 image: Visual Studio 2022
 
 environment:
-  matrix:
-    - nodejs_version: "22"
-    - nodejs_version: "24"
+  nodejs_version: "24"
 
 platform: x64
+
+clone_depth: 1
 
 install:
   - ps: Install-Product node $env:nodejs_version x64


### PR DESCRIPTION
## Why

AppVeyor was taking 4-10 minutes end-to-end on recent PRs (e.g. #1332) for ~65 seconds of actual work. Timing data from the AppVeyor API for the last 15 builds:

- **Queue wait**: 1-6.5 min before the first job starts (free-tier shared queue - not fixable via config).
- **Run**: ~190-240s, of which each matrix job is only ~60-65s. The free plan runs **1 concurrent job**, so the Node 22 + 24 matrix ran *sequentially*, with a second ~65s VM provision between them.

Per-job breakdown (build 357): clone 8s, Install-Product node 10s, npm install 22s, typecheck 5s, unit tests 18s.

## What

- **Drop the Node matrix, keep a single Node 24 job.** This job exists for Windows coverage only; the Node version matrix (22/24/26) is already covered by GitHub Actions on Linux, where each job finishes in ~20s. Cuts the AppVeyor run from ~3.5 min to ~1 min and halves queue exposure (one job queues instead of two).
- **`clone_depth: 1`** - shaves most of the 8s full clone.

## What was considered and not done

- **Caching `node_modules`**: would save ~15s of the 22s install, but cache save/restore on AppVeyor costs a similar amount for a tree this size, and there is no npm lockfile (repo ships `bun.lock`) to key it reliably. Not worth it.
- **The queue wait itself can't be configured away.** If 1-6.5 min of queue is still too slow, the real fix is moving Windows coverage to GitHub Actions (`runs-on: windows-latest` starts in seconds) and retiring AppVeyor - happy to do that in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)