### PR TITLE
feat(session): separate reply/press tables and caller-set TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,19 +34,30 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Reply and callback tracking
 
-- Added `expectReply(ctx, messageId, marker?)`, `matchReply<M>(ctx)` and
-  `forgetReply(ctx, messageId)` - "awaiting a reply to this message" recorded as
-  persisted data (matched on `reply_to_message.message_id`), never a live
-  continuation, so it survives a restart and works on serverless.
-- Added the callback-query peers `expectCallback(ctx, messageId, marker?)` and
-  `matchCallback<M>(ctx, { once? })`, keyed on `callback_query.message.message_id`
-  and sharing the same table. Matching a press does not consume the marker by
-  default (a keyboard usually stays live for several presses); `{ once: true }`
-  opts into a one-shot button. Plain `callback_data` remains the idiomatic router -
-  these are for a marker over 64 bytes, one the client must not read, or a
-  one-shot press.
-- Added `taggedReplies<Tag>(ctx)` - `expect` / `match` / `expectPress` /
-  `matchPress` / `forget` for plain string tags, typing both ends with one union.
+- Added `expectReply(ctx, messageId, marker?, { ttlSeconds? })`,
+  `matchReply<M>(ctx)` and `forgetReply(ctx, messageId)` - "awaiting a reply to
+  this message" recorded as persisted data (matched on
+  `reply_to_message.message_id`), never a live continuation, so it survives a
+  restart and works on serverless.
+- Added the callback-query peers `expectCallback(ctx, messageId, marker?, { ttlSeconds? })`,
+  `matchCallback<M>(ctx, { once? })` and `forgetCallback(ctx, messageId)`, keyed on
+  `callback_query.message.message_id`. Matching a press does not consume the marker
+  by default (a keyboard usually stays live for several presses); `{ once: true }`
+  makes a button fire at most once - it consumes only that message's marker, and
+  consumption happens before the handler runs. Plain `callback_data` remains the
+  idiomatic router - these are for a marker over 64 bytes, one the client must not
+  read, or a one-shot press.
+- Replies and presses are kept in **separate** tables, so a quoted reply to a
+  message that also carries an inline keyboard cannot consume the button's marker.
+- Expectations never expire on their own (a prompt answered tomorrow is normal);
+  `ttlSeconds` bounds one, and expired entries are pruned the next time the layer
+  touches the session, so a bot that sets a TTL cannot grow its envelope without
+  limit. There is no cap and no default.
+- Added `taggedReplies<Tag>(ctx)` - `expect` / `match` / `forget` / `expectPress` /
+  `matchPress` / `forgetPress` for plain string tags, typing both ends with one union.
+- Note the default session key is per chat, so in a group any member's reply or
+  press matches a marker; carry the asker's id in the marker and check it when
+  that matters.
 
 ### Bot lifecycle
 

--- a/README.md
+++ b/README.md
@@ -342,11 +342,15 @@ bot.on("message", async (ctx, next) => {
 });
 ```
 
-`taggedReplies` is sugar over the primitives `expectReply(ctx, id, marker?)` (stores any JSON marker object), `matchReply<M>(ctx)` (returns it typed as `M`) and `forgetReply(ctx, id)` (cancels a pending expectation). With a single prompt in flight you can drop the marker entirely - its presence alone is the signal.
+`taggedReplies` is sugar over the primitives `expectReply(ctx, id, marker?, { ttlSeconds? })` (stores any JSON marker object), `matchReply<M>(ctx)` (returns it typed as `M`) and `forgetReply(ctx, id)` (cancels a pending expectation). With a single prompt in flight you can drop the marker entirely - its presence alone is the signal.
+
+Nothing expires on its own: a prompt answered tomorrow is normal, so a marker stays pending until it matches or you forget it. Pass `ttlSeconds` for prompts that go stale (a confirmation, a one-time code) - expired entries are pruned the next time the layer touches the session, which is what keeps a chat that ignores every prompt from growing its envelope forever.
+
+The default session key is per **chat**, so in a group the marker belongs to the group and any member's reply or press matches it. Put the asker's id in the marker and check it when that matters.
 
 #### Button presses
 
-`expectCallback(ctx, id, marker?)` / `matchCallback<M>(ctx, { once? })` are the callback-query peers, keyed on `callback_query.message.message_id` and sharing the same table (`taggedReplies(ctx).expectPress` / `.matchPress` for string tags).
+`expectCallback(ctx, id, marker?, { ttlSeconds? })` / `matchCallback<M>(ctx, { once? })` are the callback-query peers, keyed on `callback_query.message.message_id` (`taggedReplies(ctx).expectPress` / `.matchPress` for string tags). Replies and presses live in **separate tables**, so a quoted reply to a message that also carries a keyboard cannot consume the button's marker; register both if a message can be answered either way.
 
 **Reach for them only when `callback_data` is not enough.** A button already carries 64 bytes you chose, round-tripped by Telegram for free - that is the idiomatic way to route a press, and it needs no session at all:
 
@@ -356,20 +360,29 @@ bot.on("callback_query", (ctx) => {
 });
 ```
 
