### PR TITLE
refactor(api-parser): bracket table rows with onEndTag

### DIFF
--- a/test/unit/encode.test.ts
+++ b/test/unit/encode.test.ts
@@ -110,4 +110,28 @@ describe("encodeForm", () => {
     assert.strictEqual(await norm(buffered), await norm(streamed));
     assert.strictEqual(await norm(buffered), await norm(buffered), "Blob body drains repeatedly");
   });
+
+  test("a surrogate pair straddling a 2048 UTF-16-code-unit boundary survives intact (#1335)", async () => {
+    // v1's qs-based transport split exactly this shape of string at 1024-unit
+    // chunk boundaries and corrupted the message Telegram received. The native
+    // encoders here must round-trip it unchanged if the transport ever changes.
+    const emoji = "\u{1F50E}"; // astral char = one surrogate pair
+    const text = `<b>${"P".repeat(2044)}${emoji}</b>${"P".repeat(10)}`;
+    // the pair occupies UTF-16 units [2047, 2048], straddling the 2048 boundary
+    assert.strictEqual(text.slice(2047, 2049), emoji);
+
+    // urlencoded: the decoded value is the exact original string
+    const urlencoded = await encodeForm({ chat_id: 1, text, parse_mode: "HTML" });
+    const params = urlencoded.body();
+    assert.ok(params instanceof URLSearchParams);
+    assert.strictEqual(params.get("text"), text);
+
+    // multipart: a string field is one TextEncoder piece, never chunked
+    const multipart = await encodeForm(
+      { chat_id: 1, text, parse_mode: "HTML", photo: new InputFile(new Uint8Array([65]), { filename: "p.png" }) },
+      true,
+    );
+    const wire = await bodyText(multipart.body());
+    assert.ok(wire.includes(`name="text"\r\n\r\n${text}\r\n`));
+  });
 });


### PR DESCRIPTION
## Summary

Refactors table/list text extraction in `scripts/api-parser.ts`, plus a devDependency bump and one regression test.

**`scripts/api-parser.ts`**
- Bracket table rows with `onEndTag` instead of the `_pendingRow` deferred-materialization flag: `<tr>` opens a `curRow` buffer and its `</tr>` end-tag commits it (a `<th>`-bearing row into `headers`, otherwise into `rows`). Drops the `_pendingRow` field and the `lastCell` helper.
- Collapse the separate `th` and `td` element handlers into one shared `cellHandler` (a `<th>` just flags the row as a header).
- Extract an `appendLast` helper for appending HTMLRewriter's streamed text chunks to the open slot, reused by both table cells and `<ul><li>` list items.

**`package.json` / `bun.lock`**
- Bump the `bun` devDependency to 1.4.0.

**`test/unit/encode.test.ts`**
- Add a regression test (#1335): a surrogate pair straddling a 2048 UTF-16-code-unit boundary must round-trip unchanged through the native urlencoded and multipart encoders, guarding against the v1 qs chunk-splitting bug.

## Test plan

- `bun test test/unit/encode.test.ts` passes (7/7).
- `npm run generate:types` produces **zero diff** to the generated sources (`src/core/api.ts`, `src/types/schemas.ts`) - the generator refactor is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)