### PR TITLE
2.2.0-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+## [2.2.0-rc0][2.2.0-rc0] - 2026-09-03
+
 ### Sessions
 
 - Added opt-in session middleware: `createSession<T>(options)` (aliased `session`)
@@ -1194,4 +1196,5 @@ Fixed:
 [1.1.2]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v1.1.2
 [2.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.0.0
 [2.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.1.0
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v2.1.0...master
+[2.2.0-rc0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.2.0-rc0
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v2.2.0-rc0...master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "2.1.0",
+  "version": "2.2.0-rc0",
   "description": "Telegram Bot API - runtime-agnostic TypeScript client (v2).",
   "type": "module",
   "main": "./dist/core/index.cjs",


### PR DESCRIPTION
Release 2.2.0-rc0 (prerelease, publishes under npm dist-tag `next`).

Highlights (see CHANGELOG.md for the full entry):

- **Sessions**: opt-in `createSession<T>` middleware with a value-agnostic `SessionStore` contract; stores `MemorySessionStorage`, `FileSessionStorage` (`/node`), and `SqliteSessionStorage` / `SqlSessionStorage` / `RedisSessionStorage` (`./bun`); versioned envelope, change-skip flush, per-key in-process locking.
- **Reply and callback tracking**: `expectReply` / `matchReply` / `forgetReply`, `expectCallback` / `matchCallback` / `forgetCallback` (separate tables), `taggedReplies<Tag>`, caller-set TTL pruning.
- **Bot lifecycle**: `bot.init()` / `bot.close()` with per-plugin init tracking and reverse-order teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)