### PR TITLE
test surrogate pair encoding boundary

### DIFF
--- a/test/unit/encode.test.ts
+++ b/test/unit/encode.test.ts
@@ -38,6 +38,16 @@ describe("encodeForm", () => {
     assert.strictEqual(params.get("reply_markup"), '{"inline_keyboard":[]}');
   });
 
+  test("preserves a surrogate pair across a 2048-code-unit boundary", async () => {
+    const text = `<b>${"P".repeat(2044)}🔎</b>${"P".repeat(10)}`;
+    assert.strictEqual(text.codePointAt(2047), 0x1f50e);
+
+    const { body } = await encodeForm({ chat_id: 1, text, parse_mode: "HTML" });
+    const params = body();
+    assert.ok(params instanceof URLSearchParams);
+    assert.strictEqual(params.get("text"), text);
+  });
+
   test("with file -> streamed multipart body carrying string fields and the file part", async () => {
     // Streaming pinned on: the multipart layout is runtime-independent; the
     // default mode only picks stream-vs-Blob delivery (probed per runtime).


### PR DESCRIPTION
## Summary

Add a v2 encoder regression test that places an astral Unicode character across the 2048 UTF-16-code-unit boundary from issue #1335.

## Why

The legacy transport's transitive `qs` encoder split surrogate pairs at 1024-code-unit chunk boundaries and corrupted the following character. V2 uses the platform's native `URLSearchParams` and is not affected, but this test preserves that behavior if the transport changes later.

## Impact

No runtime behavior changes. The test verifies that the exact HTML payload survives form encoding unchanged.

## Validation

- `bun test test/unit/encode.test.ts`
- `npm run typecheck:test`
- `git diff --check`