### PR TITLE
Support Bot API 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+### Bot API 10.2 (July 14, 2026)
+
+#### Rich Messages
+
+- Added `InputRichMessageMedia`, `InputMediaVoiceNote`, `InputRichBlock`,
+  `InputRichBlockListItem`, and the 21 input rich-block variants.
+- Added `media` and `blocks` to `InputRichMessage`.
+
+#### Ephemeral Messages
+
+- Added `editEphemeralMessageText`, `editEphemeralMessageMedia`,
+  `editEphemeralMessageCaption`, `editEphemeralMessageReplyMarkup`, and
+  `deleteEphemeralMessage`.
+- Added ephemeral targeting parameters to the 13 supported send methods and
+  ephemeral-message fields to `BotCommand`, `Message`, and `ReplyParameters`.
+
+#### Communities
+
+- Added `Community`, `CommunityChatAdded`, `CommunityChatRemoved`, and their
+  related `Message` and `ChatFullInfo` fields.
+
+#### General
+
+- Added `BotSubscriptionUpdated` and the `subscription` update type.
+
 v2 is a from-scratch redesign with **no backward compatibility** with the v1
 `TelegramBot` surface. There is no shim - the table below is the migration path.
 The core is runtime-agnostic (Node 18+, Bun, Deno, Cloudflare Workers, Vercel/Deno

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align=center>
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-v.10.1-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-v.10.2-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
 
 [![https://telegram.me/node_telegram_bot_api](https://img.shields.io/badge/💬%20Telegram-Channel-blue.svg?style=flat-square)](https://telegram.me/node_telegram_bot_api)

--- a/doc/api.md
+++ b/doc/api.md
@@ -58,6 +58,7 @@ An animated profile photo (a video); `main_frame_timestamp` picks the still fram
 | `deleteBusinessMessages` | `params`: [DeleteBusinessMessagesParams](#deletebusinessmessagesparams), `signal?`: AbortSignal | Promise<boolean> | [deleteBusinessMessages](https://core.telegram.org/bots/api#deletebusinessmessages) |
 | `deleteChatPhoto` | `params`: [DeleteChatPhotoParams](#deletechatphotoparams), `signal?`: AbortSignal | Promise<boolean> | [deleteChatPhoto](https://core.telegram.org/bots/api#deletechatphoto) |
 | `deleteChatStickerSet` | `params`: [DeleteChatStickerSetParams](#deletechatstickersetparams), `signal?`: AbortSignal | Promise<boolean> | [deleteChatStickerSet](https://core.telegram.org/bots/api#deletechatstickerset) |
+| `deleteEphemeralMessage` | `params`: [DeleteEphemeralMessageParams](#deleteephemeralmessageparams), `signal?`: AbortSignal | Promise<boolean> | [deleteEphemeralMessage](https://core.telegram.org/bots/api#deleteephemeralmessage) |
 | `deleteForumTopic` | `params`: [DeleteForumTopicParams](#deleteforumtopicparams), `signal?`: AbortSignal | Promise<boolean> | [deleteForumTopic](https://core.telegram.org/bots/api#deleteforumtopic) |
 | `deleteMessage` | `params`: [DeleteMessageParams](#deletemessageparams), `signal?`: AbortSignal | Promise<boolean> | [deleteMessage](https://core.telegram.org/bots/api#deletemessage) |
 | `deleteMessageReaction` | `params`: [DeleteMessageReactionParams](#deletemessagereactionparams), `signal?`: AbortSignal | Promise<boolean> | [deleteMessageReaction](https://core.telegram.org/bots/api#deletemessagereaction) |
@@ -69,6 +70,10 @@ An animated profile photo (a video); `main_frame_timestamp` picks the still fram
 | `deleteWebhook` | `params?`: [DeleteWebhookParams](#deletewebhookparams), `signal?`: AbortSignal | Promise<boolean> | [deleteWebhook](https://core.telegram.org/bots/api#deletewebhook) |
 | `editChatInviteLink` | `params`: [EditChatInviteLinkParams](#editchatinvitelinkparams), `signal?`: AbortSignal | Promise<[ChatInviteLink](#chatinvitelink)> | [editChatInviteLink](https://core.telegram.org/bots/api#editchatinvitelink) |
 | `editChatSubscriptionInviteLink` | `params`: [EditChatSubscriptionInviteLinkParams](#editchatsubscriptioninvitelinkparams), `signal?`: AbortSignal | Promise<[ChatInviteLink](#chatinvitelink)> | [editChatSubscriptionInviteLink](https://core.telegram.org/bots/api#editchatsubscriptioninvitelink) |
+| `editEphemeralMessageCaption` | `params`: [EditEphemeralMessageCaptionParams](#editephemeralmessagecaptionparams), `signal?`: AbortSignal | Promise<boolean> | [editEphemeralMessageCaption](https://core.telegram.org/bots/api#editephemeralmessagecaption) |
+| `editEphemeralMessageMedia` | `params`: [EditEphemeralMessageMediaParams](#editephemeralmessagemediaparams), `signal?`: AbortSignal | Promise<boolean> | [editEphemeralMessageMedia](https://core.telegram.org/bots/api#editephemeralmessagemedia) |
+| `editEphemeralMessageReplyMarkup` | `params`: [EditEphemeralMessageReplyMarkupParams](#editephemeralmessagereplymarkupparams), `signal?`: AbortSignal | Promise<boolean> | [editEphemeralMessageReplyMarkup](https://core.telegram.org/bots/api#editephemeralmessagereplymarkup) |
+| `editEphemeralMessageText` | `params`: [EditEphemeralMessageTextParams](#editephemeralmessagetextparams), `signal?`: AbortSignal | Promise<boolean> | [editEphemeralMessageText](https://core.telegram.org/bots/api#editephemeralmessagetext) |
 | `editForumTopic` | `params`: [EditForumTopicParams](#editforumtopicparams), `signal?`: AbortSignal | Promise<boolean> | [editForumTopic](https://core.telegram.org/bots/api#editforumtopic) |
 | `editGeneralForumTopic` | `params`: [EditGeneralForumTopicParams](#editgeneralforumtopicparams), `signal?`: AbortSignal | Promise<boolean> | [editGeneralForumTopic](https://core.telegram.org/bots/api#editgeneralforumtopic) |
 | `editMessageCaption` | `params?`: [EditMessageCaptionParams](#editmessagecaptionparams), `signal?`: AbortSignal | Promise<[EditMessageCaptionResult](#editmessagecaptionresult)> | [editMessageCaption](https://core.telegram.org/bots/api#editmessagecaption) |
@@ -221,7 +226,7 @@ An animated profile photo (a video); `main_frame_timestamp` picks the still fram
 | `handleUpdate` | `update`: [Update](#update) | Promise<void> | Build a Context and run the composed chain; route errors to the `catch` boundary (default: log and continue). Rejects only when that boundary itself throws. |
 | `hears` | `trigger`: string \| RegExp \| (string \| RegExp)[], `...handlers`: [Middleware](#middleware)<[Context](#context)>[] | this | Match message text: a string matches exactly (sets `ctx.match` to the text); a RegExp matches when `text.match(re)` is non-null (sets `ctx.match` to the `RegExpMatchArray`). |
 | `isRunning` | - | boolean | - |
-| `on` | `kind`: "message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| ("message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot")[], `...handlers`: [Middleware](#middleware)<[Context](#context)>[] | this | Run `handlers` only when the given payload key (e.g. `"message"`, `"callback_query"`) is present on the update. |
+| `on` | `kind`: "message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| "subscription" \| ("message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| "subscription")[], `...handlers`: [Middleware](#middleware)<[Context](#context)>[] | this | Run `handlers` only when the given payload key (e.g. `"message"`, `"callback_query"`) is present on the update. |
 | `startPolling` | `source?`: AsyncIterable<[Update](#update), any, any>, `options?`: [LongPollOptions](#longpolloptions) | Promise<void> | Pump an update source (default `longPoll`) through `handleUpdate` until `stop()` aborts. Resolves when the source is exhausted or aborted. This is long-poll mode; for webhooks use `webhookCallback`/`createWebhookServer`.  A handler error does not stop the pump: it is routed to the `catch` boundary (default: log and continue). The promise rejects only when that boundary itself throws - the fail-loud opt-in (see `catch`).  Not re-entrant: calling it while a previous pump is still active throws, so `isRunning()` stays truthful and the prior `AbortController` is never orphaned. Stop the running loop (`stop()`, then `await` its promise) first. |
 | `stop` | - | void | Abort the running pump loop. |
 | `use` | `...mw`: [Middleware](#middleware)<[Context](#context)>[] | this | Register one or more middleware to run on every update. |
@@ -1345,6 +1350,7 @@ type BotAccessSettings = {
 type BotCommand = {
   command: string;
   description: string;
+  is_ephemeral?: boolean;
 };
 ```
 
@@ -1435,6 +1441,16 @@ type BotName = {
 ```ts
 type BotShortDescription = {
   short_description: string;
+};
+```
+
+### `BotSubscriptionUpdated`
+
+```ts
+type BotSubscriptionUpdated = {
+  invoice_payload: string;
+  state: string;
+  user: [User](#user);
 };
 ```
 
@@ -1677,6 +1693,7 @@ type ChatFullInfo = {
   business_opening_hours?: [BusinessOpeningHours](#businessopeninghours);
   can_send_paid_media?: true;
   can_set_sticker_set?: true;
+  community?: [Community](#community);
   custom_emoji_sticker_set_name?: string;
   description?: string;
   emoji_status_custom_emoji_id?: string;
@@ -2046,6 +2063,29 @@ type CloseParams = Record<string, never>;
 type CloseResult = boolean;
 ```
 
+### `Community`
+
+```ts
+type Community = {
+  id: number;
+  name: string;
+};
+```
+
+### `CommunityChatAdded`
+
+```ts
+type CommunityChatAdded = {
+  community: [Community](#community);
+};
+```
+
+### `CommunityChatRemoved`
+
+```ts
+type CommunityChatRemoved = Record<string, never>;
+```
+
 ### `Contact`
 
 ```ts
@@ -2328,6 +2368,22 @@ type DeleteChatStickerSetParams = {
 type DeleteChatStickerSetResult = boolean;
 ```
 
+### `DeleteEphemeralMessageParams`
+
+```ts
+type DeleteEphemeralMessageParams = {
+  chat_id: number | string;
+  ephemeral_message_id: number;
+  receiver_user_id: number;
+};
+```
+
+### `DeleteEphemeralMessageResult`
+
+```ts
+type DeleteEphemeralMessageResult = boolean;
+```
+
 ### `DeleteForumTopicParams`
 
 ```ts
@@ -2535,6 +2591,82 @@ type EditChatSubscriptionInviteLinkParams = {
 
 ```ts
 type EditChatSubscriptionInviteLinkResult = [ChatInviteLink](#chatinvitelink);
+```
+
+### `EditEphemeralMessageCaptionParams`
+
+```ts
+type EditEphemeralMessageCaptionParams = {
+  caption?: string;
+  caption_entities?: [MessageEntity](#messageentity)[];
+  chat_id: number | string;
+  ephemeral_message_id: number;
+  parse_mode?: string;
+  receiver_user_id: number;
+  reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
+};
+```
+
+### `EditEphemeralMessageCaptionResult`
+
+```ts
+type EditEphemeralMessageCaptionResult = boolean;
+```
+
+### `EditEphemeralMessageMediaParams`
+
+```ts
+type EditEphemeralMessageMediaParams = {
+  chat_id: number | string;
+  ephemeral_message_id: number;
+  media: [InputMedia](#inputmedia);
+  receiver_user_id: number;
+  reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
+};
+```
+
+### `EditEphemeralMessageMediaResult`
+
+```ts
+type EditEphemeralMessageMediaResult = boolean;
+```
+
+### `EditEphemeralMessageReplyMarkupParams`
+
+```ts
+type EditEphemeralMessageReplyMarkupParams = {
+  chat_id: number | string;
+  ephemeral_message_id: number;
+  receiver_user_id: number;
+  reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
+};
+```
+
+### `EditEphemeralMessageReplyMarkupResult`
+
+```ts
+type EditEphemeralMessageReplyMarkupResult = boolean;
+```
+
+### `EditEphemeralMessageTextParams`
+
+```ts
+type EditEphemeralMessageTextParams = {
+  chat_id: number | string;
+  entities?: [MessageEntity](#messageentity)[];
+  ephemeral_message_id: number;
+  link_preview_options?: [LinkPreviewOptions](#linkpreviewoptions);
+  parse_mode?: string;
+  receiver_user_id: number;
+  reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
+  text: string;
+};
+```
+
+### `EditEphemeralMessageTextResult`
+
+```ts
+type EditEphemeralMessageTextResult = boolean;
 ```
 
 ### `EditForumTopicParams`
@@ -4246,6 +4378,19 @@ type InputMediaVideo = {
 };
 ```
 
+### `InputMediaVoiceNote`
+
+```ts
+type InputMediaVoiceNote = {
+  caption?: string;
+  caption_entities?: [MessageEntity](#messageentity)[];
+  duration?: number;
+  media: [InputFile](#inputfile) | string;
+  parse_mode?: string;
+  type: string;
+};
+```
+
 ### `InputMessageContent`
 
 ```ts
@@ -4341,13 +4486,241 @@ type InputProfilePhotoStatic = {
 };
 ```
 
+### `InputRichBlock`
+
+```ts
+type InputRichBlock = [InputRichBlockParagraph](#inputrichblockparagraph) | [InputRichBlockSectionHeading](#inputrichblocksectionheading) | [InputRichBlockPreformatted](#inputrichblockpreformatted) | [InputRichBlockFooter](#inputrichblockfooter) | [InputRichBlockDivider](#inputrichblockdivider) | [InputRichBlockMathematicalExpression](#inputrichblockmathematicalexpression) | [InputRichBlockAnchor](#inputrichblockanchor) | [InputRichBlockList](#inputrichblocklist) | [InputRichBlockBlockQuotation](#inputrichblockblockquotation) | [InputRichBlockPullQuotation](#inputrichblockpullquotation) | [InputRichBlockCollage](#inputrichblockcollage) | [InputRichBlockSlideshow](#inputrichblockslideshow) | [InputRichBlockTable](#inputrichblocktable) | [InputRichBlockDetails](#inputrichblockdetails) | [InputRichBlockMap](#inputrichblockmap) | [InputRichBlockAnimation](#inputrichblockanimation) | [InputRichBlockAudio](#inputrichblockaudio) | [InputRichBlockPhoto](#inputrichblockphoto) | [InputRichBlockVideo](#inputrichblockvideo) | [InputRichBlockVoiceNote](#inputrichblockvoicenote) | [InputRichBlockThinking](#inputrichblockthinking);
+```
+
+### `InputRichBlockAnchor`
+
+```ts
+type InputRichBlockAnchor = {
+  name: string;
+  type: string;
+};
+```
+
+### `InputRichBlockAnimation`
+
+```ts
+type InputRichBlockAnimation = {
+  animation: [InputMediaAnimation](#inputmediaanimation);
+  caption?: [RichBlockCaption](#richblockcaption);
+  type: string;
+};
+```
+
+### `InputRichBlockAudio`
+
+```ts
+type InputRichBlockAudio = {
+  audio: [InputMediaAudio](#inputmediaaudio);
+  caption?: [RichBlockCaption](#richblockcaption);
+  type: string;
+};
+```
+
+### `InputRichBlockBlockQuotation`
+
+```ts
+type InputRichBlockBlockQuotation = {
+  blocks: [InputRichBlock](#inputrichblock)[];
+  credit?: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockCollage`
+
+```ts
+type InputRichBlockCollage = {
+  blocks: [InputRichBlock](#inputrichblock)[];
+  caption?: [RichBlockCaption](#richblockcaption);
+  type: string;
+};
+```
+
+### `InputRichBlockDetails`
+
+```ts
+type InputRichBlockDetails = {
+  blocks: [InputRichBlock](#inputrichblock)[];
+  is_open?: true;
+  summary: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockDivider`
+
+```ts
+type InputRichBlockDivider = {
+  type: string;
+};
+```
+
+### `InputRichBlockFooter`
+
+```ts
+type InputRichBlockFooter = {
+  text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockList`
+
+```ts
+type InputRichBlockList = {
+  items: [InputRichBlockListItem](#inputrichblocklistitem)[];
+  type: string;
+};
+```
+
+### `InputRichBlockListItem`
+
+```ts
+type InputRichBlockListItem = {
+  blocks: [InputRichBlock](#inputrichblock)[];
+  has_checkbox?: true;
+  is_checked?: true;
+  type?: string;
+  value?: number;
+};
+```
+
+### `InputRichBlockMap`
+
+```ts
+type InputRichBlockMap = {
+  caption?: [RichBlockCaption](#richblockcaption);
+  height: number;
+  location: [Location](#location);
+  type: string;
+  width: number;
+  zoom: number;
+};
+```
+
+### `InputRichBlockMathematicalExpression`
+
+```ts
+type InputRichBlockMathematicalExpression = {
+  expression: string;
+  type: string;
+};
+```
+
+### `InputRichBlockParagraph`
+
+```ts
+type InputRichBlockParagraph = {
+  text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockPhoto`
+
+```ts
+type InputRichBlockPhoto = {
+  caption?: [RichBlockCaption](#richblockcaption);
+  photo: [InputMediaPhoto](#inputmediaphoto);
+  type: string;
+};
+```
+
+### `InputRichBlockPreformatted`
+
+```ts
+type InputRichBlockPreformatted = {
+  language?: string;
+  text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockPullQuotation`
+
+```ts
+type InputRichBlockPullQuotation = {
+  credit?: [RichText](#richtext);
+  text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockSectionHeading`
+
+```ts
+type InputRichBlockSectionHeading = {
+  size: number;
+  text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockSlideshow`
+
+```ts
+type InputRichBlockSlideshow = {
+  blocks: [InputRichBlock](#inputrichblock)[];
+  caption?: [RichBlockCaption](#richblockcaption);
+  type: string;
+};
+```
+
+### `InputRichBlockTable`
+
+```ts
+type InputRichBlockTable = {
+  caption?: [RichText](#richtext);
+  cells: [RichBlockTableCell](#richblocktablecell)[][];
+  is_bordered?: true;
+  is_striped?: true;
+  type: string;
+};
+```
+
+### `InputRichBlockThinking`
+
+```ts
+type InputRichBlockThinking = {
+  text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `InputRichBlockVideo`
+
+```ts
+type InputRichBlockVideo = {
+  caption?: [RichBlockCaption](#richblockcaption);
+  type: string;
+  video: [InputMediaVideo](#inputmediavideo);
+};
+```
+
+### `InputRichBlockVoiceNote`
+
+```ts
+type InputRichBlockVoiceNote = {
+  caption?: [RichBlockCaption](#richblockcaption);
+  type: string;
+  voice_note: [InputMediaVoiceNote](#inputmediavoicenote);
+};
+```
+
 ### `InputRichMessage`
 
 ```ts
 type InputRichMessage = {
+  blocks?: [InputRichBlock](#inputrichblock)[];
   html?: string;
   is_rtl?: boolean;
   markdown?: string;
+  media?: [InputRichMessageMedia](#inputrichmessagemedia)[];
   skip_entity_detection?: boolean;
 };
 ```
@@ -4357,6 +4730,15 @@ type InputRichMessage = {
 ```ts
 type InputRichMessageContent = {
   rich_message: [InputRichMessage](#inputrichmessage);
+};
+```
+
+### `InputRichMessageMedia`
+
+```ts
+type InputRichMessageMedia = {
+  id: string;
+  media: [InputMediaAnimation](#inputmediaanimation) | [InputMediaAudio](#inputmediaaudio) | [InputMediaPhoto](#inputmediaphoto) | [InputMediaVideo](#inputmediavideo) | [InputMediaVoiceNote](#inputmediavoicenote);
 };
 ```
 
@@ -4695,6 +5077,8 @@ type Message = {
   checklist?: [Checklist](#checklist);
   checklist_tasks_added?: [ChecklistTasksAdded](#checklisttasksadded);
   checklist_tasks_done?: [ChecklistTasksDone](#checklisttasksdone);
+  community_chat_added?: [CommunityChatAdded](#communitychatadded);
+  community_chat_removed?: [CommunityChatRemoved](#communitychatremoved);
   connected_website?: string;
   contact?: [Contact](#contact);
   date: number;
@@ -4706,6 +5090,7 @@ type Message = {
   edit_date?: number;
   effect_id?: string;
   entities?: [MessageEntity](#messageentity)[];
+  ephemeral_message_id?: number;
   external_reply?: [ExternalReplyInfo](#externalreplyinfo);
   forum_topic_closed?: [ForumTopicClosed](#forumtopicclosed);
   forum_topic_created?: [ForumTopicCreated](#forumtopiccreated);
@@ -4758,6 +5143,7 @@ type Message = {
   poll_option_deleted?: [PollOptionDeleted](#polloptiondeleted);
   proximity_alert_triggered?: [ProximityAlertTriggered](#proximityalerttriggered);
   quote?: [TextQuote](#textquote);
+  receiver_user?: [User](#user);
   refunded_payment?: [RefundedPayment](#refundedpayment);
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
   reply_to_checklist_task_id?: number;
@@ -5642,7 +6028,8 @@ type ReplyParameters = {
   allow_sending_without_reply?: boolean;
   chat_id?: number | string;
   checklist_task_id?: number;
-  message_id: number;
+  ephemeral_message_id?: number;
+  message_id?: number;
   poll_option_id?: string;
   quote?: string;
   quote_entities?: [MessageEntity](#messageentity)[];
@@ -6292,6 +6679,7 @@ type SendAnimationParams = {
   allow_paid_broadcast?: boolean;
   animation: [InputFile](#inputfile) | string;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6304,6 +6692,7 @@ type SendAnimationParams = {
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -6326,6 +6715,7 @@ type SendAudioParams = {
   allow_paid_broadcast?: boolean;
   audio: [InputFile](#inputfile) | string;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6337,6 +6727,7 @@ type SendAudioParams = {
   parse_mode?: string;
   performer?: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6410,6 +6801,7 @@ type SendChecklistResult = [Message](#message);
 type SendContactParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
@@ -6419,6 +6811,7 @@ type SendContactParams = {
   message_thread_id?: number;
   phone_number: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6463,6 +6856,7 @@ type SendDiceResult = [Message](#message);
 type SendDocumentParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6474,6 +6868,7 @@ type SendDocumentParams = {
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6580,6 +6975,7 @@ type SendInvoiceResult = [Message](#message);
 type SendLivePhotoParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6592,6 +6988,7 @@ type SendLivePhotoParams = {
   parse_mode?: string;
   photo: [InputFile](#inputfile) | string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -6611,6 +7008,7 @@ type SendLivePhotoResult = [Message](#message);
 type SendLocationParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
@@ -6623,6 +7021,7 @@ type SendLocationParams = {
   message_thread_id?: number;
   protect_content?: boolean;
   proximity_alert_radius?: number;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6683,6 +7082,7 @@ type SendMessageDraftResult = boolean;
 type SendMessageParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
@@ -6692,6 +7092,7 @@ type SendMessageParams = {
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6741,6 +7142,7 @@ type SendPaidMediaResult = [Message](#message);
 type SendPhotoParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6752,6 +7154,7 @@ type SendPhotoParams = {
   parse_mode?: string;
   photo: [InputFile](#inputfile) | string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -6860,6 +7263,7 @@ type SendRichMessageResult = [Message](#message);
 type SendStickerParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
@@ -6867,6 +7271,7 @@ type SendStickerParams = {
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   sticker: [InputFile](#inputfile) | string;
@@ -6887,6 +7292,7 @@ type SendVenueParams = {
   address: string;
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
@@ -6899,6 +7305,7 @@ type SendVenueParams = {
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6918,6 +7325,7 @@ type SendVenueResult = [Message](#message);
 type SendVideoNoteParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
@@ -6926,6 +7334,7 @@ type SendVideoNoteParams = {
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6946,6 +7355,7 @@ type SendVideoNoteResult = [Message](#message);
 type SendVideoParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6959,6 +7369,7 @@ type SendVideoParams = {
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -6983,6 +7394,7 @@ type SendVideoResult = [Message](#message);
 type SendVoiceParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
+  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6993,6 +7405,7 @@ type SendVoiceParams = {
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
+  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -8277,6 +8690,10 @@ type Update = {
   update_id: number;
 } & {
   managed_bot: [ManagedBotUpdated](#managedbotupdated);
+} | {
+  update_id: number;
+} & {
+  subscription: [BotSubscriptionUpdated](#botsubscriptionupdated);
 };
 ```
 
@@ -8618,7 +9035,7 @@ const HTTP_STATUS_TOO_MANY_REQUESTS: 429;
 `Update` field names dispatched as events (every `Update` payload key except `update_id`).
 
 ```ts
-const UPDATE_TYPES: readonly ["message", "edited_message", "channel_post", "edited_channel_post", "business_connection", "business_message", "edited_business_message", "deleted_business_messages", "guest_message", "message_reaction", "message_reaction_count", "inline_query", "chosen_inline_result", "callback_query", "shipping_query", "pre_checkout_query", "purchased_paid_media", "poll", "poll_answer", "my_chat_member", "chat_member", "chat_join_request", "chat_boost", "removed_chat_boost", "managed_bot"];
+const UPDATE_TYPES: readonly ["message", "edited_message", "channel_post", "edited_channel_post", "business_connection", "business_message", "edited_business_message", "deleted_business_messages", "guest_message", "message_reaction", "message_reaction_count", "inline_query", "chosen_inline_result", "callback_query", "shipping_query", "pre_checkout_query", "purchased_paid_media", "poll", "poll_answer", "my_chat_member", "chat_member", "chat_join_request", "chat_boost", "removed_chat_boost", "managed_bot", "subscription"];
 ```
 
 ### `nextPagesWebhook`

--- a/scripts/api-parser.ts
+++ b/scripts/api-parser.ts
@@ -157,7 +157,7 @@ function mapType(raw: string): string {
     return /[ |]/.test(inner) ? `(${inner})[]` : `${inner}[]`;
   }
   const parts = splitUnion(s);
-  if (parts.length > 1) return [...new Set(parts.map(mapType))].join(" | ");
+  if (parts.length > 1) return [...new Set(parts.flatMap((part) => mapType(part).split(" | ")))].join(" | ");
   return mapScalar(s);
 }
 

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -595,6 +595,22 @@ export class Api {
   stopPoll(params: T.StopPollParams, signal?: AbortSignal): Promise<T.StopPollResult> {
     return this.request<T.StopPollResult>("stopPoll", params, signal);
   }
+  /** {@link https://core.telegram.org/bots/api#editephemeralmessagetext editEphemeralMessageText} */
+  editEphemeralMessageText(params: T.EditEphemeralMessageTextParams, signal?: AbortSignal): Promise<T.EditEphemeralMessageTextResult> {
+    return this.request<T.EditEphemeralMessageTextResult>("editEphemeralMessageText", params, signal);
+  }
+  /** {@link https://core.telegram.org/bots/api#editephemeralmessagemedia editEphemeralMessageMedia} */
+  editEphemeralMessageMedia(params: T.EditEphemeralMessageMediaParams, signal?: AbortSignal): Promise<T.EditEphemeralMessageMediaResult> {
+    return this.request<T.EditEphemeralMessageMediaResult>("editEphemeralMessageMedia", params, signal);
+  }
+  /** {@link https://core.telegram.org/bots/api#editephemeralmessagecaption editEphemeralMessageCaption} */
+  editEphemeralMessageCaption(params: T.EditEphemeralMessageCaptionParams, signal?: AbortSignal): Promise<T.EditEphemeralMessageCaptionResult> {
+    return this.request<T.EditEphemeralMessageCaptionResult>("editEphemeralMessageCaption", params, signal);
+  }
+  /** {@link https://core.telegram.org/bots/api#editephemeralmessagereplymarkup editEphemeralMessageReplyMarkup} */
+  editEphemeralMessageReplyMarkup(params: T.EditEphemeralMessageReplyMarkupParams, signal?: AbortSignal): Promise<T.EditEphemeralMessageReplyMarkupResult> {
+    return this.request<T.EditEphemeralMessageReplyMarkupResult>("editEphemeralMessageReplyMarkup", params, signal);
+  }
   /** {@link https://core.telegram.org/bots/api#approvesuggestedpost approveSuggestedPost} */
   approveSuggestedPost(params: T.ApproveSuggestedPostParams, signal?: AbortSignal): Promise<T.ApproveSuggestedPostResult> {
     return this.request<T.ApproveSuggestedPostResult>("approveSuggestedPost", params, signal);
@@ -610,6 +626,10 @@ export class Api {
   /** {@link https://core.telegram.org/bots/api#deletemessages deleteMessages} */
   deleteMessages(params: T.DeleteMessagesParams, signal?: AbortSignal): Promise<T.DeleteMessagesResult> {
     return this.request<T.DeleteMessagesResult>("deleteMessages", params, signal);
+  }
+  /** {@link https://core.telegram.org/bots/api#deleteephemeralmessage deleteEphemeralMessage} */
+  deleteEphemeralMessage(params: T.DeleteEphemeralMessageParams, signal?: AbortSignal): Promise<T.DeleteEphemeralMessageResult> {
+    return this.request<T.DeleteEphemeralMessageResult>("deleteEphemeralMessage", params, signal);
   }
   /** {@link https://core.telegram.org/bots/api#deletemessagereaction deleteMessageReaction} */
   deleteMessageReaction(params: T.DeleteMessageReactionParams, signal?: AbortSignal): Promise<T.DeleteMessageReactionResult> {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -65,6 +65,7 @@ const chatOf: { [K in UpdateType]: (u: Variant<K>) => Chat | undefined } = {
   chat_boost: (u) => u.chat_boost.chat,
   removed_chat_boost: (u) => u.removed_chat_boost.chat,
   managed_bot: () => undefined,
+  subscription: () => undefined,
 };
 
 /**
@@ -102,6 +103,7 @@ const fromOf: { [K in UpdateType]: (u: Variant<K>) => User | undefined } = {
   chat_boost: () => undefined,
   removed_chat_boost: () => undefined,
   managed_bot: (u) => u.managed_bot.user,
+  subscription: (u) => u.subscription.user,
 };
 
 /**

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -56,7 +56,8 @@ export type Update =
   | ({ update_id: number } & { chat_join_request: ChatJoinRequest })
   | ({ update_id: number } & { chat_boost: ChatBoostUpdated })
   | ({ update_id: number } & { removed_chat_boost: ChatBoostRemoved })
-  | ({ update_id: number } & { managed_bot: ManagedBotUpdated });
+  | ({ update_id: number } & { managed_bot: ManagedBotUpdated })
+  | ({ update_id: number } & { subscription: BotSubscriptionUpdated });
 
 
 /** `keyof` distributed over a union (each member's keys, unioned). */
@@ -92,6 +93,7 @@ export const UPDATE_TYPES = [
   "chat_boost",
   "removed_chat_boost",
   "managed_bot",
+  "subscription",
 ] as const satisfies readonly Exclude<_UpdateKeys, "update_id">[];
 export type UpdateType = (typeof UPDATE_TYPES)[number];
 
@@ -203,6 +205,7 @@ export type ChatFullInfo = {
   unique_gift_colors?: UniqueGiftColors;
   paid_message_star_count?: number;
   guard_bot?: User;
+  community?: Community;
 };
 
 export type Message = {
@@ -214,6 +217,8 @@ export type Message = {
   sender_boost_count?: number;
   sender_business_bot?: User;
   sender_tag?: string;
+  receiver_user?: User;
+  ephemeral_message_id?: number;
   date: number;
   guest_query_id?: string;
   business_connection_id?: string;
@@ -295,6 +300,8 @@ export type Message = {
   chat_background_set?: ChatBackground;
   checklist_tasks_done?: ChecklistTasksDone;
   checklist_tasks_added?: ChecklistTasksAdded;
+  community_chat_added?: CommunityChatAdded;
+  community_chat_removed?: CommunityChatRemoved;
   direct_message_price_changed?: DirectMessagePriceChanged;
   forum_topic_created?: ForumTopicCreated;
   forum_topic_edited?: ForumTopicEdited;
@@ -382,8 +389,9 @@ export type ExternalReplyInfo = {
 };
 
 export type ReplyParameters = {
-  message_id: number;
+  message_id?: number;
   chat_id?: number | string;
+  ephemeral_message_id?: number;
   allow_sending_without_reply?: boolean;
   quote?: string;
   quote_parse_mode?: string;
@@ -658,17 +666,6 @@ export type InputChecklist = {
   others_can_mark_tasks_as_done?: boolean;
 };
 
-export type ChecklistTasksDone = {
-  checklist_message?: Message;
-  marked_as_done_task_ids?: number[];
-  marked_as_not_done_task_ids?: number[];
-};
-
-export type ChecklistTasksAdded = {
-  checklist_message?: Message;
-  tasks: ChecklistTask[];
-};
-
 export type Location = {
   latitude: number;
   longitude: number;
@@ -710,6 +707,12 @@ export type ManagedBotCreated = {
 export type ManagedBotUpdated = {
   user: User;
   bot: User;
+};
+
+export type BotSubscriptionUpdated = {
+  user: User;
+  invoice_payload: string;
+  state: string;
 };
 
 export type PollOptionAdded = {
@@ -777,6 +780,21 @@ export type BackgroundTypeChatTheme = {
 
 export type ChatBackground = {
   type: BackgroundType;
+};
+
+export type ChecklistTasksDone = {
+  checklist_message?: Message;
+  marked_as_done_task_ids?: number[];
+  marked_as_not_done_task_ids?: number[];
+};
+
+export type ChecklistTasksAdded = {
+  checklist_message?: Message;
+  tasks: ChecklistTask[];
+};
+
+export type CommunityChatAdded = {
+  community: Community;
 };
 
 export type ForumTopicCreated = {
@@ -1069,6 +1087,11 @@ export type ForceReply = {
   force_reply: true;
   input_field_placeholder?: string;
   selective?: boolean;
+};
+
+export type Community = {
+  id: number;
+  name: string;
 };
 
 export type ChatPhoto = {
@@ -1516,6 +1539,7 @@ export type StarAmount = {
 export type BotCommand = {
   command: string;
   description: string;
+  is_ephemeral?: boolean;
 };
 
 export type BotCommandScopeDefault = {
@@ -1783,6 +1807,15 @@ export type InputMediaVideo = {
   has_spoiler?: boolean;
 };
 
+export type InputMediaVoiceNote = {
+  type: string;
+  media: InputFile | string;
+  caption?: string;
+  parse_mode?: string;
+  caption_entities?: MessageEntity[];
+  duration?: number;
+};
+
 export type InputPaidMediaLivePhoto = {
   type: string;
   media: InputFile | string;
@@ -1877,10 +1910,17 @@ export type RichMessage = {
 };
 
 export type InputRichMessage = {
+  blocks?: InputRichBlock[];
   html?: string;
   markdown?: string;
+  media?: InputRichMessageMedia[];
   is_rtl?: boolean;
   skip_entity_detection?: boolean;
+};
+
+export type InputRichMessageMedia = {
+  id: string;
+  media: InputMediaAnimation | InputMediaAudio | InputMediaPhoto | InputMediaVideo | InputMediaVoiceNote;
 };
 
 export type RichTextBold = {
@@ -2169,6 +2209,138 @@ export type RichBlockVoiceNote = {
 };
 
 export type RichBlockThinking = {
+  type: string;
+  text: RichText;
+};
+
+export type InputRichBlockListItem = {
+  blocks: InputRichBlock[];
+  has_checkbox?: true;
+  is_checked?: true;
+  value?: number;
+  type?: string;
+};
+
+export type InputRichBlockParagraph = {
+  type: string;
+  text: RichText;
+};
+
+export type InputRichBlockSectionHeading = {
+  type: string;
+  text: RichText;
+  size: number;
+};
+
+export type InputRichBlockPreformatted = {
+  type: string;
+  text: RichText;
+  language?: string;
+};
+
+export type InputRichBlockFooter = {
+  type: string;
+  text: RichText;
+};
+
+export type InputRichBlockDivider = {
+  type: string;
+};
+
+export type InputRichBlockMathematicalExpression = {
+  type: string;
+  expression: string;
+};
+
+export type InputRichBlockAnchor = {
+  type: string;
+  name: string;
+};
+
+export type InputRichBlockList = {
+  type: string;
+  items: InputRichBlockListItem[];
+};
+
+export type InputRichBlockBlockQuotation = {
+  type: string;
+  blocks: InputRichBlock[];
+  credit?: RichText;
+};
+
+export type InputRichBlockPullQuotation = {
+  type: string;
+  text: RichText;
+  credit?: RichText;
+};
+
+export type InputRichBlockCollage = {
+  type: string;
+  blocks: InputRichBlock[];
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockSlideshow = {
+  type: string;
+  blocks: InputRichBlock[];
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockTable = {
+  type: string;
+  cells: RichBlockTableCell[][];
+  is_bordered?: true;
+  is_striped?: true;
+  caption?: RichText;
+};
+
+export type InputRichBlockDetails = {
+  type: string;
+  summary: RichText;
+  blocks: InputRichBlock[];
+  is_open?: true;
+};
+
+export type InputRichBlockMap = {
+  type: string;
+  location: Location;
+  zoom: number;
+  width: number;
+  height: number;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockAnimation = {
+  type: string;
+  animation: InputMediaAnimation;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockAudio = {
+  type: string;
+  audio: InputMediaAudio;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockPhoto = {
+  type: string;
+  photo: InputMediaPhoto;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockVideo = {
+  type: string;
+  video: InputMediaVideo;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockVoiceNote = {
+  type: string;
+  voice_note: InputMediaVoiceNote;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockThinking = {
   type: string;
   text: RichText;
 };
@@ -2811,6 +2983,8 @@ export type GameHighScore = {
 
 export type CallbackGame = Record<string, never>;
 
+export type CommunityChatRemoved = Record<string, never>;
+
 export type ForumTopicClosed = Record<string, never>;
 
 export type ForumTopicReopened = Record<string, never>;
@@ -2865,6 +3039,8 @@ export type InputStoryContent = InputStoryContentPhoto | InputStoryContentVideo;
 export type RichText = RichTextBold | RichTextItalic | RichTextUnderline | RichTextStrikethrough | RichTextSpoiler | RichTextDateTime | RichTextTextMention | RichTextSubscript | RichTextSuperscript | RichTextMarked | RichTextCode | RichTextCustomEmoji | RichTextMathematicalExpression | RichTextUrl | RichTextEmailAddress | RichTextPhoneNumber | RichTextBankCardNumber | RichTextMention | RichTextHashtag | RichTextCashtag | RichTextBotCommand | RichTextAnchor | RichTextAnchorLink | RichTextReference | RichTextReferenceLink;
 
 export type RichBlock = RichBlockParagraph | RichBlockSectionHeading | RichBlockPreformatted | RichBlockFooter | RichBlockDivider | RichBlockMathematicalExpression | RichBlockAnchor | RichBlockList | RichBlockBlockQuotation | RichBlockPullQuotation | RichBlockCollage | RichBlockSlideshow | RichBlockTable | RichBlockDetails | RichBlockMap | RichBlockAnimation | RichBlockAudio | RichBlockPhoto | RichBlockVideo | RichBlockVoiceNote | RichBlockThinking;
+
+export type InputRichBlock = InputRichBlockParagraph | InputRichBlockSectionHeading | InputRichBlockPreformatted | InputRichBlockFooter | InputRichBlockDivider | InputRichBlockMathematicalExpression | InputRichBlockAnchor | InputRichBlockList | InputRichBlockBlockQuotation | InputRichBlockPullQuotation | InputRichBlockCollage | InputRichBlockSlideshow | InputRichBlockTable | InputRichBlockDetails | InputRichBlockMap | InputRichBlockAnimation | InputRichBlockAudio | InputRichBlockPhoto | InputRichBlockVideo | InputRichBlockVoiceNote | InputRichBlockThinking;
 
 export type InlineQueryResult = InlineQueryResultCachedAudio | InlineQueryResultCachedDocument | InlineQueryResultCachedGif | InlineQueryResultCachedMpeg4Gif | InlineQueryResultCachedPhoto | InlineQueryResultCachedSticker | InlineQueryResultCachedVideo | InlineQueryResultCachedVoice | InlineQueryResultArticle | InlineQueryResultAudio | InlineQueryResultContact | InlineQueryResultGame | InlineQueryResultDocument | InlineQueryResultGif | InlineQueryResultLocation | InlineQueryResultMpeg4Gif | InlineQueryResultPhoto | InlineQueryResultVenue | InlineQueryResultVideo | InlineQueryResultVoice;
 
@@ -2922,6 +3098,8 @@ export type SendMessageParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   text: string;
   parse_mode?: string;
   entities?: MessageEntity[];
@@ -2999,6 +3177,8 @@ export type SendPhotoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   photo: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3020,6 +3200,8 @@ export type SendLivePhotoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   live_photo: InputFile | string;
   photo: InputFile | string;
   caption?: string;
@@ -3042,6 +3224,8 @@ export type SendAudioParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   audio: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3065,6 +3249,8 @@ export type SendDocumentParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   document: InputFile | string;
   thumbnail?: InputFile | string;
   caption?: string;
@@ -3086,6 +3272,8 @@ export type SendVideoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   video: InputFile | string;
   duration?: number;
   width?: number;
@@ -3114,6 +3302,8 @@ export type SendAnimationParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   animation: InputFile | string;
   duration?: number;
   width?: number;
@@ -3139,6 +3329,8 @@ export type SendVoiceParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   voice: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3159,6 +3351,8 @@ export type SendVideoNoteParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   video_note: InputFile | string;
   duration?: number;
   length?: number;
@@ -3213,6 +3407,8 @@ export type SendLocationParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   latitude: number;
   longitude: number;
   horizontal_accuracy?: number;
@@ -3234,6 +3430,8 @@ export type SendVenueParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   latitude: number;
   longitude: number;
   title: string;
@@ -3257,6 +3455,8 @@ export type SendContactParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   phone_number: string;
   first_name: string;
   last_name?: string;
@@ -4152,6 +4352,46 @@ export type StopPollParams = {
 };
 export type StopPollResult = Poll;
 
+export type EditEphemeralMessageTextParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  text: string;
+  parse_mode?: string;
+  entities?: MessageEntity[];
+  link_preview_options?: LinkPreviewOptions;
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageTextResult = boolean;
+
+export type EditEphemeralMessageMediaParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  media: InputMedia;
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageMediaResult = boolean;
+
+export type EditEphemeralMessageCaptionParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  caption?: string;
+  parse_mode?: string;
+  caption_entities?: MessageEntity[];
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageCaptionResult = boolean;
+
+export type EditEphemeralMessageReplyMarkupParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+  reply_markup?: InlineKeyboardMarkup;
+};
+export type EditEphemeralMessageReplyMarkupResult = boolean;
+
 export type ApproveSuggestedPostParams = {
   chat_id: number;
   message_id: number;
@@ -4178,6 +4418,13 @@ export type DeleteMessagesParams = {
 };
 export type DeleteMessagesResult = boolean;
 
+export type DeleteEphemeralMessageParams = {
+  chat_id: number | string;
+  receiver_user_id: number;
+  ephemeral_message_id: number;
+};
+export type DeleteEphemeralMessageResult = boolean;
+
 export type DeleteMessageReactionParams = {
   chat_id: number | string;
   message_id: number;
@@ -4198,6 +4445,8 @@ export type SendStickerParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  receiver_user_id?: number;
+  callback_query_id?: string;
   sticker: InputFile | string;
   emoji?: string;
   disable_notification?: boolean;

--- a/test/e2e/methods.test.ts
+++ b/test/e2e/methods.test.ts
@@ -1506,6 +1506,88 @@ describe("methods", () => {
     });
   });
 
+  method("editEphemeralMessageText", () => {
+    test("edits an ephemeral text message", async () => {
+      const receiver_user_id = await targetUserId();
+      const sent = await api.sendMessage({ chat_id: chatId, receiver_user_id, text: "e2e ephemeral text" });
+      expect(sent.ephemeral_message_id).toBeDefined();
+      const ephemeral_message_id = sent.ephemeral_message_id as number;
+      await api.editEphemeralMessageText({
+        chat_id: chatId,
+        receiver_user_id,
+        ephemeral_message_id,
+        text: "e2e ephemeral text edited",
+      });
+      await api.deleteEphemeralMessage({ chat_id: chatId, receiver_user_id, ephemeral_message_id });
+    });
+  });
+
+  method("editEphemeralMessageMedia", () => {
+    test("edits ephemeral message media", async () => {
+      const receiver_user_id = await targetUserId();
+      const sent = await api.sendPhoto({
+        chat_id: chatId,
+        receiver_user_id,
+        photo: new InputFile(JPEG_160, { filename: "e2e.jpg", contentType: "image/jpeg" }),
+        caption: "e2e ephemeral media",
+      });
+      expect(sent.ephemeral_message_id).toBeDefined();
+      const ephemeral_message_id = sent.ephemeral_message_id as number;
+      const fileId = sent.photo?.at(-1)?.file_id;
+      expect(fileId).toBeTruthy();
+      const media = {
+        type: "photo",
+        media: fileId as string,
+        caption: "e2e ephemeral media edited",
+      } satisfies InputMedia;
+      await api.editEphemeralMessageMedia({ chat_id: chatId, receiver_user_id, ephemeral_message_id, media });
+      await api.deleteEphemeralMessage({ chat_id: chatId, receiver_user_id, ephemeral_message_id });
+    });
+  });
+
+  method("editEphemeralMessageCaption", () => {
+    test("edits an ephemeral message caption", async () => {
+      const receiver_user_id = await targetUserId();
+      const sent = await api.sendPhoto({
+        chat_id: chatId,
+        receiver_user_id,
+        photo: new InputFile(JPEG_160, { filename: "e2e.jpg", contentType: "image/jpeg" }),
+        caption: "e2e ephemeral caption",
+      });
+      expect(sent.ephemeral_message_id).toBeDefined();
+      const ephemeral_message_id = sent.ephemeral_message_id as number;
+      await api.editEphemeralMessageCaption({
+        chat_id: chatId,
+        receiver_user_id,
+        ephemeral_message_id,
+        caption: "e2e ephemeral caption edited",
+      });
+      await api.deleteEphemeralMessage({ chat_id: chatId, receiver_user_id, ephemeral_message_id });
+    });
+  });
+
+  method("editEphemeralMessageReplyMarkup", () => {
+    test("edits ephemeral message reply markup", async () => {
+      const receiver_user_id = await targetUserId();
+      const sent = await api.sendMessage({
+        chat_id: chatId,
+        receiver_user_id,
+        text: "e2e ephemeral reply markup",
+        reply_markup: sampleInlineKeyboard,
+      });
+      expect(sent.ephemeral_message_id).toBeDefined();
+      const ephemeral_message_id = sent.ephemeral_message_id as number;
+      const reply_markup = new InlineKeyboardBuilder().url("docs", "https://core.telegram.org").build();
+      await api.editEphemeralMessageReplyMarkup({
+        chat_id: chatId,
+        receiver_user_id,
+        ephemeral_message_id,
+        reply_markup,
+      });
+      await api.deleteEphemeralMessage({ chat_id: chatId, receiver_user_id, ephemeral_message_id });
+    });
+  });
+
   method("stopPoll", () => {
     test("stops a freshly-sent poll", async () => {
       const poll = await api.sendPoll({
@@ -1546,6 +1628,21 @@ describe("methods", () => {
         message_ids: [sent.message_id],
       });
       expect(ok).toBeDefined();
+    });
+  });
+
+  method("deleteEphemeralMessage", () => {
+    test("deletes an ephemeral message", async () => {
+      const receiver_user_id = await targetUserId();
+      const sent = await api.sendMessage({ chat_id: chatId, receiver_user_id, text: "e2e ephemeral delete" });
+      expect(sent.ephemeral_message_id).toBeDefined();
+      const ephemeral_message_id = sent.ephemeral_message_id as number;
+      const ok = await api.deleteEphemeralMessage({
+        chat_id: chatId,
+        receiver_user_id,
+        ephemeral_message_id,
+      });
+      expect(ok).toBe(true);
     });
   });
 

--- a/test/unit/context.test.ts
+++ b/test/unit/context.test.ts
@@ -128,6 +128,7 @@ describe("Context", () => {
       { kind: "business_message", payload: { message_id: 1, date: 0, chat: { id: 1, type: "private" }, from: user, text: "x" } },
       { kind: "guest_message", payload: { message_id: 1, date: 0, chat: { id: 1, type: "private" }, from: user, text: "x" } },
       { kind: "managed_bot", payload: { user, bot: { id: 2, is_bot: true, first_name: "B" } } },
+      { kind: "subscription", payload: { user, invoice_payload: "e2e", state: "active" } },
     ];
     for (const { kind, payload } of cases) {
       const ctx = new Context({ update_id: 1, [kind]: payload } as unknown as Update, api);


### PR DESCRIPTION
- [x] `npm run check` is clean (typecheck src + test + examples, `lint:core`, `check:edge`, unit suite)
- [x] `npm run build` is clean
- [x] Generated files are untouched / regenerated (`src/types/schemas.ts` and `src/core/api.ts` come from `npm run generate:types`; never hand-edit)

### Description

Adds support for Telegram Bot API 10.2.

- Regenerates the public types and `Api` client.
- Adds rich-message, ephemeral-message, community, and subscription update support.
- Adds live E2E coverage for all five ephemeral-message methods.
- Updates `Context` extraction, generated API documentation, the changelog, and the README badge.
- Deduplicates composite union members emitted by the API parser after Telegram changed upload parameter wording.

The five scoped live E2E tests and the API method coverage guard also pass.

### References

- [Telegram Bot API 10.2 changelog](https://core.telegram.org/bots/api-changelog#july-14-2026)
- [Telegram Bot API reference](https://core.telegram.org/bots/api)

---

### Running the test suite

The project ships two test layers and runs under both Bun and Node. All scripts
assume `npm install` (or `bun install`) has been run first.

#### Unit tests

Pure unit tests with no network. Safe to run anywhere - no token required.

```bash
npm test                  # Bun (bun:test) - the default unit run
npm run test:node:unit    # Node (node:test via tsx)
```

The full local gate is `npm run check` - it chains the typechecks (`src` +
`test` + `examples`), `lint:core` and `check:edge` (keeping `src/core` free of
`node:*` imports / Node globals / bundled builtins), and the unit suite.

#### E2E tests

Hit `api.telegram.org` directly. Methods that would brick the shared test bot
or need a chat it lacks (e.g. `logOut`, `close`, the forum-topic ops, ...) are
`test.skip`-ed so the suite never terminates the session or floods. There is
**no skip-if-no-token guard** - without valid credentials the real calls reject
and the tests fail by design.

**Required environment variables** (read from `.env`; Bun loads it automatically)

| Var | Purpose |
| --- | --- |
| `NODE_TELEGRAM_TOKEN` | Bot token (`TEST_TELEGRAM_TOKEN` is read as a fallback). Create one via [@BotFather](https://t.me/BotFather). |
| `TEST_GROUP_ID` | Chat id where the bot can send messages (group or private). |
| `TEST_USER_ID` | A user id the bot can resolve in `TEST_GROUP_ID`. |

```bash
npm run test:e2e    # bun test --timeout 300000 test/e2e
```

> **Tip:** add the bot to a private test group, grab its id with
> [`@RawDataBot`](https://t.me/RawDataBot) (or any update logger), and
> use that id for `TEST_GROUP_ID`. The suite is slow and flood-limited, so run
> it scoped to the methods you changed (see the `run-tests` skill).