### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+## [1.2.0][1.2.0] - 2026-07-14
+
 ### Added
 
 - Support for [Telegram Bot API 10.2](https://core.telegram.org/bots/api-changelog#july-14-2026):
@@ -861,4 +863,5 @@ Fixed:
 [1.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.0
 [1.1.1]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.1
 [1.1.2]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.2
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.1.2...master
+[1.2.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.2.0
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.2.0...v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-telegram-bot-api",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Telegram Bot API — modern TypeScript rewrite with generated types",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Release 1.2.0 on the v1 line: Bot API 10.2 support (Ephemeral Messages, Rich Message blocks, Communities, BotSubscriptionUpdated). See CHANGELOG.md for the full entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)