### PR TITLE
chore: add AGENTS.md + .agents/skills, wire e2e suite to a local emulator

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+./CLAUDE.md

--- a/test/e2e/methods.test.ts
+++ b/test/e2e/methods.test.ts
@@ -73,14 +73,17 @@ const USER_ID = Number(process.env.TEST_USER_ID ?? "0");
 // large negative numbers that survive better as strings on the wire).
 const chatId: number | string = /^-?\d+$/.test(GROUP_ID) ? Number(GROUP_ID) : GROUP_ID;
 
-// ONE shared, rate-limited client constructed at module scope (no shared setup hook).
-// `global: 1` (~1 req/s) respects Telegram's flood limits like v1's ~1.1s
-// throttle. maxRetries:2 allows one bounded 429 retry without blowing the
-// per-test timeout.
+// ONE shared client constructed at module scope (no shared setup hook).
+// Against the live API, throttle globally (~1 req/s) to respect Telegram's flood
+// limits. Against a local emulator (TEST_API_ROOT set) there are no such limits,
+// so cap per-chat instead (~1 send / 3s) - enough to stay under TDLib's own send
+// anti-flood while leaving reads at full speed. maxRetries:2 bounds 429 retries.
+const EMULATOR = Boolean(process.env.TEST_API_ROOT);
 const api = new Api(TOKEN ?? "0:placeholder", {
-  rateLimit: { global: 1 },
+  rateLimit: EMULATOR ? { perChat: 1 / 3 } : { global: 1 },
   maxRetries: 2,
   timeoutMs: 30_000,
+  apiRoot: process.env.TEST_API_ROOT, // local telegram-bot-api when set, else the default
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two small, unrelated bits of tooling that had been sitting uncommitted:

- **`AGENTS.md`** - mirrors `CLAUDE.md` so agents following the AGENTS.md convention read the same repo guidance (what the package is, the commands, the core-vs-node invariants).
- **`.agents/skills`** - a symlink to the shared `.claude/skills`, so the same skill playbooks are reachable under the AGENTS.md layout.
- **`test/e2e/methods.test.ts`** - honor `TEST_API_ROOT` to point the e2e suite at a local `telegram-bot-api` emulator, and choose the rate-limit strategy by target: a global ~1 req/s throttle against the live API, a per-chat cap (~1 send / 3s) against the emulator, which has no flood limits of its own but still relays TDLib's send anti-flood. The explanatory comment was trimmed to the essentials.

## Notes

- No source or public API changes; `test/tsconfig.json` typechecks.
- The e2e suite is not run in CI (it needs a real token / group); this only changes how it targets an emulator when one is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
