### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+## [2.0.0][2.0.0] - 2026-08-16
+
 ### Bot API 10.2 (July 14, 2026)
 
 #### Rich Messages
@@ -1073,4 +1075,5 @@ Fixed:
 [1.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.0
 [1.1.1]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.1
 [1.1.2]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.2
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v1.1.2...master
+[2.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.0.0
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v2.0.0...master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "description": "Telegram Bot API - runtime-agnostic TypeScript client (v2).",
   "type": "module",
   "main": "./dist/core/index.cjs",


### PR DESCRIPTION
- [x] `npm run check` is clean (typecheck src + test + examples, `lint:core`, `check:edge`, unit suite)
- [x] `npm run build` is clean
- [x] Generated files are untouched / regenerated (`src/types/schemas.ts` and `src/core/api.ts` come from `npm run generate:types`; never hand-edit)

### Description

Prepares the stable v2.0.0 release.

- Bumps the package version from `2.0.0-alpha.3` to `2.0.0`.
- Moves the accumulated v2 changes under the dated `2.0.0` changelog section.
- Updates the release and Unreleased comparison links.
- Leaves `bun.lock` unchanged, as expected.

### References

- [Bot API 10.2 support PR #1340](https://github.com/yagop/node-telegram-bot-api/pull/1340)

---

### Running the test suite

The project ships two test layers and runs under both Bun and Node. All scripts
assume `npm install` (or `bun install`) has been run first.

#### Unit tests

Pure unit tests with no network. Safe to run anywhere - no token required.

```bash
npm test                  # Bun (bun:test) - the default unit run
npm run test:node:unit    # Node (node:test via tsx)
```

The full local gate is `npm run check` - it chains the typechecks (`src` +
`test` + `examples`), `lint:core` and `check:edge` (keeping `src/core` free of
`node:*` imports / Node globals / bundled builtins), and the unit suite.

#### E2E tests

Hit `api.telegram.org` directly. Methods that would brick the shared test bot
or need a chat it lacks (e.g. `logOut`, `close`, the forum-topic ops, ...) are
`test.skip`-ed so the suite never terminates the session or floods. There is
**no skip-if-no-token guard** - without valid credentials the real calls reject
and the tests fail by design.

**Required environment variables** (read from `.env`; Bun loads it automatically)

| Var | Purpose |
| --- | --- |
| `NODE_TELEGRAM_TOKEN` | Bot token (`TEST_TELEGRAM_TOKEN` is read as a fallback). Create one via [@BotFather](https://t.me/BotFather). |
| `TEST_GROUP_ID` | Chat id where the bot can send messages (group or private). |
| `TEST_USER_ID` | A user id the bot can resolve in `TEST_GROUP_ID`. |

```bash
npm run test:e2e    # bun test --timeout 300000 test/e2e
```

> **Tip:** add the bot to a private test group, grab its id with
> [`@RawDataBot`](https://t.me/RawDataBot) (or any update logger), and
> use that id for `TEST_GROUP_ID`. The suite is slow and flood-limited, so run
> it scoped to the methods you changed (see the `run-tests` skill).