-The session-backed version earns its keep for a marker that does not fit in 64 bytes, one the client must not read (`callback_data` is plain text in the app), or a button that must fire once:
+The session-backed version earns its keep for a marker that does not fit in 64 bytes, one the client must not read (`callback_data` is plain text in the app), or a button that must fire at most once:
 
 ```ts
 const sent = await ctx.reply("Delete everything?", { reply_markup: { inline_keyboard: [[{ text: "Yes", callback_data: "y" }]] } });
-expectCallback(ctx, sent.message_id, { op: "delete", scope: "all" });
+expectCallback(ctx, sent.message_id, { op: "delete", by: ctx.from?.id }, { ttlSeconds: 3600 });
 
 bot.on("callback_query", async (ctx, next) => {
-  const hit = matchCallback<{ op: string }>(ctx, { once: true }); // one-shot: a double tap can't fire twice
+  const hit = matchCallback<{ op: string; by?: number }>(ctx, { once: true });
   if (!hit) return next();
+  if (ctx.from?.id !== hit.by) return ctx.answerCallbackQuery({ text: "Not your button." });
   await ctx.answerCallbackQuery({ text: `Running ${hit.op}` });
 });
 ```
 
-Unlike a reply, matching a press does **not** consume the marker by default - an inline keyboard usually stays live for several presses (paging, a toggle), and consuming would break every press after the first. Pass `{ once: true }` for a one-shot button. A press on an inline-mode message carries no `message`, so there is nothing to key on; route those by `callback_data`.
+Unlike a reply, matching a press does **not** consume the marker by default - an inline keyboard usually stays live for several presses (paging, a toggle), and consuming would break every press after the first. Pass `{ once: true }` for a one-shot button.
+
+Three things worth knowing about that "once":
+
+- It consumes only *that message's* marker. Send two confirmations and both stay armed - `forgetCallback(ctx, previousId)` the older one if only the newest may act.
+- It is **at most once**, not exactly once: the marker is consumed before your handler runs, and the flush persists that even if the handler throws.
+- A press on an inline-mode message carries no `message`, so there is nothing to key on; route those by `callback_data`.
+
+[`examples/17-callback-tracking.ts`](examples/17-callback-tracking.ts) puts both routes in one bot: `callback_data` paging next to a one-shot, requester-checked confirmation.
 
 ### Storage backends
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -779,20 +779,24 @@ so tracing stays a no-op.
 ### `expectCallback()`
 
 Record that a **button press** on the message you just sent (`messageId`) is
