### PR TITLE
Support Bot API 10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+### Bot API 10.3 (August 24, 2026)
+
+#### Rich Messages
+
+- Added `RichMessageButton`, `RichTextButton`, `RichBlockButtons`/`InputRichBlockButtons`,
+  `RichBlockExpandableBlockQuotation`/`InputRichBlockExpandableBlockQuotation`, and
+  `RichBlockDocument`/`InputRichBlockDocument`.
+- Added `is_compact` to `RichBlockTable` and `InputRichBlockTable`, `InputMediaDocument`
+  to `InputRichMessageMedia.media`, and support for `tg://document?id=` upload links.
+
+#### Ephemeral Messages
+
+- Added `EphemeralMessageParameters` and replaced `receiver_user_id`/`callback_query_id`
+  with `ephemeral_message_parameters` in the 13 supported send methods; added
+  `ephemeral_message_parameters` to `sendRichMessage`.
+- Added `replace_callback_query_message` to `EphemeralMessageParameters`, file upload
+  in `editEphemeralMessageMedia`, `show_caption_above_media` to
+  `editEphemeralMessageCaption`, and `rich_message` to `editEphemeralMessageText`.
+- Added `can_send_welcome_messages` to `ChatAdministratorRights`,
+  `ChatMemberAdministrator`, and `promoteChatMember`.
+
+#### Reply markup
+
+- Added `DisabledButton` and `disabled` on `InlineKeyboardButton`, plus `force_reply`
+  on `InlineKeyboardMarkup` and `ReplyKeyboardMarkup`.
+
+#### General
+
+- Added `can_stop`/`keep_on_stop` to `sendMessageDraft` and `sendRichMessageDraft`.
+- Added `MessageGenerationStopped` and the `stopped_message_generation` update type.
+- Added `CommunityChatJoined` and `Message.community_chat_joined`.
+- Added `text`, `entities`, and `is_private` to `UniqueGiftInfo`.
+
 ## [2.0.0][2.0.0] - 2026-08-16
 
 ### Bot API 10.2 (July 14, 2026)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align=center>
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-v.10.2-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-v.10.3-00aced.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![npm package](https://img.shields.io/npm/v/node-telegram-bot-api?logo=npm&style=flat-square)](https://www.npmjs.org/package/node-telegram-bot-api)
 
 [![https://telegram.me/node_telegram_bot_api](https://img.shields.io/badge/💬%20Telegram-Channel-blue.svg?style=flat-square)](https://telegram.me/node_telegram_bot_api)

--- a/doc/api.md
+++ b/doc/api.md
@@ -226,7 +226,7 @@ An animated profile photo (a video); `main_frame_timestamp` picks the still fram
 | `handleUpdate` | `update`: [Update](#update) | Promise<void> | Build a Context and run the composed chain; route errors to the `catch` boundary (default: log and continue). Rejects only when that boundary itself throws. |
 | `hears` | `trigger`: string \| RegExp \| (string \| RegExp)[], `...handlers`: [Middleware](#middleware)<[Context](#context)>[] | this | Match message text: a string matches exactly (sets `ctx.match` to the text); a RegExp matches when `text.match(re)` is non-null (sets `ctx.match` to the `RegExpMatchArray`). |
 | `isRunning` | - | boolean | - |
-| `on` | `kind`: "message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| "subscription" \| ("message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| "subscription")[], `...handlers`: [Middleware](#middleware)<[Context](#context)>[] | this | Run `handlers` only when the given payload key (e.g. `"message"`, `"callback_query"`) is present on the update. |
+| `on` | `kind`: "message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| "subscription" \| "stopped_message_generation" \| ("message" \| "edited_message" \| "channel_post" \| "edited_channel_post" \| "business_connection" \| "business_message" \| "edited_business_message" \| "deleted_business_messages" \| "guest_message" \| "message_reaction" \| "message_reaction_count" \| "inline_query" \| "chosen_inline_result" \| "callback_query" \| "shipping_query" \| "pre_checkout_query" \| "purchased_paid_media" \| "poll" \| "poll_answer" \| "my_chat_member" \| "chat_member" \| "chat_join_request" \| "chat_boost" \| "removed_chat_boost" \| "managed_bot" \| "subscription" \| "stopped_message_generation")[], `...handlers`: [Middleware](#middleware)<[Context](#context)>[] | this | Run `handlers` only when the given payload key (e.g. `"message"`, `"callback_query"`) is present on the update. |
 | `startPolling` | `source?`: AsyncIterable<[Update](#update), any, any>, `options?`: [LongPollOptions](#longpolloptions) | Promise<void> | Pump an update source (default `longPoll`) through `handleUpdate` until `stop()` aborts. Resolves when the source is exhausted or aborted. This is long-poll mode; for webhooks use `webhookCallback`/`createWebhookServer`.  A handler error does not stop the pump: it is routed to the `catch` boundary (default: log and continue). The promise rejects only when that boundary itself throws - the fail-loud opt-in (see `catch`).  Not re-entrant: calling it while a previous pump is still active throws, so `isRunning()` stays truthful and the prior `AbortController` is never orphaned. Stop the running loop (`stop()`, then `await` its promise) first. |
 | `stop` | - | void | Abort the running pump loop. |
 | `use` | `...mw`: [Middleware](#middleware)<[Context](#context)>[] | this | Register one or more middleware to run on every update. |
@@ -1590,6 +1590,7 @@ type ChatAdministratorRights = {
   can_post_stories: boolean;
   can_promote_members: boolean;
   can_restrict_members: boolean;
+  can_send_welcome_messages: boolean;
   is_anonymous: boolean;
 };
 ```
@@ -1813,6 +1814,7 @@ type ChatMemberAdministrator = {
   can_post_stories: boolean;
   can_promote_members: boolean;
   can_restrict_members: boolean;
+  can_send_welcome_messages: boolean;
   custom_title?: string;
   is_anonymous: boolean;
   status: string;
@@ -2076,6 +2078,14 @@ type Community = {
 
 ```ts
 type CommunityChatAdded = {
+  community: [Community](#community);
+};
+```
+
+### `CommunityChatJoined`
+
+```ts
+type CommunityChatJoined = {
   community: [Community](#community);
 };
 ```
@@ -2545,6 +2555,12 @@ type DirectMessagesTopic = {
 };
 ```
 
+### `DisabledButton`
+
+```ts
+type DisabledButton = Record<string, never>;
+```
+
 ### `Document`
 
 ```ts
@@ -2604,6 +2620,7 @@ type EditEphemeralMessageCaptionParams = {
   parse_mode?: string;
   receiver_user_id: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
+  show_caption_above_media?: boolean;
 };
 ```
 
@@ -2659,7 +2676,8 @@ type EditEphemeralMessageTextParams = {
   parse_mode?: string;
   receiver_user_id: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup);
-  text: string;
+  rich_message?: [InputRichMessage](#inputrichmessage);
+  text?: string;
 };
 ```
 
@@ -2885,6 +2903,16 @@ type EncryptedPassportElement = {
   selfie?: [PassportFile](#passportfile);
   translation?: [PassportFile](#passportfile)[];
   type: string;
+};
+```
+
+### `EphemeralMessageParameters`
+
+```ts
+type EphemeralMessageParameters = {
+  callback_query_id?: string;
+  receiver_user_id: number;
+  replace_callback_query_message?: boolean;
 };
 ```
 
@@ -3719,6 +3747,7 @@ type InlineKeyboardButton = {
   callback_data?: string;
   callback_game?: [CallbackGame](#callbackgame);
   copy_text?: [CopyTextButton](#copytextbutton);
+  disabled?: [DisabledButton](#disabledbutton);
   icon_custom_emoji_id?: string;
   login_url?: [LoginUrl](#loginurl);
   pay?: boolean;
@@ -3736,6 +3765,7 @@ type InlineKeyboardButton = {
 
 ```ts
 type InlineKeyboardMarkup = {
+  force_reply?: boolean;
   inline_keyboard: [InlineKeyboardButton](#inlinekeyboardbutton)[][];
 };
 ```
@@ -4489,7 +4519,7 @@ type InputProfilePhotoStatic = {
 ### `InputRichBlock`
 
 ```ts
-type InputRichBlock = [InputRichBlockParagraph](#inputrichblockparagraph) | [InputRichBlockSectionHeading](#inputrichblocksectionheading) | [InputRichBlockPreformatted](#inputrichblockpreformatted) | [InputRichBlockFooter](#inputrichblockfooter) | [InputRichBlockDivider](#inputrichblockdivider) | [InputRichBlockMathematicalExpression](#inputrichblockmathematicalexpression) | [InputRichBlockAnchor](#inputrichblockanchor) | [InputRichBlockList](#inputrichblocklist) | [InputRichBlockBlockQuotation](#inputrichblockblockquotation) | [InputRichBlockPullQuotation](#inputrichblockpullquotation) | [InputRichBlockCollage](#inputrichblockcollage) | [InputRichBlockSlideshow](#inputrichblockslideshow) | [InputRichBlockTable](#inputrichblocktable) | [InputRichBlockDetails](#inputrichblockdetails) | [InputRichBlockMap](#inputrichblockmap) | [InputRichBlockAnimation](#inputrichblockanimation) | [InputRichBlockAudio](#inputrichblockaudio) | [InputRichBlockPhoto](#inputrichblockphoto) | [InputRichBlockVideo](#inputrichblockvideo) | [InputRichBlockVoiceNote](#inputrichblockvoicenote) | [InputRichBlockThinking](#inputrichblockthinking);
+type InputRichBlock = [InputRichBlockParagraph](#inputrichblockparagraph) | [InputRichBlockSectionHeading](#inputrichblocksectionheading) | [InputRichBlockPreformatted](#inputrichblockpreformatted) | [InputRichBlockFooter](#inputrichblockfooter) | [InputRichBlockDivider](#inputrichblockdivider) | [InputRichBlockMathematicalExpression](#inputrichblockmathematicalexpression) | [InputRichBlockAnchor](#inputrichblockanchor) | [InputRichBlockList](#inputrichblocklist) | [InputRichBlockBlockQuotation](#inputrichblockblockquotation) | [InputRichBlockExpandableBlockQuotation](#inputrichblockexpandableblockquotation) | [InputRichBlockPullQuotation](#inputrichblockpullquotation) | [InputRichBlockCollage](#inputrichblockcollage) | [InputRichBlockSlideshow](#inputrichblockslideshow) | [InputRichBlockTable](#inputrichblocktable) | [InputRichBlockDetails](#inputrichblockdetails) | [InputRichBlockMap](#inputrichblockmap) | [InputRichBlockButtons](#inputrichblockbuttons) | [InputRichBlockAnimation](#inputrichblockanimation) | [InputRichBlockAudio](#inputrichblockaudio) | [InputRichBlockDocument](#inputrichblockdocument) | [InputRichBlockPhoto](#inputrichblockphoto) | [InputRichBlockVideo](#inputrichblockvideo) | [InputRichBlockVoiceNote](#inputrichblockvoicenote) | [InputRichBlockThinking](#inputrichblockthinking);
 ```
 
 ### `InputRichBlockAnchor`
@@ -4531,6 +4561,16 @@ type InputRichBlockBlockQuotation = {
 };
 ```
 
+### `InputRichBlockButtons`
+
+```ts
+type InputRichBlockButtons = {
+  align?: string;
+  buttons: [RichMessageButton](#richmessagebutton)[];
+  type: string;
+};
+```
+
 ### `InputRichBlockCollage`
 
 ```ts
@@ -4556,6 +4596,26 @@ type InputRichBlockDetails = {
 
 ```ts
 type InputRichBlockDivider = {
+  type: string;
+};
+```
+
+### `InputRichBlockDocument`
+
+```ts
+type InputRichBlockDocument = {
+  caption?: [RichBlockCaption](#richblockcaption);
+  document: [InputMediaDocument](#inputmediadocument);
+  type: string;
+};
+```
+
+### `InputRichBlockExpandableBlockQuotation`
+
+```ts
+type InputRichBlockExpandableBlockQuotation = {
+  credit?: [RichText](#richtext);
+  text: [RichText](#richtext);
   type: string;
 };
 ```
@@ -4595,11 +4655,11 @@ type InputRichBlockListItem = {
 ```ts
 type InputRichBlockMap = {
   caption?: [RichBlockCaption](#richblockcaption);
-  height: number;
+  height?: number;
   location: [Location](#location);
   type: string;
-  width: number;
-  zoom: number;
+  width?: number;
+  zoom?: number;
 };
 ```
 
@@ -4678,6 +4738,7 @@ type InputRichBlockTable = {
   caption?: [RichText](#richtext);
   cells: [RichBlockTableCell](#richblocktablecell)[][];
   is_bordered?: true;
+  is_compact?: true;
   is_striped?: true;
   type: string;
 };
@@ -4738,7 +4799,7 @@ type InputRichMessageContent = {
 ```ts
 type InputRichMessageMedia = {
   id: string;
-  media: [InputMediaAnimation](#inputmediaanimation) | [InputMediaAudio](#inputmediaaudio) | [InputMediaPhoto](#inputmediaphoto) | [InputMediaVideo](#inputmediavideo) | [InputMediaVoiceNote](#inputmediavoicenote);
+  media: [InputMediaAnimation](#inputmediaanimation) | [InputMediaAudio](#inputmediaaudio) | [InputMediaDocument](#inputmediadocument) | [InputMediaPhoto](#inputmediaphoto) | [InputMediaVideo](#inputmediavideo) | [InputMediaVoiceNote](#inputmediavoicenote);
 };
 ```
 
@@ -5078,6 +5139,7 @@ type Message = {
   checklist_tasks_added?: [ChecklistTasksAdded](#checklisttasksadded);
   checklist_tasks_done?: [ChecklistTasksDone](#checklisttasksdone);
   community_chat_added?: [CommunityChatAdded](#communitychatadded);
+  community_chat_joined?: [CommunityChatJoined](#communitychatjoined);
   community_chat_removed?: [CommunityChatRemoved](#communitychatremoved);
   connected_website?: string;
   contact?: [Contact](#contact);
@@ -5204,6 +5266,16 @@ type MessageEntity = {
   unix_time?: number;
   url?: string;
   user?: [User](#user);
+};
+```
+
+### `MessageGenerationStopped`
+
+```ts
+type MessageGenerationStopped = {
+  chat: [Chat](#chat);
+  draft_id: number;
+  message_thread_id?: number;
 };
 ```
 
@@ -5770,6 +5842,7 @@ type PromoteChatMemberParams = {
   can_post_stories?: boolean;
   can_promote_members?: boolean;
   can_restrict_members?: boolean;
+  can_send_welcome_messages?: boolean;
   chat_id: number | string;
   is_anonymous?: boolean;
   user_id: number;
@@ -5995,6 +6068,7 @@ type ReplaceStickerInSetResult = boolean;
 
 ```ts
 type ReplyKeyboardMarkup = {
+  force_reply?: boolean;
   input_field_placeholder?: string;
   is_persistent?: boolean;
   keyboard: [KeyboardButton](#keyboardbutton)[][];
@@ -6134,7 +6208,7 @@ type RevokeChatInviteLinkResult = [ChatInviteLink](#chatinvitelink);
 ### `RichBlock`
 
 ```ts
-type RichBlock = [RichBlockParagraph](#richblockparagraph) | [RichBlockSectionHeading](#richblocksectionheading) | [RichBlockPreformatted](#richblockpreformatted) | [RichBlockFooter](#richblockfooter) | [RichBlockDivider](#richblockdivider) | [RichBlockMathematicalExpression](#richblockmathematicalexpression) | [RichBlockAnchor](#richblockanchor) | [RichBlockList](#richblocklist) | [RichBlockBlockQuotation](#richblockblockquotation) | [RichBlockPullQuotation](#richblockpullquotation) | [RichBlockCollage](#richblockcollage) | [RichBlockSlideshow](#richblockslideshow) | [RichBlockTable](#richblocktable) | [RichBlockDetails](#richblockdetails) | [RichBlockMap](#richblockmap) | [RichBlockAnimation](#richblockanimation) | [RichBlockAudio](#richblockaudio) | [RichBlockPhoto](#richblockphoto) | [RichBlockVideo](#richblockvideo) | [RichBlockVoiceNote](#richblockvoicenote) | [RichBlockThinking](#richblockthinking);
+type RichBlock = [RichBlockParagraph](#richblockparagraph) | [RichBlockSectionHeading](#richblocksectionheading) | [RichBlockPreformatted](#richblockpreformatted) | [RichBlockFooter](#richblockfooter) | [RichBlockDivider](#richblockdivider) | [RichBlockMathematicalExpression](#richblockmathematicalexpression) | [RichBlockAnchor](#richblockanchor) | [RichBlockList](#richblocklist) | [RichBlockBlockQuotation](#richblockblockquotation) | [RichBlockExpandableBlockQuotation](#richblockexpandableblockquotation) | [RichBlockPullQuotation](#richblockpullquotation) | [RichBlockCollage](#richblockcollage) | [RichBlockSlideshow](#richblockslideshow) | [RichBlockTable](#richblocktable) | [RichBlockDetails](#richblockdetails) | [RichBlockMap](#richblockmap) | [RichBlockButtons](#richblockbuttons) | [RichBlockAnimation](#richblockanimation) | [RichBlockAudio](#richblockaudio) | [RichBlockDocument](#richblockdocument) | [RichBlockPhoto](#richblockphoto) | [RichBlockVideo](#richblockvideo) | [RichBlockVoiceNote](#richblockvoicenote) | [RichBlockThinking](#richblockthinking);
 ```
 
 ### `RichBlockAnchor`
@@ -6177,6 +6251,16 @@ type RichBlockBlockQuotation = {
 };
 ```
 
+### `RichBlockButtons`
+
+```ts
+type RichBlockButtons = {
+  align?: string;
+  buttons: [RichMessageButton](#richmessagebutton)[];
+  type: string;
+};
+```
+
 ### `RichBlockCaption`
 
 ```ts
@@ -6211,6 +6295,26 @@ type RichBlockDetails = {
 
 ```ts
 type RichBlockDivider = {
+  type: string;
+};
+```
+
+### `RichBlockDocument`
+
+```ts
+type RichBlockDocument = {
+  caption?: [RichBlockCaption](#richblockcaption);
+  document: [Document](#document);
+  type: string;
+};
+```
+
+### `RichBlockExpandableBlockQuotation`
+
+```ts
+type RichBlockExpandableBlockQuotation = {
+  credit?: [RichText](#richtext);
+  text: [RichText](#richtext);
   type: string;
 };
 ```
@@ -6335,6 +6439,7 @@ type RichBlockTable = {
   caption?: [RichText](#richtext);
   cells: [RichBlockTableCell](#richblocktablecell)[][];
   is_bordered?: true;
+  is_compact?: true;
   is_striped?: true;
   type: string;
 };
@@ -6392,10 +6497,28 @@ type RichMessage = {
 };
 ```
 
+### `RichMessageButton`
+
+```ts
+type RichMessageButton = {
+  callback_data?: string;
+  copy_text?: [CopyTextButton](#copytextbutton);
+  disabled?: [DisabledButton](#disabledbutton);
+  login_url?: [LoginUrl](#loginurl);
+  style?: string;
+  switch_inline_query?: string;
+  switch_inline_query_chosen_chat?: [SwitchInlineQueryChosenChat](#switchinlinequerychosenchat);
+  switch_inline_query_current_chat?: string;
+  text: [RichText](#richtext);
+  url?: string;
+  web_app?: [WebAppInfo](#webappinfo);
+};
+```
+
 ### `RichText`
 
 ```ts
-type RichText = [RichTextBold](#richtextbold) | [RichTextItalic](#richtextitalic) | [RichTextUnderline](#richtextunderline) | [RichTextStrikethrough](#richtextstrikethrough) | [RichTextSpoiler](#richtextspoiler) | [RichTextDateTime](#richtextdatetime) | [RichTextTextMention](#richtexttextmention) | [RichTextSubscript](#richtextsubscript) | [RichTextSuperscript](#richtextsuperscript) | [RichTextMarked](#richtextmarked) | [RichTextCode](#richtextcode) | [RichTextCustomEmoji](#richtextcustomemoji) | [RichTextMathematicalExpression](#richtextmathematicalexpression) | [RichTextUrl](#richtexturl) | [RichTextEmailAddress](#richtextemailaddress) | [RichTextPhoneNumber](#richtextphonenumber) | [RichTextBankCardNumber](#richtextbankcardnumber) | [RichTextMention](#richtextmention) | [RichTextHashtag](#richtexthashtag) | [RichTextCashtag](#richtextcashtag) | [RichTextBotCommand](#richtextbotcommand) | [RichTextAnchor](#richtextanchor) | [RichTextAnchorLink](#richtextanchorlink) | [RichTextReference](#richtextreference) | [RichTextReferenceLink](#richtextreferencelink);
+type RichText = [RichTextBold](#richtextbold) | [RichTextItalic](#richtextitalic) | [RichTextUnderline](#richtextunderline) | [RichTextStrikethrough](#richtextstrikethrough) | [RichTextSpoiler](#richtextspoiler) | [RichTextDateTime](#richtextdatetime) | [RichTextTextMention](#richtexttextmention) | [RichTextSubscript](#richtextsubscript) | [RichTextSuperscript](#richtextsuperscript) | [RichTextMarked](#richtextmarked) | [RichTextCode](#richtextcode) | [RichTextCustomEmoji](#richtextcustomemoji) | [RichTextMathematicalExpression](#richtextmathematicalexpression) | [RichTextUrl](#richtexturl) | [RichTextEmailAddress](#richtextemailaddress) | [RichTextPhoneNumber](#richtextphonenumber) | [RichTextBankCardNumber](#richtextbankcardnumber) | [RichTextMention](#richtextmention) | [RichTextHashtag](#richtexthashtag) | [RichTextCashtag](#richtextcashtag) | [RichTextBotCommand](#richtextbotcommand) | [RichTextButton](#richtextbutton) | [RichTextAnchor](#richtextanchor) | [RichTextAnchorLink](#richtextanchorlink) | [RichTextReference](#richtextreference) | [RichTextReferenceLink](#richtextreferencelink);
 ```
 
 ### `RichTextAnchor`
@@ -6442,6 +6565,15 @@ type RichTextBold = {
 type RichTextBotCommand = {
   bot_command: string;
   text: [RichText](#richtext);
+  type: string;
+};
+```
+
+### `RichTextButton`
+
+```ts
+type RichTextButton = {
+  button: [RichMessageButton](#richmessagebutton);
   type: string;
 };
 ```
@@ -6679,20 +6811,19 @@ type SendAnimationParams = {
   allow_paid_broadcast?: boolean;
   animation: [InputFile](#inputfile) | string;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   duration?: number;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   has_spoiler?: boolean;
   height?: number;
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -6715,19 +6846,18 @@ type SendAudioParams = {
   allow_paid_broadcast?: boolean;
   audio: [InputFile](#inputfile) | string;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   duration?: number;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   performer?: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6801,17 +6931,16 @@ type SendChecklistResult = [Message](#message);
 type SendContactParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   first_name: string;
   last_name?: string;
   message_effect_id?: string;
   message_thread_id?: number;
   phone_number: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6856,7 +6985,6 @@ type SendDiceResult = [Message](#message);
 type SendDocumentParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -6864,11 +6992,11 @@ type SendDocumentParams = {
   disable_content_type_detection?: boolean;
   disable_notification?: boolean;
   document: [InputFile](#inputfile) | string;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -6975,12 +7103,12 @@ type SendInvoiceResult = [Message](#message);
 type SendLivePhotoParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   has_spoiler?: boolean;
   live_photo: [InputFile](#inputfile) | string;
   message_effect_id?: string;
@@ -6988,7 +7116,6 @@ type SendLivePhotoParams = {
   parse_mode?: string;
   photo: [InputFile](#inputfile) | string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -7008,10 +7135,10 @@ type SendLivePhotoResult = [Message](#message);
 type SendLocationParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   heading?: number;
   horizontal_accuracy?: number;
   latitude: number;
@@ -7021,7 +7148,6 @@ type SendLocationParams = {
   message_thread_id?: number;
   protect_content?: boolean;
   proximity_alert_radius?: number;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -7061,9 +7187,11 @@ type SendMediaGroupResult = [Message](#message)[];
 
 ```ts
 type SendMessageDraftParams = {
+  can_stop?: boolean;
   chat_id: number;
   draft_id: number;
   entities?: [MessageEntity](#messageentity)[];
+  keep_on_stop?: boolean;
   message_thread_id?: number;
   parse_mode?: string;
   text?: string;
@@ -7082,17 +7210,16 @@ type SendMessageDraftResult = boolean;
 type SendMessageParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   entities?: [MessageEntity](#messageentity)[];
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   link_preview_options?: [LinkPreviewOptions](#linkpreviewoptions);
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -7142,19 +7269,18 @@ type SendPaidMediaResult = [Message](#message);
 type SendPhotoParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   has_spoiler?: boolean;
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   photo: [InputFile](#inputfile) | string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -7219,8 +7345,10 @@ type SendPollResult = [Message](#message);
 
 ```ts
 type SendRichMessageDraftParams = {
+  can_stop?: boolean;
   chat_id: number;
   draft_id: number;
+  keep_on_stop?: boolean;
   message_thread_id?: number;
   rich_message: [InputRichMessage](#inputrichmessage);
 };
@@ -7241,6 +7369,7 @@ type SendRichMessageParams = {
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
@@ -7263,15 +7392,14 @@ type SendRichMessageResult = [Message](#message);
 type SendStickerParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   emoji?: string;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   sticker: [InputFile](#inputfile) | string;
@@ -7292,10 +7420,10 @@ type SendVenueParams = {
   address: string;
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   foursquare_id?: string;
   foursquare_type?: string;
   google_place_id?: string;
@@ -7305,7 +7433,6 @@ type SendVenueParams = {
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -7325,16 +7452,15 @@ type SendVenueResult = [Message](#message);
 type SendVideoNoteParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   duration?: number;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   length?: number;
   message_effect_id?: string;
   message_thread_id?: number;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -7355,7 +7481,6 @@ type SendVideoNoteResult = [Message](#message);
 type SendVideoParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
@@ -7363,13 +7488,13 @@ type SendVideoParams = {
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   duration?: number;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   has_spoiler?: boolean;
   height?: number;
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   show_caption_above_media?: boolean;
@@ -7394,18 +7519,17 @@ type SendVideoResult = [Message](#message);
 type SendVoiceParams = {
   allow_paid_broadcast?: boolean;
   business_connection_id?: string;
-  callback_query_id?: string;
   caption?: string;
   caption_entities?: [MessageEntity](#messageentity)[];
   chat_id: number | string;
   direct_messages_topic_id?: number;
   disable_notification?: boolean;
   duration?: number;
+  ephemeral_message_parameters?: [EphemeralMessageParameters](#ephemeralmessageparameters);
   message_effect_id?: string;
   message_thread_id?: number;
   parse_mode?: string;
   protect_content?: boolean;
-  receiver_user_id?: number;
   reply_markup?: [InlineKeyboardMarkup](#inlinekeyboardmarkup) | [ReplyKeyboardMarkup](#replykeyboardmarkup) | [ReplyKeyboardRemove](#replykeyboardremove) | [ForceReply](#forcereply);
   reply_parameters?: [ReplyParameters](#replyparameters);
   suggested_post_parameters?: [SuggestedPostParameters](#suggestedpostparameters);
@@ -8497,12 +8621,15 @@ type UniqueGiftColors = {
 
 ```ts
 type UniqueGiftInfo = {
+  entities?: [MessageEntity](#messageentity)[];
   gift: [UniqueGift](#uniquegift);
+  is_private?: true;
   last_resale_amount?: number;
   last_resale_currency?: string;
   next_transfer_date?: number;
   origin: string;
   owned_gift_id?: string;
+  text?: string;
   transfer_star_count?: number;
 };
 ```
@@ -8694,6 +8821,10 @@ type Update = {
   update_id: number;
 } & {
   subscription: [BotSubscriptionUpdated](#botsubscriptionupdated);
+} | {
+  update_id: number;
+} & {
+  stopped_message_generation: [MessageGenerationStopped](#messagegenerationstopped);
 };
 ```
 
@@ -9035,7 +9166,7 @@ const HTTP_STATUS_TOO_MANY_REQUESTS: 429;
 `Update` field names dispatched as events (every `Update` payload key except `update_id`).
 
 ```ts
-const UPDATE_TYPES: readonly ["message", "edited_message", "channel_post", "edited_channel_post", "business_connection", "business_message", "edited_business_message", "deleted_business_messages", "guest_message", "message_reaction", "message_reaction_count", "inline_query", "chosen_inline_result", "callback_query", "shipping_query", "pre_checkout_query", "purchased_paid_media", "poll", "poll_answer", "my_chat_member", "chat_member", "chat_join_request", "chat_boost", "removed_chat_boost", "managed_bot", "subscription"];
+const UPDATE_TYPES: readonly ["message", "edited_message", "channel_post", "edited_channel_post", "business_connection", "business_message", "edited_business_message", "deleted_business_messages", "guest_message", "message_reaction", "message_reaction_count", "inline_query", "chosen_inline_result", "callback_query", "shipping_query", "pre_checkout_query", "purchased_paid_media", "poll", "poll_answer", "my_chat_member", "chat_member", "chat_join_request", "chat_boost", "removed_chat_boost", "managed_bot", "subscription", "stopped_message_generation"];
 ```
 
 ### `nextPagesWebhook`

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -66,6 +66,7 @@ const chatOf: { [K in UpdateType]: (u: Variant<K>) => Chat | undefined } = {
   removed_chat_boost: (u) => u.removed_chat_boost.chat,
   managed_bot: () => undefined,
   subscription: () => undefined,
+  stopped_message_generation: (u) => u.stopped_message_generation.chat,
 };
 
 /**
@@ -104,6 +105,8 @@ const fromOf: { [K in UpdateType]: (u: Variant<K>) => User | undefined } = {
   removed_chat_boost: () => undefined,
   managed_bot: (u) => u.managed_bot.user,
   subscription: (u) => u.subscription.user,
+  // MessageGenerationStopped carries only a chat, no acting user.
+  stopped_message_generation: () => undefined,
 };
 
 /**

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -57,7 +57,8 @@ export type Update =
   | ({ update_id: number } & { chat_boost: ChatBoostUpdated })
   | ({ update_id: number } & { removed_chat_boost: ChatBoostRemoved })
   | ({ update_id: number } & { managed_bot: ManagedBotUpdated })
-  | ({ update_id: number } & { subscription: BotSubscriptionUpdated });
+  | ({ update_id: number } & { subscription: BotSubscriptionUpdated })
+  | ({ update_id: number } & { stopped_message_generation: MessageGenerationStopped });
 
 
 /** `keyof` distributed over a union (each member's keys, unioned). */
@@ -94,6 +95,7 @@ export const UPDATE_TYPES = [
   "removed_chat_boost",
   "managed_bot",
   "subscription",
+  "stopped_message_generation",
 ] as const satisfies readonly Exclude<_UpdateKeys, "update_id">[];
 export type UpdateType = (typeof UPDATE_TYPES)[number];
 
@@ -301,6 +303,7 @@ export type Message = {
   checklist_tasks_done?: ChecklistTasksDone;
   checklist_tasks_added?: ChecklistTasksAdded;
   community_chat_added?: CommunityChatAdded;
+  community_chat_joined?: CommunityChatJoined;
   community_chat_removed?: CommunityChatRemoved;
   direct_message_price_changed?: DirectMessagePriceChanged;
   forum_topic_created?: ForumTopicCreated;
@@ -399,6 +402,12 @@ export type ReplyParameters = {
   quote_position?: number;
   checklist_task_id?: number;
   poll_option_id?: string;
+};
+
+export type EphemeralMessageParameters = {
+  receiver_user_id: number;
+  callback_query_id?: string;
+  replace_callback_query_message?: boolean;
 };
 
 export type MessageOriginUser = {
@@ -715,6 +724,12 @@ export type BotSubscriptionUpdated = {
   state: string;
 };
 
+export type MessageGenerationStopped = {
+  chat: Chat;
+  message_thread_id?: number;
+  draft_id: number;
+};
+
 export type PollOptionAdded = {
   poll_message?: MaybeInaccessibleMessage;
   option_persistent_id: string;
@@ -794,6 +809,10 @@ export type ChecklistTasksAdded = {
 };
 
 export type CommunityChatAdded = {
+  community: Community;
+};
+
+export type CommunityChatJoined = {
   community: Community;
 };
 
@@ -980,6 +999,7 @@ export type ReplyKeyboardMarkup = {
   one_time_keyboard?: boolean;
   input_field_placeholder?: string;
   selective?: boolean;
+  force_reply?: boolean;
 };
 
 export type KeyboardButton = {
@@ -1036,6 +1056,7 @@ export type ReplyKeyboardRemove = {
 
 export type InlineKeyboardMarkup = {
   inline_keyboard: InlineKeyboardButton[][];
+  force_reply?: boolean;
 };
 
 export type InlineKeyboardButton = {
@@ -1052,6 +1073,7 @@ export type InlineKeyboardButton = {
   copy_text?: CopyTextButton;
   callback_game?: CallbackGame;
   pay?: boolean;
+  disabled?: DisabledButton;
 };
 
 export type LoginUrl = {
@@ -1133,6 +1155,7 @@ export type ChatAdministratorRights = {
   can_manage_topics?: boolean;
   can_manage_direct_messages?: boolean;
   can_manage_tags?: boolean;
+  can_send_welcome_messages: boolean;
 };
 
 export type ChatMemberUpdated = {
@@ -1174,6 +1197,7 @@ export type ChatMemberAdministrator = {
   can_manage_topics?: boolean;
   can_manage_direct_messages?: boolean;
   can_manage_tags?: boolean;
+  can_send_welcome_messages: boolean;
   custom_title?: string;
 };
 
@@ -1475,6 +1499,9 @@ export type GiftInfo = {
 export type UniqueGiftInfo = {
   gift: UniqueGift;
   origin: string;
+  text?: string;
+  entities?: MessageEntity[];
+  is_private?: true;
   last_resale_currency?: string;
   last_resale_amount?: number;
   owned_gift_id?: string;
@@ -1920,7 +1947,21 @@ export type InputRichMessage = {
 
 export type InputRichMessageMedia = {
   id: string;
-  media: InputMediaAnimation | InputMediaAudio | InputMediaPhoto | InputMediaVideo | InputMediaVoiceNote;
+  media: InputMediaAnimation | InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo | InputMediaVoiceNote;
+};
+
+export type RichMessageButton = {
+  text: RichText;
+  style?: string;
+  url?: string;
+  callback_data?: string;
+  web_app?: WebAppInfo;
+  login_url?: LoginUrl;
+  switch_inline_query?: string;
+  switch_inline_query_current_chat?: string;
+  switch_inline_query_chosen_chat?: SwitchInlineQueryChosenChat;
+  copy_text?: CopyTextButton;
+  disabled?: DisabledButton;
 };
 
 export type RichTextBold = {
@@ -2040,6 +2081,11 @@ export type RichTextBotCommand = {
   bot_command: string;
 };
 
+export type RichTextButton = {
+  type: string;
+  button: RichMessageButton;
+};
+
 export type RichTextAnchor = {
   type: string;
   name: string;
@@ -2133,6 +2179,12 @@ export type RichBlockBlockQuotation = {
   credit?: RichText;
 };
 
+export type RichBlockExpandableBlockQuotation = {
+  type: string;
+  text: RichText;
+  credit?: RichText;
+};
+
 export type RichBlockPullQuotation = {
   type: string;
   text: RichText;
@@ -2156,6 +2208,7 @@ export type RichBlockTable = {
   cells: RichBlockTableCell[][];
   is_bordered?: true;
   is_striped?: true;
+  is_compact?: true;
   caption?: RichText;
 };
 
@@ -2175,6 +2228,12 @@ export type RichBlockMap = {
   caption?: RichBlockCaption;
 };
 
+export type RichBlockButtons = {
+  type: string;
+  buttons: RichMessageButton[];
+  align?: string;
+};
+
 export type RichBlockAnimation = {
   type: string;
   animation: Animation;
@@ -2185,6 +2244,12 @@ export type RichBlockAnimation = {
 export type RichBlockAudio = {
   type: string;
   audio: Audio;
+  caption?: RichBlockCaption;
+};
+
+export type RichBlockDocument = {
+  type: string;
+  document: Document;
   caption?: RichBlockCaption;
 };
 
@@ -2268,6 +2333,12 @@ export type InputRichBlockBlockQuotation = {
   credit?: RichText;
 };
 
+export type InputRichBlockExpandableBlockQuotation = {
+  type: string;
+  text: RichText;
+  credit?: RichText;
+};
+
 export type InputRichBlockPullQuotation = {
   type: string;
   text: RichText;
@@ -2291,6 +2362,7 @@ export type InputRichBlockTable = {
   cells: RichBlockTableCell[][];
   is_bordered?: true;
   is_striped?: true;
+  is_compact?: true;
   caption?: RichText;
 };
 
@@ -2304,10 +2376,16 @@ export type InputRichBlockDetails = {
 export type InputRichBlockMap = {
   type: string;
   location: Location;
-  zoom: number;
-  width: number;
-  height: number;
+  zoom?: number;
+  width?: number;
+  height?: number;
   caption?: RichBlockCaption;
+};
+
+export type InputRichBlockButtons = {
+  type: string;
+  buttons: RichMessageButton[];
+  align?: string;
 };
 
 export type InputRichBlockAnimation = {
@@ -2319,6 +2397,12 @@ export type InputRichBlockAnimation = {
 export type InputRichBlockAudio = {
   type: string;
   audio: InputMediaAudio;
+  caption?: RichBlockCaption;
+};
+
+export type InputRichBlockDocument = {
+  type: string;
+  document: InputMediaDocument;
   caption?: RichBlockCaption;
 };
 
@@ -2985,6 +3069,8 @@ export type CallbackGame = Record<string, never>;
 
 export type CommunityChatRemoved = Record<string, never>;
 
+export type DisabledButton = Record<string, never>;
+
 export type ForumTopicClosed = Record<string, never>;
 
 export type ForumTopicReopened = Record<string, never>;
@@ -3036,11 +3122,11 @@ export type InputProfilePhoto = InputProfilePhotoStatic | InputProfilePhotoAnima
 
 export type InputStoryContent = InputStoryContentPhoto | InputStoryContentVideo;
 
-export type RichText = RichTextBold | RichTextItalic | RichTextUnderline | RichTextStrikethrough | RichTextSpoiler | RichTextDateTime | RichTextTextMention | RichTextSubscript | RichTextSuperscript | RichTextMarked | RichTextCode | RichTextCustomEmoji | RichTextMathematicalExpression | RichTextUrl | RichTextEmailAddress | RichTextPhoneNumber | RichTextBankCardNumber | RichTextMention | RichTextHashtag | RichTextCashtag | RichTextBotCommand | RichTextAnchor | RichTextAnchorLink | RichTextReference | RichTextReferenceLink;
+export type RichText = RichTextBold | RichTextItalic | RichTextUnderline | RichTextStrikethrough | RichTextSpoiler | RichTextDateTime | RichTextTextMention | RichTextSubscript | RichTextSuperscript | RichTextMarked | RichTextCode | RichTextCustomEmoji | RichTextMathematicalExpression | RichTextUrl | RichTextEmailAddress | RichTextPhoneNumber | RichTextBankCardNumber | RichTextMention | RichTextHashtag | RichTextCashtag | RichTextBotCommand | RichTextButton | RichTextAnchor | RichTextAnchorLink | RichTextReference | RichTextReferenceLink;
 
-export type RichBlock = RichBlockParagraph | RichBlockSectionHeading | RichBlockPreformatted | RichBlockFooter | RichBlockDivider | RichBlockMathematicalExpression | RichBlockAnchor | RichBlockList | RichBlockBlockQuotation | RichBlockPullQuotation | RichBlockCollage | RichBlockSlideshow | RichBlockTable | RichBlockDetails | RichBlockMap | RichBlockAnimation | RichBlockAudio | RichBlockPhoto | RichBlockVideo | RichBlockVoiceNote | RichBlockThinking;
+export type RichBlock = RichBlockParagraph | RichBlockSectionHeading | RichBlockPreformatted | RichBlockFooter | RichBlockDivider | RichBlockMathematicalExpression | RichBlockAnchor | RichBlockList | RichBlockBlockQuotation | RichBlockExpandableBlockQuotation | RichBlockPullQuotation | RichBlockCollage | RichBlockSlideshow | RichBlockTable | RichBlockDetails | RichBlockMap | RichBlockButtons | RichBlockAnimation | RichBlockAudio | RichBlockDocument | RichBlockPhoto | RichBlockVideo | RichBlockVoiceNote | RichBlockThinking;
 
-export type InputRichBlock = InputRichBlockParagraph | InputRichBlockSectionHeading | InputRichBlockPreformatted | InputRichBlockFooter | InputRichBlockDivider | InputRichBlockMathematicalExpression | InputRichBlockAnchor | InputRichBlockList | InputRichBlockBlockQuotation | InputRichBlockPullQuotation | InputRichBlockCollage | InputRichBlockSlideshow | InputRichBlockTable | InputRichBlockDetails | InputRichBlockMap | InputRichBlockAnimation | InputRichBlockAudio | InputRichBlockPhoto | InputRichBlockVideo | InputRichBlockVoiceNote | InputRichBlockThinking;
+export type InputRichBlock = InputRichBlockParagraph | InputRichBlockSectionHeading | InputRichBlockPreformatted | InputRichBlockFooter | InputRichBlockDivider | InputRichBlockMathematicalExpression | InputRichBlockAnchor | InputRichBlockList | InputRichBlockBlockQuotation | InputRichBlockExpandableBlockQuotation | InputRichBlockPullQuotation | InputRichBlockCollage | InputRichBlockSlideshow | InputRichBlockTable | InputRichBlockDetails | InputRichBlockMap | InputRichBlockButtons | InputRichBlockAnimation | InputRichBlockAudio | InputRichBlockDocument | InputRichBlockPhoto | InputRichBlockVideo | InputRichBlockVoiceNote | InputRichBlockThinking;
 
 export type InlineQueryResult = InlineQueryResultCachedAudio | InlineQueryResultCachedDocument | InlineQueryResultCachedGif | InlineQueryResultCachedMpeg4Gif | InlineQueryResultCachedPhoto | InlineQueryResultCachedSticker | InlineQueryResultCachedVideo | InlineQueryResultCachedVoice | InlineQueryResultArticle | InlineQueryResultAudio | InlineQueryResultContact | InlineQueryResultGame | InlineQueryResultDocument | InlineQueryResultGif | InlineQueryResultLocation | InlineQueryResultMpeg4Gif | InlineQueryResultPhoto | InlineQueryResultVenue | InlineQueryResultVideo | InlineQueryResultVoice;
 
@@ -3098,8 +3184,7 @@ export type SendMessageParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   text: string;
   parse_mode?: string;
   entities?: MessageEntity[];
@@ -3177,8 +3262,7 @@ export type SendPhotoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   photo: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3200,8 +3284,7 @@ export type SendLivePhotoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   live_photo: InputFile | string;
   photo: InputFile | string;
   caption?: string;
@@ -3224,8 +3307,7 @@ export type SendAudioParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   audio: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3249,8 +3331,7 @@ export type SendDocumentParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   document: InputFile | string;
   thumbnail?: InputFile | string;
   caption?: string;
@@ -3272,8 +3353,7 @@ export type SendVideoParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   video: InputFile | string;
   duration?: number;
   width?: number;
@@ -3302,8 +3382,7 @@ export type SendAnimationParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   animation: InputFile | string;
   duration?: number;
   width?: number;
@@ -3329,8 +3408,7 @@ export type SendVoiceParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   voice: InputFile | string;
   caption?: string;
   parse_mode?: string;
@@ -3351,8 +3429,7 @@ export type SendVideoNoteParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   video_note: InputFile | string;
   duration?: number;
   length?: number;
@@ -3407,8 +3484,7 @@ export type SendLocationParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   latitude: number;
   longitude: number;
   horizontal_accuracy?: number;
@@ -3430,8 +3506,7 @@ export type SendVenueParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   latitude: number;
   longitude: number;
   title: string;
@@ -3455,8 +3530,7 @@ export type SendContactParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   phone_number: string;
   first_name: string;
   last_name?: string;
@@ -3544,6 +3618,8 @@ export type SendMessageDraftParams = {
   text?: string;
   parse_mode?: string;
   entities?: MessageEntity[];
+  can_stop?: boolean;
+  keep_on_stop?: boolean;
 };
 export type SendMessageDraftResult = boolean;
 
@@ -3633,6 +3709,7 @@ export type PromoteChatMemberParams = {
   can_manage_topics?: boolean;
   can_manage_direct_messages?: boolean;
   can_manage_tags?: boolean;
+  can_send_welcome_messages?: boolean;
 };
 export type PromoteChatMemberResult = boolean;
 
@@ -4356,9 +4433,10 @@ export type EditEphemeralMessageTextParams = {
   chat_id: number | string;
   receiver_user_id: number;
   ephemeral_message_id: number;
-  text: string;
+  text?: string;
   parse_mode?: string;
   entities?: MessageEntity[];
+  rich_message?: InputRichMessage;
   link_preview_options?: LinkPreviewOptions;
   reply_markup?: InlineKeyboardMarkup;
 };
@@ -4380,6 +4458,7 @@ export type EditEphemeralMessageCaptionParams = {
   caption?: string;
   parse_mode?: string;
   caption_entities?: MessageEntity[];
+  show_caption_above_media?: boolean;
   reply_markup?: InlineKeyboardMarkup;
 };
 export type EditEphemeralMessageCaptionResult = boolean;
@@ -4445,8 +4524,7 @@ export type SendStickerParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
-  receiver_user_id?: number;
-  callback_query_id?: string;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   sticker: InputFile | string;
   emoji?: string;
   disable_notification?: boolean;
@@ -4560,6 +4638,7 @@ export type SendRichMessageParams = {
   chat_id: number | string;
   message_thread_id?: number;
   direct_messages_topic_id?: number;
+  ephemeral_message_parameters?: EphemeralMessageParameters;
   rich_message: InputRichMessage;
   disable_notification?: boolean;
   protect_content?: boolean;
@@ -4576,6 +4655,8 @@ export type SendRichMessageDraftParams = {
   message_thread_id?: number;
   draft_id: number;
   rich_message: InputRichMessage;
+  can_stop?: boolean;
+  keep_on_stop?: boolean;
 };
 export type SendRichMessageDraftResult = boolean;
 

--- a/test/e2e/methods.test.ts
+++ b/test/e2e/methods.test.ts
@@ -1509,7 +1509,11 @@ describe("methods", () => {
   method("editEphemeralMessageText", () => {
     test("edits an ephemeral text message", async () => {
       const receiver_user_id = await targetUserId();
-      const sent = await api.sendMessage({ chat_id: chatId, receiver_user_id, text: "e2e ephemeral text" });
+      const sent = await api.sendMessage({
+        chat_id: chatId,
+        ephemeral_message_parameters: { receiver_user_id },
+        text: "e2e ephemeral text",
+      });
       expect(sent.ephemeral_message_id).toBeDefined();
       const ephemeral_message_id = sent.ephemeral_message_id as number;
       await api.editEphemeralMessageText({
@@ -1527,7 +1531,7 @@ describe("methods", () => {
       const receiver_user_id = await targetUserId();
       const sent = await api.sendPhoto({
         chat_id: chatId,
-        receiver_user_id,
+        ephemeral_message_parameters: { receiver_user_id },
         photo: new InputFile(JPEG_160, { filename: "e2e.jpg", contentType: "image/jpeg" }),
         caption: "e2e ephemeral media",
       });
@@ -1550,7 +1554,7 @@ describe("methods", () => {
       const receiver_user_id = await targetUserId();
       const sent = await api.sendPhoto({
         chat_id: chatId,
-        receiver_user_id,
+        ephemeral_message_parameters: { receiver_user_id },
         photo: new InputFile(JPEG_160, { filename: "e2e.jpg", contentType: "image/jpeg" }),
         caption: "e2e ephemeral caption",
       });
@@ -1571,7 +1575,7 @@ describe("methods", () => {
       const receiver_user_id = await targetUserId();
       const sent = await api.sendMessage({
         chat_id: chatId,
-        receiver_user_id,
+        ephemeral_message_parameters: { receiver_user_id },
         text: "e2e ephemeral reply markup",
         reply_markup: sampleInlineKeyboard,
       });
@@ -1634,7 +1638,11 @@ describe("methods", () => {
   method("deleteEphemeralMessage", () => {
     test("deletes an ephemeral message", async () => {
       const receiver_user_id = await targetUserId();
-      const sent = await api.sendMessage({ chat_id: chatId, receiver_user_id, text: "e2e ephemeral delete" });
+      const sent = await api.sendMessage({
+        chat_id: chatId,
+        ephemeral_message_parameters: { receiver_user_id },
+        text: "e2e ephemeral delete",
+      });
       expect(sent.ephemeral_message_id).toBeDefined();
       const ephemeral_message_id = sent.ephemeral_message_id as number;
       const ok = await api.deleteEphemeralMessage({


### PR DESCRIPTION
Adds support for [Bot API 10.3](https://core.telegram.org/bots/api-changelog#august-24-2026) (August 24, 2026).

## What changed

Regenerated the type surface (`src/types/schemas.ts`) and `Api` client (`src/core/api.ts`) via `bun scripts/api-parser.ts` - clean run, no unmapped types or return-type fallbacks. No new methods, so no new e2e `describe` blocks.

**Rich Messages**
- New `RichMessageButton`, `RichTextButton`, `RichBlockButtons`/`InputRichBlockButtons`, `RichBlockExpandableBlockQuotation`/`InputRichBlockExpandableBlockQuotation`, `RichBlockDocument`/`InputRichBlockDocument`.
- `is_compact` on `RichBlockTable`/`InputRichBlockTable`, `InputMediaDocument` in `InputRichMessageMedia.media`, `tg://document?id=` upload links.

**Ephemeral Messages**
- New `EphemeralMessageParameters`; `receiver_user_id`/`callback_query_id` replaced by `ephemeral_message_parameters` on the 13 send methods, and added to `sendRichMessage`.
- `replace_callback_query_message`, file upload in `editEphemeralMessageMedia`, `show_caption_above_media` on `editEphemeralMessageCaption`, `rich_message` on `editEphemeralMessageText`.
- `can_send_welcome_messages` on `ChatAdministratorRights`, `ChatMemberAdministrator`, `promoteChatMember`.

**Reply markup**
- `DisabledButton` + `disabled` on `InlineKeyboardButton`; `force_reply` on `InlineKeyboardMarkup`/`ReplyKeyboardMarkup`.

**General**
- `can_stop`/`keep_on_stop` on `sendMessageDraft`/`sendRichMessageDraft`.
- `MessageGenerationStopped` + `stopped_message_generation` update type.
- `CommunityChatJoined` + `Message.community_chat_joined`.
- `text`/`entities`/`is_private` on `UniqueGiftInfo`.

## Hand-work (beyond regeneration)
- `src/core/context.ts`: added `stopped_message_generation` rows to the exhaustive `chatOf`/`fromOf` resolvers (its payload has a `chat`, no acting user).
- `test/e2e/methods.test.ts`: migrated ephemeral send calls to `ephemeral_message_parameters`.
- Regenerated `doc/api.md`, added the CHANGELOG entry, bumped the README badge to v.10.3.

## Verification
- `npm run check` (typecheck x3 + lint:core + check:edge + 131 unit tests) - green.
- `npm run build` - green.
- Live e2e not run (needs a token, flood-limited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Arms6Kg2JSPbT3eGH8WNKh