### PR TITLE
Add support for Bot API 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+### Added
+
+- Support for [Telegram Bot API 10.2](https://core.telegram.org/bots/api-changelog#july-14-2026):
+  - **Ephemeral Messages**: new methods `editEphemeralMessageText`,
+    `editEphemeralMessageMedia`, `editEphemeralMessageCaption`,
+    `editEphemeralMessageReplyMarkup` and `deleteEphemeralMessage`; new
+    `receiver_user_id` / `callback_query_id` options on `sendMessage`,
+    `sendAnimation`, `sendAudio`, `sendDocument`, `sendPhoto`, `sendSticker`,
+    `sendVideo`, `sendVideoNote`, `sendVoice`, `sendContact`, `sendLocation`
+    and `sendVenue`; `ephemeral_message_id` on `Message` and `ReplyParameters`
+    (whose `message_id` is now optional); `is_ephemeral` on `BotCommand`;
+    `receiver_user` on `Message`.
+  - **Rich Messages**: new `InputRichMessageMedia`, `InputMediaVoiceNote`,
+    `InputRichBlockListItem` and the `InputRichBlock*` block classes; new
+    `media` and `blocks` fields on `InputRichMessage`.
+  - **Communities**: new `Community`, `CommunityChatAdded` and
+    `CommunityChatRemoved` types; `community_chat_added` /
+    `community_chat_removed` on `Message`; `community` on `ChatFullInfo`.
+  - **General**: new `BotSubscriptionUpdated` type and the `subscription`
+    update field.
+
 ## [1.1.2][1.1.2] - 2026-06-25
 
 ### Added

--- a/doc/api.md
+++ b/doc/api.md
@@ -151,6 +151,11 @@
         * [.editMessageMedia(media, [options])](#TelegramBot+editMessageMedia) ⇒ <code>Promise</code>
         * [.editMessageChecklist(businessConnectionId, chatId, messageId, checklist, [options])](#TelegramBot+editMessageChecklist) ⇒ <code>Promise</code>
         * [.editMessageReplyMarkup(replyMarkup, [options])](#TelegramBot+editMessageReplyMarkup) ⇒ <code>Promise</code>
+        * [.editEphemeralMessageText(chatId, receiverUserId, ephemeralMessageId, text, [options])](#TelegramBot+editEphemeralMessageText) ⇒ <code>Promise</code>
+        * [.editEphemeralMessageMedia(chatId, receiverUserId, ephemeralMessageId, media, [options])](#TelegramBot+editEphemeralMessageMedia) ⇒ <code>Promise</code>
+        * [.editEphemeralMessageCaption(chatId, receiverUserId, ephemeralMessageId, [options])](#TelegramBot+editEphemeralMessageCaption) ⇒ <code>Promise</code>
+        * [.editEphemeralMessageReplyMarkup(chatId, receiverUserId, ephemeralMessageId, [options])](#TelegramBot+editEphemeralMessageReplyMarkup) ⇒ <code>Promise</code>
+        * [.deleteEphemeralMessage(chatId, receiverUserId, ephemeralMessageId, [options])](#TelegramBot+deleteEphemeralMessage) ⇒ <code>Promise</code>
         * [.stopPoll(chatId, pollId, [options])](#TelegramBot+stopPoll) ⇒ <code>Promise</code>
         * [.approveSuggestedPost(chatId, messageId, [options])](#TelegramBot+approveSuggestedPost) ⇒ <code>Promise</code>
         * [.declineSuggestedPost(chatId, messageId, [options])](#TelegramBot+declineSuggestedPost) ⇒ <code>Promise</code>
@@ -2293,6 +2298,96 @@ accepted for the primary `media`.
 | Param | Type | Description |
 | --- | --- | --- |
 | replyMarkup | <code>Object</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+editEphemeralMessageText"></a>
+
+### telegramBot.editEphemeralMessageText(chatId, receiverUserId, ephemeralMessageId, text, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#editephemeralmessagetext
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| receiverUserId | <code>Number</code> |  |
+| ephemeralMessageId | <code>Number</code> |  |
+| text | <code>String</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+editEphemeralMessageMedia"></a>
+
+### telegramBot.editEphemeralMessageMedia(chatId, receiverUserId, ephemeralMessageId, media, [options]) ⇒ <code>Promise</code>
+Edit an ephemeral message's media. The `media` (and its `thumbnail` /
+`cover`) accept a file (Buffer / stream / local path, uploaded via an
+`attach://` part) or a file_id / URL string, like {@link editMessageMedia}.
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#editephemeralmessagemedia
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| receiverUserId | <code>Number</code> |  |
+| ephemeralMessageId | <code>Number</code> |  |
+| media | <code>Object</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+editEphemeralMessageCaption"></a>
+
+### telegramBot.editEphemeralMessageCaption(chatId, receiverUserId, ephemeralMessageId, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#editephemeralmessagecaption
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| receiverUserId | <code>Number</code> |  |
+| ephemeralMessageId | <code>Number</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+editEphemeralMessageReplyMarkup"></a>
+
+### telegramBot.editEphemeralMessageReplyMarkup(chatId, receiverUserId, ephemeralMessageId, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| receiverUserId | <code>Number</code> |  |
+| ephemeralMessageId | <code>Number</code> |  |
+| [options] | <code>Object</code> | Additional Telegram query options |
+
+<a name="TelegramBot+deleteEphemeralMessage"></a>
+
+### telegramBot.deleteEphemeralMessage(chatId, receiverUserId, ephemeralMessageId, [options]) ⇒ <code>Promise</code>
+
+**Kind**: instance method of [<code>TelegramBot</code>](#TelegramBot)
+
+**Returns**: <code>Promise</code>
+
+**See**: https://core.telegram.org/bots/api#deleteephemeralmessage
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chatId | <code>Number \| String</code> |  |
+| receiverUserId | <code>Number</code> |  |
+| ephemeralMessageId | <code>Number</code> |  |
 | [options] | <code>Object</code> | Additional Telegram query options |
 
 <a name="TelegramBot+stopPoll"></a>

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -129,6 +129,11 @@ import type {
   EditMessageMediaParams,
   EditMessageChecklistParams,
   EditMessageReplyMarkupParams,
+  EditEphemeralMessageTextParams,
+  EditEphemeralMessageMediaParams,
+  EditEphemeralMessageCaptionParams,
+  EditEphemeralMessageReplyMarkupParams,
+  DeleteEphemeralMessageParams,
   StopPollParams,
   ApproveSuggestedPostParams,
   DeclineSuggestedPostParams,
@@ -258,6 +263,7 @@ import type {
   DeleteBusinessMessagesResult,
   DeleteChatPhotoResult,
   DeleteChatStickerSetResult,
+  DeleteEphemeralMessageResult,
   DeleteForumTopicResult,
   DeleteMessageReactionResult,
   DeleteMessageResult,
@@ -269,6 +275,10 @@ import type {
   DeleteWebhookResult,
   EditChatInviteLinkResult,
   EditChatSubscriptionInviteLinkResult,
+  EditEphemeralMessageCaptionResult,
+  EditEphemeralMessageMediaResult,
+  EditEphemeralMessageReplyMarkupResult,
+  EditEphemeralMessageTextResult,
   EditForumTopicResult,
   EditGeneralForumTopicResult,
   EditMessageCaptionResult,
@@ -2226,6 +2236,89 @@ export class TelegramBot extends EventEmitter {
       ...form,
       reply_markup: replyMarkup,
     } satisfies EditMessageReplyMarkupParams);
+  }
+
+  // --- Ephemeral messages -----------------------------------------------
+
+  editEphemeralMessageText(
+    chatId: ChatId,
+    receiverUserId: number,
+    ephemeralMessageId: number,
+    text: string,
+    form: Omit<EditEphemeralMessageTextParams, "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "text"> = {},
+  ): Promise<EditEphemeralMessageTextResult> {
+    return this._form("editEphemeralMessageText", {
+      ...form,
+      chat_id: chatId,
+      receiver_user_id: receiverUserId,
+      ephemeral_message_id: ephemeralMessageId,
+      text,
+    } satisfies EditEphemeralMessageTextParams);
+  }
+
+  /**
+   * Edit an ephemeral message's media. The `media` (and its `thumbnail` /
+   * `cover`) accept a file (Buffer / stream / local path, uploaded via an
+   * `attach://` part) or a file_id / URL string, like {@link editMessageMedia}.
+   */
+  async editEphemeralMessageMedia(
+    chatId: ChatId,
+    receiverUserId: number,
+    ephemeralMessageId: number,
+    media: Uploadable<InputMedia>,
+    form: Omit<EditEphemeralMessageMediaParams, "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "media"> = {},
+  ): Promise<EditEphemeralMessageMediaResult> {
+    const { inputMedia, formData } = await this._buildMediaItems([{ ...media }]);
+    const out = {
+      ...form,
+      chat_id: chatId,
+      receiver_user_id: receiverUserId,
+      ephemeral_message_id: ephemeralMessageId,
+      media: stringify(inputMedia[0]!),
+    };
+    return this._request("editEphemeralMessageMedia", { form: out, formData });
+  }
+
+  editEphemeralMessageCaption(
+    chatId: ChatId,
+    receiverUserId: number,
+    ephemeralMessageId: number,
+    form: Omit<EditEphemeralMessageCaptionParams, "chat_id" | "receiver_user_id" | "ephemeral_message_id"> = {},
+  ): Promise<EditEphemeralMessageCaptionResult> {
+    return this._form("editEphemeralMessageCaption", {
+      ...form,
+      chat_id: chatId,
+      receiver_user_id: receiverUserId,
+      ephemeral_message_id: ephemeralMessageId,
+    } satisfies EditEphemeralMessageCaptionParams);
+  }
+
+  editEphemeralMessageReplyMarkup(
+    chatId: ChatId,
+    receiverUserId: number,
+    ephemeralMessageId: number,
+    form: Omit<EditEphemeralMessageReplyMarkupParams, "chat_id" | "receiver_user_id" | "ephemeral_message_id"> = {},
+  ): Promise<EditEphemeralMessageReplyMarkupResult> {
+    return this._form("editEphemeralMessageReplyMarkup", {
+      ...form,
+      chat_id: chatId,
+      receiver_user_id: receiverUserId,
+      ephemeral_message_id: ephemeralMessageId,
+    } satisfies EditEphemeralMessageReplyMarkupParams);
+  }
+
+  deleteEphemeralMessage(
+    chatId: ChatId,
+    receiverUserId: number,
+    ephemeralMessageId: number,
+    form: {} = {},
+  ): Promise<DeleteEphemeralMessageResult> {
+    return this._form("deleteEphemeralMessage", {
+      ...form,
+      chat_id: chatId,
+      receiver_user_id: receiverUserId,
+      ephemeral_message_id: ephemeralMessageId,
+    } satisfies DeleteEphemeralMessageParams);
   }
 
   stopPoll(

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -104,6 +104,7 @@ export const UPDATE_TYPES = [
   "chat_boost",
   "removed_chat_boost",
   "managed_bot",
+  "subscription",
 ] as const satisfies readonly Exclude<keyof Update, "update_id">[];
 export type UpdateType = (typeof UPDATE_TYPES)[number];
 
@@ -145,6 +146,7 @@ export type Update = {
   chat_boost?: ChatBoostUpdated;
   removed_chat_boost?: ChatBoostRemoved;
   managed_bot?: ManagedBotUpdated;
+  subscription?: BotSubscriptionUpdated;
 };
 
 export type WebhookInfo = {
@@ -244,6 +246,7 @@ export type ChatFullInfo = {
   unique_gift_colors?: UniqueGiftColors;
   paid_message_star_count?: number;
   guard_bot?: User;
+  community?: Community;
 };
 
 export type Message = {
@@ -255,6 +258,8 @@ export type Message = {
   sender_boost_count?: number;
   sender_business_bot?: User;
   sender_tag?: string;
+  receiver_user?: User;
+  ephemeral_message_id?: number;
   date: number;
   guest_query_id?: string;
   business_connection_id?: string;
@@ -336,6 +341,8 @@ export type Message = {
   chat_background_set?: ChatBackground;
   checklist_tasks_done?: ChecklistTasksDone;
   checklist_tasks_added?: ChecklistTasksAdded;
+  community_chat_added?: CommunityChatAdded;
+  community_chat_removed?: CommunityChatRemoved;
   direct_message_price_changed?: DirectMessagePriceChanged;
   forum_topic_created?: ForumTopicCreated;
   forum_topic_edited?: ForumTopicEdited;
@@ -423,8 +430,9 @@ export type ExternalReplyInfo = {
 };
 
 export type ReplyParameters = {
-  message_id: number;
+  message_id?: number;
   chat_id?: number | string;
+  ephemeral_message_id?: number;
   allow_sending_without_reply?: boolean;
   quote?: string;
   quote_parse_mode?: string;
@@ -699,17 +707,6 @@ export type InputChecklist = {
   others_can_mark_tasks_as_done?: boolean;
 };
 
-export type ChecklistTasksDone = {
-  checklist_message?: Message;
-  marked_as_done_task_ids?: number[];
-  marked_as_not_done_task_ids?: number[];
-};
-
-export type ChecklistTasksAdded = {
-  checklist_message?: Message;
-  tasks: ChecklistTask[];
-};
-
 export type Location = {
   latitude: number;
   longitude: number;
@@ -751,6 +748,12 @@ export type ManagedBotCreated = {
 export type ManagedBotUpdated = {
   user: User;
   bot: User;
+};
+
+export type BotSubscriptionUpdated = {
+  user: User;
+  invoice_payload: string;
+  state: string;
 };
 
 export type PollOptionAdded = {
@@ -818,6 +821,21 @@ export type BackgroundTypeChatTheme = {
 
 export type ChatBackground = {
   type: BackgroundType;
+};
+
+export type ChecklistTasksDone = {
+  checklist_message?: Message;
+  marked_as_done_task_ids?: number[];
+  marked_as_not_done_task_ids?: number[];
+};
+
+export type ChecklistTasksAdded = {
+  checklist_message?: Message;
+  tasks: ChecklistTask[];
+};
+
+export type CommunityChatAdded = {
+  community: Community;
 };
 
 export type ForumTopicCreated = {
@@ -1110,6 +1128,11 @@ export type ForceReply = {
   force_reply: true;
   input_field_placeholder?: string;
   selective?: boolean;
+};
+
+export type Community = {
+  id: number;
+  name: string;
 };
 
 export type ChatPhoto = {
@@ -1557,6 +1580,7 @@ export type StarAmount = {
 export type BotCommand = {
   command: string;
   description: string;
+  is_ephemeral?: boolean;
 };
 
 export type BotCommandScopeDefault = {
@@ -1824,6 +1848,15 @@ export type InputMediaVideo = {
   has_spoiler?: boolean;
 };
 
+export type InputMediaVoiceNote = {
+  type: string;
+  media: string;
+  caption?: string;
+  parse_mode?: string;
+  caption_entities?: MessageEntity[];
+  duration?: number;
+};
+
 export type InputPaidMediaLivePhoto = {
   type: string;
   media: string;
@@ -1918,10 +1951,17 @@ export type RichMessage = {
 };
 
 export type InputRichMessage = {
+  blocks?: InputRichBlock[];
   html?: string;
   markdown?: string;
+  media?: InputRichMessageMedia[];
   is_rtl?: boolean;
   skip_entity_detection?: boolean;
+};
+
+export type InputRichMessageMedia = {
+  id: string;
+  media: InputMediaAnimation | InputMediaAudio | InputMediaPhoto | InputMediaVideo | InputMediaVoiceNote;
 };
 
 export type RichTextBold = {
@@ -2210,6 +2250,138 @@ export type RichBlockVoiceNote = {
 };
 
 export type RichBlockThinking = {
+  type: string;
+  text: RichText;
+};
+
+export type InputRichBlockListItem = {
+  blocks: InputRichBlock[];
+  has_checkbox?: true;
+  is_checked?: true;
+  value?: number;
+  type?: string;
+};
+
+export type InputRichBlockParagraph = {
+  type: string;
+  text: RichText;
+};
+
+export type InputRichBlockSectionHeading = {
+  type: string;
+  text: RichText;
+  size: number;
+};
+
+export type InputRichBlockPreformatted = {
+  type: string;
+  text: RichText;
+  language?: string;
+};
+
+export type InputRichBlockFooter = {
+  type: string;
+  text: RichText;
+};
+
+export type InputRichBlockDivider = {
+  type: string;
+};
+
+export type InputRichBlockMathematicalExpression = {
+  type: string;
+  expression: string;
+};
+
+export type InputRichBlockAnchor = {
+  type: string;
+  name: string;
+};
+
+export type InputRichBlockList = {
+  type: string;
+  items: InputRichBlockListItem[];
+};
+
+export type InputRichBlockBlockQuotation = {
+  type: string;
+  blocks: InputRichBlock[];
+  credit?: RichText;
+};
+
+export type InputRichBlockPullQuotation = {
+  type: string;
+  text: RichText;
+  credit?: RichText;
+};
+
+export type InputRichBlockCollage = {
+  type: string;
+  blocks: InputRichBlock[];
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockSlideshow = {
+  type: string;
+  blocks: InputRichBlock[];
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockTable = {
+  type: string;
+  cells: RichBlockTableCell[][];
+  is_bordered?: true;
+  is_striped?: true;
+  caption?: RichText;
+};
+
+export type InputRichBlockDetails = {
+  type: string;
+  summary: RichText;
+  blocks: InputRichBlock[];
+  is_open?: true;
+};
+
+export type InputRichBlockMap = {
+  type: string;
+  location: Location;
+  zoom: number;
+  width: number;
+  height: number;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockAnimation = {
+  type: string;
+  animation: InputMediaAnimation;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockAudio = {
+  type: string;
+  audio: InputMediaAudio;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockPhoto = {
+  type: string;
+  photo: InputMediaPhoto;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockVideo = {
+  type: string;
+  video: InputMediaVideo;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockVoiceNote = {
+  type: string;
+  voice_note: InputMediaVoiceNote;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockThinking = {
   type: string;
   text: RichText;
 };
@@ -2852,6 +3024,8 @@ export type GameHighScore = {
 
 export type CallbackGame = Record<string, never>;
 
+export type CommunityChatRemoved = Record<string, never>;
+
 export type ForumTopicClosed = Record<string, never>;
 
 export type ForumTopicReopened = Record<string, never>;
@@ -2906,6 +3080,8 @@ export type InputStoryContent = InputStoryContentPhoto | InputStoryContentVideo;
 export type RichText = RichTextBold | RichTextItalic | RichTextUnderline | RichTextStrikethrough | RichTextSpoiler | RichTextDateTime | RichTextTextMention | RichTextSubscript | RichTextSuperscript | RichTextMarked | RichTextCode | RichTextCustomEmoji | RichTextMathematicalExpression | RichTextUrl | RichTextEmailAddress | RichTextPhoneNumber | RichTextBankCardNumber | RichTextMention | RichTextHashtag | RichTextCashtag | RichTextBotCommand | RichTextAnchor | RichTextAnchorLink | RichTextReference | RichTextReferenceLink;
 
 export type RichBlock = RichBlockParagraph | RichBlockSectionHeading | RichBlockPreformatted | RichBlockFooter | RichBlockDivider | RichBlockMathematicalExpression | RichBlockAnchor | RichBlockList | RichBlockBlockQuotation | RichBlockPullQuotation | RichBlockCollage | RichBlockSlideshow | RichBlockTable | RichBlockDetails | RichBlockMap | RichBlockAnimation | RichBlockAudio | RichBlockPhoto | RichBlockVideo | RichBlockVoiceNote | RichBlockThinking;
+
+export type InputRichBlock = InputRichBlockParagraph | InputRichBlockSectionHeading | InputRichBlockPreformatted | InputRichBlockFooter | InputRichBlockDivider | InputRichBlockMathematicalExpression | InputRichBlockAnchor | InputRichBlockList | InputRichBlockBlockQuotation | InputRichBlockPullQuotation | InputRichBlockCollage | InputRichBlockSlideshow | InputRichBlockTable | InputRichBlockDetails | InputRichBlockMap | InputRichBlockAnimation | InputRichBlockAudio | InputRichBlockPhoto | InputRichBlockVideo | InputRichBlockVoiceNote | InputRichBlockThinking;
 
 export type InlineQueryResult = InlineQueryResultCachedAudio | InlineQueryResultCachedDocument | InlineQueryResultCachedGif | InlineQueryResultCachedMpeg4Gif | InlineQueryResultCachedPhoto | InlineQueryResultCachedSticker | InlineQueryResultCachedVideo | InlineQueryResultCachedVoice | InlineQueryResultArticle | InlineQueryResultAudio | InlineQueryResultContact | InlineQueryResultGame | InlineQueryResultDocument | InlineQueryResultGif | InlineQueryResultLocation | InlineQueryResultMpeg4Gif | InlineQueryResultPhoto | InlineQueryResultVenue | InlineQueryResultVideo | InlineQueryResultVoice;
 
@@ -2963,6 +3139,8 @@ export type SendMessageParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   text: string;
   parse_mode?: string;
   entities?: MessageEntity[];
@@ -3040,6 +3218,8 @@ export type SendPhotoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   photo: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3061,6 +3241,8 @@ export type SendLivePhotoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   live_photo: InputFile | string;
   photo: InputFile | string;
   caption?: string;
@@ -3083,6 +3265,8 @@ export type SendAudioParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   audio: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3106,6 +3290,8 @@ export type SendDocumentParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   document: InputFile | string;
   thumbnail?: InputFile | string;
   caption?: string;
@@ -3127,6 +3313,8 @@ export type SendVideoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   video: InputFile | string;
   duration?: number;
   width?: number;
@@ -3155,6 +3343,8 @@ export type SendAnimationParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   animation: InputFile | string;
   duration?: number;
   width?: number;
@@ -3180,6 +3370,8 @@ export type SendVoiceParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   voice: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3200,6 +3392,8 @@ export type SendVideoNoteParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   video_note: InputFile | string;
   duration?: number;
   length?: number;
@@ -3254,6 +3448,8 @@ export type SendLocationParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   latitude: number;
   longitude: number;
   horizontal_accuracy?: number;
@@ -3275,6 +3471,8 @@ export type SendVenueParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   latitude: number;
   longitude: number;
   title: string;
@@ -3298,6 +3496,8 @@ export type SendContactParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   phone_number: string;
   first_name: string;
   last_name?: string;
@@ -4193,6 +4393,46 @@ export type StopPollParams = {
 };
 export type StopPollResult = Poll;
 
+export type EditEphemeralMessageTextParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  text: string;
+  parse_mode?: string;
+  entities?: MessageEntity[];
+  link_preview_options?: LinkPreviewOptions;
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageTextResult = boolean;
+
+export type EditEphemeralMessageMediaParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  media: InputMedia;
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageMediaResult = boolean;
+
+export type EditEphemeralMessageCaptionParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  caption?: string;
+  parse_mode?: string;
+  caption_entities?: MessageEntity[];
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageCaptionResult = boolean;
+
+export type EditEphemeralMessageReplyMarkupParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageReplyMarkupResult = boolean;
+
 export type ApproveSuggestedPostParams = {
   chat_id: number;
   message_id: number;
@@ -4219,6 +4459,13 @@ export type DeleteMessagesParams = {
 };
 export type DeleteMessagesResult = boolean;
 
+export type DeleteEphemeralMessageParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+};
+export type DeleteEphemeralMessageResult = boolean;
+
 export type DeleteMessageReactionParams = {
   chat_id: number | string;
   message_id: number;
@@ -4239,6 +4486,8 @@ export type SendStickerParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   sticker: InputFile | string;
   emoji?: string;
   disable_notification?: boolean;

--- a/test/integration/telegram.test.ts
+++ b/test/integration/telegram.test.ts
@@ -1483,6 +1483,69 @@ describe("Telegram Bot API (integration)", () => {
     });
   });
 
+  // --- Ephemeral messages ------------------------------------------------
+
+  // Seeding helper: an ephemeral message visible only to USER_ID. The reply
+  // carries ephemeral_message_id (and message_id: 0) instead of a real
+  // message_id.
+  async function sendEphemeral(text: string): Promise<number> {
+    const sent = await bot.sendMessage(GROUP_ID, text, { receiver_user_id: USER_ID });
+    assert.equal(typeof sent.ephemeral_message_id, "number");
+    return sent.ephemeral_message_id!;
+  }
+
+  describe("editEphemeralMessageText", () => {
+    it("edits an ephemeral message's text (returns true)", async () => {
+      const eid = await sendEphemeral(`ephemeral-edit-me ${TIMESTAMP}`);
+      const ok = await bot.editEphemeralMessageText(GROUP_ID, USER_ID, eid, "ephemeral edited", {
+        entities: [{ type: "bold", offset: 0, length: 9 }],
+        link_preview_options: { is_disabled: true },
+        reply_markup: { inline_keyboard: [[{ text: "e", callback_data: "e" }]] },
+      });
+      assert.equal(ok, true);
+    });
+  });
+
+  describe("editEphemeralMessageCaption", () => {
+    it("edits an ephemeral message's caption (returns true)", async () => {
+      const eid = await sendEphemeral(`ephemeral-caption ${TIMESTAMP}`);
+      const ok = await bot.editEphemeralMessageCaption(GROUP_ID, USER_ID, eid, {
+        caption: "ephemeral cap",
+        caption_entities: [{ type: "italic", offset: 0, length: 9 }],
+      });
+      assert.equal(ok, true);
+    });
+  });
+
+  describe("editEphemeralMessageMedia", () => {
+    it("replaces an ephemeral message's media by URL (returns true)", async () => {
+      const eid = await sendEphemeral(`ephemeral-media ${TIMESTAMP}`);
+      const ok = await bot.editEphemeralMessageMedia(GROUP_ID, USER_ID, eid, {
+        type: "photo",
+        media: photoFileId,
+      });
+      assert.equal(ok, true);
+    });
+  });
+
+  describe("editEphemeralMessageReplyMarkup", () => {
+    it("updates an ephemeral message's inline keyboard (returns true)", async () => {
+      const eid = await sendEphemeral(`ephemeral-markup ${TIMESTAMP}`);
+      const ok = await bot.editEphemeralMessageReplyMarkup(GROUP_ID, USER_ID, eid, {
+        reply_markup: { inline_keyboard: [[{ text: "b", callback_data: "b" }]] },
+      });
+      assert.equal(ok, true);
+    });
+  });
+
+  describe("deleteEphemeralMessage", () => {
+    it("removes an ephemeral message (returns true)", async () => {
+      const eid = await sendEphemeral(`ephemeral-delete ${TIMESTAMP}`);
+      const ok = await bot.deleteEphemeralMessage(GROUP_ID, USER_ID, eid);
+      assert.equal(ok, true);
+    });
+  });
+
   // --- Deleting & reactions --------------------------------------------
 
   describe("deleteMessage", () => {

--- a/test/unit/telegram.test.ts
+++ b/test/unit/telegram.test.ts
@@ -475,6 +475,106 @@ describe("TelegramBot (unit)", () => {
     });
   });
 
+  describe("editEphemeralMessageText()", () => {
+    it("sends the ids positionally and serializes structured fields", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.editEphemeralMessageText(1, 42, 7, "hi", {
+        entities: [{ type: "bold", offset: 0, length: 2 }],
+        reply_markup: { inline_keyboard: [[{ text: "b", callback_data: "d" }]] },
+        link_preview_options: { is_disabled: true },
+      });
+      const { url, init } = captured.at(-1)!;
+      assert.match(url, /\/editEphemeralMessageText$/);
+      const params = new URLSearchParams(String(init.body));
+      assert.equal(params.get("chat_id"), "1");
+      assert.equal(params.get("receiver_user_id"), "42");
+      assert.equal(params.get("ephemeral_message_id"), "7");
+      assert.equal(params.get("text"), "hi");
+      assert.deepEqual(JSON.parse(params.get("entities")!), [
+        { type: "bold", offset: 0, length: 2 },
+      ]);
+      assert.deepEqual(JSON.parse(params.get("reply_markup")!), {
+        inline_keyboard: [[{ text: "b", callback_data: "d" }]],
+      });
+      assert.deepEqual(JSON.parse(params.get("link_preview_options")!), { is_disabled: true });
+    });
+  });
+
+  describe("editEphemeralMessageMedia()", () => {
+    it("uploads a Buffer as an attach:// part", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      const buf = Buffer.from("\xff\xd8\xff\xe0NEW", "binary");
+      await bot.editEphemeralMessageMedia(1, 42, 7, { type: "photo", media: buf, caption: "x" });
+      const fd = captured.at(-1)!.init.body as FormData;
+      assert.equal(fd.get("chat_id"), "1");
+      assert.equal(fd.get("receiver_user_id"), "42");
+      assert.equal(fd.get("ephemeral_message_id"), "7");
+      const inputMedia = JSON.parse(String(fd.get("media"))) as Record<string, unknown>;
+      assert.equal(inputMedia.media, "attach://0_media");
+      assert.equal(inputMedia.caption, "x");
+      assert.ok(fd.get("0_media") instanceof Blob);
+    });
+
+    it("passes a file_id through without uploading (urlencoded body)", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN", { filepath: false });
+      await bot.editEphemeralMessageMedia(1, 42, 7, { type: "photo", media: "photo-file-id" });
+      const params = new URLSearchParams(String(captured.at(-1)!.init.body));
+      const inputMedia = JSON.parse(String(params.get("media"))) as Record<string, unknown>;
+      assert.equal(inputMedia.media, "photo-file-id");
+    });
+  });
+
+  describe("editEphemeralMessageCaption()", () => {
+    it("sends the caption from the options bag and serializes caption_entities", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.editEphemeralMessageCaption(1, 42, 7, {
+        caption: "cap",
+        caption_entities: [{ type: "italic", offset: 0, length: 3 }],
+      });
+      const params = new URLSearchParams(String(captured.at(-1)!.init.body));
+      assert.equal(params.get("chat_id"), "1");
+      assert.equal(params.get("receiver_user_id"), "42");
+      assert.equal(params.get("ephemeral_message_id"), "7");
+      assert.equal(params.get("caption"), "cap");
+      assert.deepEqual(JSON.parse(params.get("caption_entities")!), [
+        { type: "italic", offset: 0, length: 3 },
+      ]);
+    });
+  });
+
+  describe("editEphemeralMessageReplyMarkup()", () => {
+    it("serializes the reply_markup from the options bag", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.editEphemeralMessageReplyMarkup(1, 42, 7, {
+        reply_markup: { inline_keyboard: [[{ text: "b", callback_data: "d" }]] },
+      });
+      const params = new URLSearchParams(String(captured.at(-1)!.init.body));
+      assert.equal(params.get("ephemeral_message_id"), "7");
+      assert.deepEqual(JSON.parse(params.get("reply_markup")!), {
+        inline_keyboard: [[{ text: "b", callback_data: "d" }]],
+      });
+    });
+  });
+
+  describe("deleteEphemeralMessage()", () => {
+    it("sends the three ids", async () => {
+      stubFetch(() => ({ ok: true, result: true }));
+      const bot = new TelegramBot("TOKEN");
+      await bot.deleteEphemeralMessage(1, 42, 7);
+      const { url, init } = captured.at(-1)!;
+      assert.match(url, /\/deleteEphemeralMessage$/);
+      const params = new URLSearchParams(String(init.body));
+      assert.equal(params.get("chat_id"), "1");
+      assert.equal(params.get("receiver_user_id"), "42");
+      assert.equal(params.get("ephemeral_message_id"), "7");
+    });
+  });
+
   describe("createNewStickerSet()", () => {
     it("uploads file-bearing stickers as attach:// parts and serializes the stickers array", async () => {
       stubFetch(() => ({ ok: true, result: true }));


### PR DESCRIPTION
Adds support for [Bot API 10.2 (July 14, 2026)](https://core.telegram.org/bots/api-changelog#july-14-2026) on the v1 line.

## Changes

- **Types regenerated** from the live docs (`src/types/schemas.ts`): Rich Message blocks (`InputRichBlock*`), `InputRichMessageMedia`, `InputMediaVoiceNote`, Communities (`Community`, `CommunityChatAdded`/`Removed`), `BotSubscriptionUpdated`, ephemeral fields on `Message`/`ReplyParameters`/`BotCommand`, and the new `receiver_user_id`/`callback_query_id` send parameters.
- **Five new Ephemeral Message methods** on `TelegramBot`: `editEphemeralMessageText`, `editEphemeralMessageMedia` (reuses the attach:// upload path), `editEphemeralMessageCaption`, `editEphemeralMessageReplyMarkup`, `deleteEphemeralMessage`.
- New send parameters ride in automatically via the `Omit<...Params>` options bags; all structured fields were already covered by existing `_fix*` serialization.
- `doc/api.md` regenerated; CHANGELOG entry added.

## Testing

- Unit tests per new method asserting the wire format (ids, JSON-stringified entities/markup, multipart uploads) - full unit suite: 111 pass.
- Live-probed all five methods first, then integration tests pinned to that behavior; scoped run passes 5/5 against api.telegram.org.
- `npm run typecheck` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)