-expected - the callback-query peer of expectReply, sharing one table,
-so a message cannot be awaiting a reply and a press under different markers.
+expected - the callback-query peer of expectReply, in its own table.
 
 Prefer plain `callback_data` when it suffices: Telegram round-trips those 64
 bytes for you, with no session and no store, and that is the idiomatic way to
 route a button. This is for what `callback_data` cannot carry - a marker too
 big for 64 bytes, one the client must not be able to read (callback_data is
-plain text in the app), or a button that must work only once.
+plain text in the app), or a button that must work at most once.
+
+The per-chat caveat on expectReply applies here too, and more sharply:
+an inline keyboard in a group is pressable by every member, so a destructive
+button should carry the requester's id in its marker and check it.
 
 | Param | Type |
 | --- | --- |
 | `ctx` | [Context](#context) |
 | `messageId` | number |
 | `marker` | [ReplyMarker](#replymarker) |
+| `options?` | [ExpectOptions](#expectoptions) |
 
 **Returns:** void
 
@@ -810,17 +814,33 @@ Pure session write - safe on serverless. Pair the sent message with
 `reply_markup: { force_reply: true }` so the client quotes it and the reply
 carries `reply_to_message.message_id`.
 
+Note the default session key is per **chat**, so in a group the marker belongs
+to the group, and any member's reply matches it. Put the asker's id in the
+marker and check it, or key sessions per user, when that matters.
+
 | Param | Type |
 | --- | --- |
 | `ctx` | [Context](#context) |
 | `messageId` | number |
 | `marker` | [ReplyMarker](#replymarker) |
+| `options?` | [ExpectOptions](#expectoptions) |
+
+**Returns:** void
+
+### `forgetCallback()`
+
+Forget a pending press expectation (a keyboard that is no longer live).
+
+| Param | Type |
+| --- | --- |
+| `ctx` | [Context](#context) |
+| `messageId` | number |
 
 **Returns:** void
 
 ### `forgetReply()`
 
-Forget a pending expectation (a prompt that timed out, or was cancelled).
+Forget a pending reply expectation (a prompt that timed out, or was cancelled).
 
 | Param | Type |
 | --- | --- |
@@ -918,9 +938,14 @@ within this session key), return that message's marker; otherwise `undefined`.
 
 Unlike matchReply this does **not** consume the marker by default: an
 inline keyboard usually stays live for several presses (paging, a toggle), and
-consuming would break every press after the first. Pass `{ once: true }` for a
-one-shot button - a confirm/cancel pair, say - so a double tap or a press on a
-stale message cannot fire it twice; forgetReply drops it explicitly.
+consuming would break every press after the first. Pass `{ once: true }` when a
+button must fire at most once, so a second tap on *that message* finds nothing.
+It says nothing about other messages: two confirmations sent by two commands
+hold two markers, and each can still be pressed once - forgetCallback
+the older one if only the newest may act.
+
+"At most once", not "exactly once": the marker is consumed before your handler
+does its work, and the session flush persists that even if the handler throws.
 
 | Param | Type |
 | --- | --- |
@@ -935,6 +960,9 @@ If the current update is a reply to a message a prior expectReply
 registered (matched on `reply_to_message.message_id` within this session key),
 consume and return that message's marker; otherwise `undefined` - so a handler
 typically does `const hit = matchReply(ctx); if (!hit) return next();`.
+
+Only reply expectations are considered: a quoted reply never consumes a marker
+left by expectCallback.
 
 `M` is a type-only assertion for the marker you stored (like the `<T>` on
 `ctx.getSession`): it types the return value and generates no runtime check.
@@ -1102,14 +1130,14 @@ a bare `"EMAIL"` cannot be stored directly; this boxes it as `{ tag }` on write
 and unboxes it on read. One `Tag` union types both ends, so the stored and
 matched tags cannot drift apart.
 
-`expectPress` / `matchPress` are the callback-query peers of `expect` /
-`match`, keeping the non-consuming default of matchCallback.
+`expectPress` / `matchPress` / `forgetPress` are the callback-query peers,
+keeping the non-consuming default of matchCallback.
 
 | Param | Type |
 | --- | --- |
 | `ctx` | [Context](#context) |
 
-**Returns:** { expect: (messageId: number, tag: Tag) => void; expectPress: (messageId: number, tag: Tag) => void; forget: (messageId: number) => void; match: () => Tag | undefined; matchPress: (options?: { once?: boolean }) => Tag | undefined }
+**Returns:** { expect: (messageId: number, tag: Tag, options?: [ExpectOptions](#expectoptions)) => void; expectPress: (messageId: number, tag: Tag, options?: [ExpectOptions](#expectoptions)) => void; forget: (messageId: number) => void; forgetPress: (messageId: number) => void; match: () => Tag | undefined; matchPress: (options?: { once?: boolean }) => Tag | undefined }
 
 ### `webhookCallback()`
 
@@ -3227,6 +3255,16 @@ type EphemeralMessageParameters = {
   callback_query_id?: string;
   receiver_user_id: number;
   replace_callback_query_message?: boolean;
+};
+```
+
+### `ExpectOptions`
+
+How long a recorded expectation stays live. Omitted: until matched or forgotten.
+
+```ts
+type ExpectOptions = {
+  ttlSeconds?: number;
 };
 ```
 
@@ -9645,7 +9683,7 @@ const HTTP_STATUS_TOO_MANY_REQUESTS: 429;
 
 ### `REPLY_NAMESPACE`
 
-The `ext` namespace this layer stores its table under.
+The `ext` namespace this layer stores its tables under.
 
 ```ts
 const REPLY_NAMESPACE: "reply";

--- a/examples/17-callback-tracking.ts
+++ b/examples/17-callback-tracking.ts
@@ -13,12 +13,19 @@
  *    `callback_data` cannot do here: the payload is bigger than 64 bytes, it
  *    names things the user should not see (callback_data is plain text in the
  *    client, readable by anyone who can inspect the message), and the button
- *    must fire exactly once - a double tap or a press on a stale message must
- *    not run the deletion twice. `matchCallback(ctx, { once: true })` consumes
- *    the marker, so the second press finds nothing.
+ *    must fire at most once.
  *
- * Both handlers answer the callback query: until you do, the client shows a
- * spinner on the button.
+ * Three things the "one-shot button" needs beyond `{ once: true }`, all of them
+ * easy to get wrong:
+ *
+ * - `{ once: true }` only consumes the marker of *that* message. Run `/delete`
+ *   twice and the older confirmation is still armed, so this example forgets the
+ *   previous one first - one outstanding confirmation per chat.
+ * - The default session key is per **chat**, so in a group any member can press
+ *   your button. The marker carries the requester's id and the handler checks it.
+ * - The marker is consumed *before* the work runs, and the session flush persists
+ *   that even if the handler throws - so this is "at most once", not "exactly
+ *   once". A failure loses the confirmation; the user runs `/delete` again.
  *
  * Run: BOT_TOKEN=123:abc bun examples/17-callback-tracking.ts
  */
@@ -26,9 +33,11 @@ import {
   Bot,
   createSession,
   expectCallback,
-  MemorySessionStorage,
-  matchCallback,
+  forgetCallback,
   type InlineKeyboardMarkup,
+  matchCallback,
+  MemorySessionStorage,
+  TelegramApiError,
 } from "node-telegram-bot-api";
 import { run } from "node-telegram-bot-api/node";
 
@@ -40,14 +49,18 @@ type PendingDelete = {
   op: "purge";
   reason: string;
   targets: string[];
+  requestedBy: number; // only this user may confirm
   requestedAt: string;
 };
+
+/** The session bag: which confirmation (if any) is currently armed for this chat. */
+type Session = { pendingConfirmationId?: number };
 
 const bot = new Bot(process.env.BOT_TOKEN!);
 
 // Memory is fine here: this example is a single long-polling process. Swap in
 // FileSessionStorage (/node) or a Bun store to survive a restart.
-bot.use(createSession({ store: new MemorySessionStorage() }));
+bot.use(createSession<Session>({ store: new MemorySessionStorage(), initial: () => ({}) }));
 
 /** Pager keyboard: the page number rides in `callback_data`, nowhere else. */
 function pageKeyboard(page: number): InlineKeyboardMarkup {
@@ -73,22 +86,38 @@ bot.on("callback_query", async (ctx, next) => {
   const match = /^page:(\d+)$/.exec(ctx.callbackQuery?.data ?? "");
   if (!match) return next();
 
+  // Answer first: two quick taps send the same page, so the second edit below is
+  // a no-op that Telegram rejects with 400 "message is not modified". Answering
+  // afterwards would leave the button spinning until the query expires.
+  await ctx.answerCallbackQuery();
+
   const page = Number(match[1]);
   const message = ctx.callbackQuery?.message;
-  if (message) {
+  if (!message) return; // inline-mode message: nothing to edit
+
+  try {
     await ctx.api.editMessageText({
       chat_id: message.chat.id,
       message_id: message.message_id,
       text: pageText(page),
       reply_markup: pageKeyboard(page),
     });
+  } catch (err) {
+    // The identical-edit race above; any other API error is a real problem.
+    if (!(err instanceof TelegramApiError && err.description.includes("message is not modified"))) throw err;
   }
   // The keyboard stays live: press again and this handler runs again.
-  await ctx.answerCallbackQuery();
 });
 
 // 2) A one-shot, private, oversized marker - what callback_data cannot carry.
 bot.command("delete", async (ctx) => {
+  const session = ctx.getSession<Session>();
+
+  // Disarm the previous confirmation, so only the newest one can act. Without
+  // this, `/delete` twice would leave two armed buttons and each would purge.
+  const previous = session.data.pendingConfirmationId;
+  if (previous !== undefined) forgetCallback(ctx, previous);
+
   const sent = await ctx.reply("Delete all your data? This cannot be undone.", {
     reply_markup: { inline_keyboard: [[{ text: "Yes, delete", callback_data: "confirm" }]] },
   });
@@ -97,16 +126,20 @@ bot.command("delete", async (ctx) => {
     op: "purge",
     reason: "user asked via /delete",
     targets: ["profile", "messages", "attachments", "audit-log"],
+    requestedBy: ctx.from?.id ?? 0,
     requestedAt: new Date().toISOString(),
   };
-  expectCallback(ctx, sent.message_id, pending);
+  // A confirmation that sits unanswered for an hour is stale; the TTL keeps the
+  // session from carrying it (and every other abandoned one) forever.
+  expectCallback(ctx, sent.message_id, pending, { ttlSeconds: 3600 });
+  session.data.pendingConfirmationId = sent.message_id;
 });
 
 bot.on("callback_query", async (ctx, next) => {
-  // `once` consumes the marker, so a double tap (or a press on an older
-  // confirmation message) finds nothing and falls through.
-  const hit = matchCallback<PendingDelete>(ctx, { once: true });
-  if (!hit) {
+  // Peek without consuming: the requester check comes first, so a bystander's
+  // press in a group cannot burn the marker.
+  const pending = matchCallback<PendingDelete>(ctx);
+  if (!pending) {
     if (ctx.callbackQuery?.data === "confirm") {
       await ctx.answerCallbackQuery({ text: "That confirmation has expired.", show_alert: true });
       return;
@@ -114,8 +147,17 @@ bot.on("callback_query", async (ctx, next) => {
     return next();
   }
 
+  if (ctx.from?.id !== pending.requestedBy) {
+    await ctx.answerCallbackQuery({ text: "Only the person who ran /delete can confirm.", show_alert: true });
+    return;
+  }
+
+  // Now consume it: a second tap on this message finds nothing.
+  matchCallback(ctx, { once: true });
+  ctx.getSession<Session>().data.pendingConfirmationId = undefined;
+
   await ctx.answerCallbackQuery({ text: "Deleting..." });
-  await ctx.reply(`Ran ${hit.op} on ${hit.targets.join(", ")} (asked at ${hit.requestedAt}).`);
+  await ctx.reply(`Ran ${pending.op} on ${pending.targets.join(", ")} (asked at ${pending.requestedAt}).`);
 });
 
 await run(bot);

--- a/src/core/reply-tracking.ts
+++ b/src/core/reply-tracking.ts
@@ -1,25 +1,33 @@
 /**
- * Reply tracking - "I am waiting for a reply to *this* message" - built as a
- * layer **on top of** the session, not baked into it.
+ * Reply and callback tracking - "I am waiting for an answer to *this* message" -
+ * built as a layer **on top of** the session, not baked into it.
  *
- * The state is a plain table (`message_id we sent -> marker`) kept in the
- * session envelope's `ext` under the `"reply"` namespace, so:
+ * The state is two plain tables (`message_id we sent -> marker`), one for
+ * replies and one for button presses, kept in the session envelope's `ext` under
+ * the `"reply"` namespace, so:
  *
- * - a bot that never tracks replies persists nothing extra;
- * - changing this table's shape never touches the session format;
- * - it is a persisted marker, never a live continuation, so it survives a
+ * - a bot that never tracks answers persists nothing extra;
+ * - changing these tables' shape never touches the session format;
+ * - a marker is persisted data, never a live continuation, so it survives a
  *   restart and works under one-invocation-per-update serverless (there is
  *   deliberately no awaitable `waitForReply`: a Promise cannot cross an
  *   invocation).
  *
- * The same table also backs **callback queries** ({@link expectCallback} /
- * {@link matchCallback}), keyed on the message the inline keyboard is attached
- * to. Note a callback query already carries your own `callback_data`, so reach
- * for those only when 64 bytes of client-visible text are not enough: a bigger
- * marker, one the client must not see (callback_data is plain text in the app),
- * or a button that must fire once. And unlike a reply, a keyboard is often
- * pressed repeatedly, so matching a callback does *not* consume the marker
- * unless you ask.
+ * Replies and presses are tracked **separately**, because they are consumed
+ * differently and would otherwise steal each other's markers: a quoted reply to
+ * a message that also carries an inline keyboard would consume the press marker
+ * and kill the button. Register both if a message can be answered either way.
+ *
+ * A callback query already carries your own `callback_data`, so reach for
+ * {@link expectCallback} only when 64 bytes of client-visible text are not
+ * enough: a bigger marker, one the client must not see (callback_data is plain
+ * text in the app), or a button that must fire at most once.
+ *
+ * Markers do not expire on their own - a prompt nobody answers stays pending, by
+ * design, since "the user replies tomorrow" is normal. Pass `ttlSeconds` when
+ * recording one to bound that; expired entries are dropped the next time this
+ * layer touches the session, so a bot that sets a TTL cannot grow its envelope
+ * without limit.
  *
  * Everything here reads the session off the context (`ctx.getSession()`), so it
  * needs the session middleware registered and an update with a session key -
@@ -28,7 +36,7 @@
  * ```ts
  * bot.command("start", async (ctx) => {
  *   const sent = await ctx.reply("Your name?", { reply_markup: { force_reply: true } });
- *   expectReply(ctx, sent.message_id, { step: "name" });
+ *   expectReply(ctx, sent.message_id, { step: "name" }, { ttlSeconds: 3600 });
  * });
  *
  * bot.on("message", async (ctx, next) => {
@@ -44,22 +52,59 @@ import type { Context } from "./context.js";
 /** Opaque, JSON-serializable tag a caller attaches to an awaited reply or button press. */
 export type ReplyMarker = Record<string, unknown>;
 
-/** The `ext` namespace this layer stores its table under. */
+/** The `ext` namespace this layer stores its tables under. */
 export const REPLY_NAMESPACE = "reply";
 
-type ReplyState = { awaiting: Record<number, ReplyMarker> };
+/** How long a recorded expectation stays live. Omitted: until matched or forgotten. */
+export type ExpectOptions = {
+  /**
+   * Drop this expectation after so many seconds. There is no default and no cap:
+   * a prompt waiting for tomorrow's reply is legitimate, so nothing expires
+   * unless you say so. Set it for prompts that go stale (a confirmation, a
+   * one-time code) to keep an unanswered chat's envelope from growing forever.
+   */
+  ttlSeconds?: number;
+};
+
+/** One recorded expectation: the caller's marker, plus its deadline if it has one. */
+type Entry = { marker: ReplyMarker; expiresAt?: number };
+
+/** The two tables, keyed by the id of the message we sent. */
+type ReplyState = {
+  replies: Record<number, Entry>;
+  presses: Record<number, Entry>;
+};
+
+function isTable(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 /**
- * This key's reply table, created on first use inside the session envelope. The
- * stored slot is untrusted, so a slot whose `awaiting` is missing or not a plain
- * object is replaced by a fresh table rather than blowing up on the first write.
+ * This key's tables, created on first use inside the session envelope, with
+ * expired entries pruned. The stored slot is untrusted (a foreign writer, a hand
+ * edit, an older layout), so one missing either table is replaced by a fresh
+ * pair rather than blowing up on the first write.
  */
-function replyState(ctx: Context): ReplyState {
-  return ctx.getSession().ext<ReplyState>(
+function replyState(ctx: Context, now = Date.now()): ReplyState {
+  const state = ctx.getSession().ext<ReplyState>(
     REPLY_NAMESPACE,
-    () => ({ awaiting: {} }),
-    (slot) => typeof slot.awaiting === "object" && slot.awaiting !== null && !Array.isArray(slot.awaiting),
+    () => ({ replies: {}, presses: {} }),
+    (slot) => isTable(slot.replies) && isTable(slot.presses),
   );
+  // Pruned here rather than on a timer: this is the only moment the layer is
+  // guaranteed to be looking at the session, and the flush that follows persists
+  // the smaller table.
+  for (const table of [state.replies, state.presses]) {
+    for (const [id, entry] of Object.entries(table)) {
+      if (entry?.expiresAt !== undefined && entry.expiresAt <= now) delete table[Number(id)];
+    }
+  }
+  return state;
+}
+
+function record(table: Record<number, Entry>, messageId: number, marker: ReplyMarker, options?: ExpectOptions): void {
+  table[messageId] =
+    options?.ttlSeconds === undefined ? { marker } : { marker, expiresAt: Date.now() + options.ttlSeconds * 1000 };
 }
 
 /**
@@ -74,9 +119,13 @@ function replyState(ctx: Context): ReplyState {
  * Pure session write - safe on serverless. Pair the sent message with
  * `reply_markup: { force_reply: true }` so the client quotes it and the reply
  * carries `reply_to_message.message_id`.
+ *
+ * Note the default session key is per **chat**, so in a group the marker belongs
+ * to the group, and any member's reply matches it. Put the asker's id in the
+ * marker and check it, or key sessions per user, when that matters.
  */
-export function expectReply(ctx: Context, messageId: number, marker: ReplyMarker = {}): void {
-  replyState(ctx).awaiting[messageId] = marker;
+export function expectReply(ctx: Context, messageId: number, marker: ReplyMarker = {}, options?: ExpectOptions): void {
+  record(replyState(ctx).replies, messageId, marker, options);
 }
 
 /**
@@ -85,37 +134,48 @@ export function expectReply(ctx: Context, messageId: number, marker: ReplyMarker
  * consume and return that message's marker; otherwise `undefined` - so a handler
  * typically does `const hit = matchReply(ctx); if (!hit) return next();`.
  *
+ * Only reply expectations are considered: a quoted reply never consumes a marker
+ * left by {@link expectCallback}.
+ *
  * `M` is a type-only assertion for the marker you stored (like the `<T>` on
  * `ctx.getSession`): it types the return value and generates no runtime check.
  */
 export function matchReply<M extends ReplyMarker = ReplyMarker>(ctx: Context): M | undefined {
   const repliedTo = ctx.message?.reply_to_message?.message_id;
   if (repliedTo === undefined) return undefined;
-  const state = replyState(ctx);
-  const marker = state.awaiting[repliedTo];
-  if (marker === undefined) return undefined;
-  delete state.awaiting[repliedTo];
-  return marker as M;
+  const table = replyState(ctx).replies;
+  const entry = table[repliedTo];
+  if (entry === undefined) return undefined;
+  delete table[repliedTo];
+  return entry.marker as M;
 }
 
-/** Forget a pending expectation (a prompt that timed out, or was cancelled). */
+/** Forget a pending reply expectation (a prompt that timed out, or was cancelled). */
 export function forgetReply(ctx: Context, messageId: number): void {
-  delete replyState(ctx).awaiting[messageId];
+  delete replyState(ctx).replies[messageId];
 }
 
 /**
  * Record that a **button press** on the message you just sent (`messageId`) is
- * expected - the callback-query peer of {@link expectReply}, sharing one table,
- * so a message cannot be awaiting a reply and a press under different markers.
+ * expected - the callback-query peer of {@link expectReply}, in its own table.
  *
  * Prefer plain `callback_data` when it suffices: Telegram round-trips those 64
  * bytes for you, with no session and no store, and that is the idiomatic way to
  * route a button. This is for what `callback_data` cannot carry - a marker too
  * big for 64 bytes, one the client must not be able to read (callback_data is
- * plain text in the app), or a button that must work only once.
+ * plain text in the app), or a button that must work at most once.
+ *
+ * The per-chat caveat on {@link expectReply} applies here too, and more sharply:
+ * an inline keyboard in a group is pressable by every member, so a destructive
+ * button should carry the requester's id in its marker and check it.
  */
-export function expectCallback(ctx: Context, messageId: number, marker: ReplyMarker = {}): void {
-  replyState(ctx).awaiting[messageId] = marker;
+export function expectCallback(
+  ctx: Context,
+  messageId: number,
+  marker: ReplyMarker = {},
+  options?: ExpectOptions,
+): void {
+  record(replyState(ctx).presses, messageId, marker, options);
 }
 
 /**
@@ -125,9 +185,14 @@ export function expectCallback(ctx: Context, messageId: number, marker: ReplyMar
  *
  * Unlike {@link matchReply} this does **not** consume the marker by default: an
  * inline keyboard usually stays live for several presses (paging, a toggle), and
- * consuming would break every press after the first. Pass `{ once: true }` for a
- * one-shot button - a confirm/cancel pair, say - so a double tap or a press on a
- * stale message cannot fire it twice; {@link forgetReply} drops it explicitly.
+ * consuming would break every press after the first. Pass `{ once: true }` when a
+ * button must fire at most once, so a second tap on *that message* finds nothing.
+ * It says nothing about other messages: two confirmations sent by two commands
+ * hold two markers, and each can still be pressed once - {@link forgetCallback}
+ * the older one if only the newest may act.
+ *
+ * "At most once", not "exactly once": the marker is consumed before your handler
+ * does its work, and the session flush persists that even if the handler throws.
  */
 export function matchCallback<M extends ReplyMarker = ReplyMarker>(
   ctx: Context,
@@ -138,11 +203,16 @@ export function matchCallback<M extends ReplyMarker = ReplyMarker>(
   // there is nothing to key on - route those by `callback_data` instead.
   const pressed = ctx.callbackQuery?.message?.message_id;
   if (pressed === undefined) return undefined;
-  const state = replyState(ctx);
-  const marker = state.awaiting[pressed];
-  if (marker === undefined) return undefined;
-  if (options?.once === true) delete state.awaiting[pressed];
-  return marker as M;
+  const table = replyState(ctx).presses;
+  const entry = table[pressed];
+  if (entry === undefined) return undefined;
+  if (options?.once === true) delete table[pressed];
+  return entry.marker as M;
+}
+
+/** Forget a pending press expectation (a keyboard that is no longer live). */
+export function forgetCallback(ctx: Context, messageId: number): void {
+  delete replyState(ctx).presses[messageId];
 }
 
 /**
@@ -151,8 +221,8 @@ export function matchCallback<M extends ReplyMarker = ReplyMarker>(
  * and unboxes it on read. One `Tag` union types both ends, so the stored and
  * matched tags cannot drift apart.
  *
- * `expectPress` / `matchPress` are the callback-query peers of `expect` /
- * `match`, keeping the non-consuming default of {@link matchCallback}.
+ * `expectPress` / `matchPress` / `forgetPress` are the callback-query peers,
+ * keeping the non-consuming default of {@link matchCallback}.
  *
  * @example
  * taggedReplies<"NAME" | "EMAIL">(ctx).expect(sent.message_id, "EMAIL");
@@ -161,17 +231,19 @@ export function matchCallback<M extends ReplyMarker = ReplyMarker>(
 export function taggedReplies<Tag extends string>(
   ctx: Context,
 ): {
-  expect(messageId: number, tag: Tag): void;
+  expect(messageId: number, tag: Tag, options?: ExpectOptions): void;
   match(): Tag | undefined;
-  expectPress(messageId: number, tag: Tag): void;
-  matchPress(options?: { once?: boolean }): Tag | undefined;
   forget(messageId: number): void;
+  expectPress(messageId: number, tag: Tag, options?: ExpectOptions): void;
+  matchPress(options?: { once?: boolean }): Tag | undefined;
+  forgetPress(messageId: number): void;
 } {
   return {
-    expect: (messageId, tag) => expectReply(ctx, messageId, { tag }),
+    expect: (messageId, tag, options) => expectReply(ctx, messageId, { tag }, options),
     match: () => matchReply<{ tag: Tag }>(ctx)?.tag,
-    expectPress: (messageId, tag) => expectCallback(ctx, messageId, { tag }),
-    matchPress: (options) => matchCallback<{ tag: Tag }>(ctx, options)?.tag,
     forget: (messageId) => forgetReply(ctx, messageId),
+    expectPress: (messageId, tag, options) => expectCallback(ctx, messageId, { tag }, options),
+    matchPress: (options) => matchCallback<{ tag: Tag }>(ctx, options)?.tag,
+    forgetPress: (messageId) => forgetCallback(ctx, messageId),
   };
 }

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -6,6 +6,7 @@ import { Context } from "../../src/core/context.js";
 import {
   expectCallback,
   expectReply,
+  forgetCallback,
   forgetReply,
   matchCallback,
   matchReply,
@@ -157,14 +158,17 @@ describe("createSession()", () => {
     });
     assert.deepEqual(store.writes.at(-1), [
       "chat:42",
-      encoded({ data: { n: 1 }, ext: { reply: { awaiting: { 9: { ok: true } } } } }),
+      encoded({ data: { n: 1 }, ext: { reply: { replies: { 9: { marker: { ok: true } } }, presses: {} } } }),
     ]);
   });
 
   test("replaces an ext slot that fails its validity check", async () => {
     const store = fakeStore();
-    // A plain object, but not a well-formed reply table (no `awaiting`).
-    store.write("chat:42", JSON.stringify({ v: 1, data: {}, ext: { reply: {} }, createdAt: AT, updatedAt: AT }));
+    // A plain object, but not a well-formed pair of tables (no `presses`).
+    store.write(
+      "chat:42",
+      JSON.stringify({ v: 1, data: {}, ext: { reply: { replies: {} } }, createdAt: AT, updatedAt: AT }),
+    );
     const mw = createSession({ store, now });
     const ctx = new Context(msg("hi"), api);
     await mw(ctx, async () => {
@@ -172,7 +176,7 @@ describe("createSession()", () => {
     });
     assert.deepEqual(store.writes.at(-1), [
       "chat:42",
-      encoded({ data: {}, ext: { reply: { awaiting: { 7: { ok: true } } } } }),
+      encoded({ data: {}, ext: { reply: { replies: { 7: { marker: { ok: true } } }, presses: {} } } }),
     ]);
   });
 
@@ -856,20 +860,94 @@ describe("callback tracking", () => {
     });
   });
 
-  test("a reply marker and a press share one table, so either can claim it", async () => {
+  test("replies and presses are separate: neither matcher sees the other's marker", async () => {
     const mw = createSession({ store: new MemorySessionStorage() });
 
     const ask = new Context(msg("?"), api);
     await mw(ask, async () => {
       expectReply(ask, 111, { step: "name" });
+      expectCallback(ask, 222, { view: "page" });
     });
 
-    const tap = new Context(press(111), api);
-    let hit: unknown;
+    const tap = new Context(press(111), api); // a press on the reply prompt
     await mw(tap, async () => {
-      hit = matchCallback(tap);
+      assert.equal(matchCallback(tap), undefined);
     });
-    assert.deepEqual(hit, { step: "name" });
+
+    const quoted = new Context(msg("hi", 222), api); // a quoted reply to the keyboard
+    await mw(quoted, async () => {
+      assert.equal(matchReply(quoted), undefined);
+    });
+
+    // ...and neither of those consumed the other's marker: both still match.
+    const properTap = new Context(press(222), api);
+    await mw(properTap, async () => {
+      assert.deepEqual(matchCallback(properTap), { view: "page" });
+    });
+    const properReply = new Context(msg("Ada", 111), api);
+    await mw(properReply, async () => {
+      assert.deepEqual(matchReply(properReply), { step: "name" });
+    });
+  });
+
+  test("ttlSeconds expires an expectation, and no TTL keeps it pending", async () => {
+    const mw = createSession({ store: new MemorySessionStorage() });
+
+    const ask = new Context(msg("?"), api);
+    await mw(ask, async () => {
+      expectReply(ask, 111, { step: "stale" }, { ttlSeconds: -1 }); // already past
+      expectCallback(ask, 222, { view: "stale" }, { ttlSeconds: -1 });
+      expectReply(ask, 333, { step: "kept" }); // no TTL -> pending indefinitely
+    });
+
+    const expiredReply = new Context(msg("late", 111), api);
+    await mw(expiredReply, async () => {
+      assert.equal(matchReply(expiredReply), undefined);
+    });
+    const expiredPress = new Context(press(222), api);
+    await mw(expiredPress, async () => {
+      assert.equal(matchCallback(expiredPress), undefined);
+    });
+    const kept = new Context(msg("Ada", 333), api);
+    await mw(kept, async () => {
+      assert.deepEqual(matchReply(kept), { step: "kept" });
+    });
+  });
+
+  test("expired entries are pruned from the stored envelope", async () => {
+    const store = fakeStore();
+    const mw = createSession({ store });
+
+    const ask = new Context(msg("?"), api);
+    await mw(ask, async () => {
+      expectReply(ask, 111, { step: "stale" }, { ttlSeconds: -1 });
+    });
+    assert.match(store.writes.at(-1)?.[1] as string, /"111"/);
+
+    // Any later update touching this layer drops it - the envelope cannot grow
+    // without limit for a bot that sets a TTL.
+    const later = new Context(msg("anything"), api);
+    await mw(later, async () => {
+      expectReply(later, 999, { step: "fresh" });
+    });
+    const stored = store.writes.at(-1)?.[1] as string;
+    assert.doesNotMatch(stored, /"111"/);
+    assert.match(stored, /"999"/);
+  });
+
+  test("forgetCallback drops a pending press expectation", async () => {
+    const mw = createSession({ store: new MemorySessionStorage() });
+
+    const ask = new Context(msg("?"), api);
+    await mw(ask, async () => {
+      expectCallback(ask, 555, { view: "page" });
+      forgetCallback(ask, 555);
+    });
+
+    const tap = new Context(press(555), api);
+    await mw(tap, async () => {
+      assert.equal(matchCallback(tap), undefined);
+    });
   });
 
   test("taggedReplies boxes and unboxes a press tag", async () => {


### PR DESCRIPTION
## What

Follow-up to the session layer merged in #1349, hardening the reply/callback tracking after an adversarial review of that work. All six review findings, plus the CHANGELOG/README/docs to match.

## Changes

- **Separate tables for replies and presses.** They shared one `awaiting` map inside `ext.reply`, so a quoted reply to a message that also carried an inline keyboard consumed the button's marker and killed the button. Now `ext.reply` holds `{ replies, presses }`; `matchReply` only touches `replies`, `matchCallback` only `presses`. Register both if a message can be answered either way.
- **Caller-set TTL, no cap.** `expectReply` / `expectCallback` take `{ ttlSeconds }`. Nothing expires on its own - a prompt answered tomorrow is legitimate - but expired entries are pruned whenever the layer touches the session, so a bot that sets a TTL cannot grow its envelope without limit. There is no default and no cap.
- **`forgetCallback`** (and `taggedReplies(...).forgetPress`) to drop a pending press expectation.
- **Honest "once".** `matchCallback(ctx, { once: true })` is documented as **at most once** (the marker is consumed before the handler runs, and the flush persists that even if it throws) and as scoped to that single message - two confirmations hold two markers.

## Example (`examples/17-callback-tracking.ts`)

Rewritten around the failure modes the review found:

- one outstanding confirmation per chat - `forgetCallback` the previous before arming a new one, so `/delete` twice cannot leave two live buttons;
- the default session key is per **chat**, so a group bystander can press your button - the marker carries `requestedBy` and the handler checks `ctx.from.id` (peek, check, then consume, so a bystander cannot burn the marker);
- the pager answers the callback query **before** editing, and swallows the identical-edit `400 message is not modified`, so a double tap cannot leave the button spinning.

## Notes

- `test/e2e/methods.test.ts` has unrelated local edits and is intentionally left out of this PR.
- Verified live against a real bot token; `npm run check` green (222 unit tests under Bun, plus the Node runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
