### PR TITLE
Transport: an empty-string apiRoot is used verbatim instead of falling back to the default (#1354)

### DIFF
--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -103,7 +103,10 @@ export class Transport {
     options: TransportOptions = {},
   ) {
     if (!token) throw new TelegramBotError("A bot token is required", { code: "EPARAM" });
-    this.apiRoot = (options.apiRoot ?? DEFAULT_API_ROOT).replace(/\/+$/, "");
+    // Coalesce an empty/whitespace-only apiRoot (e.g. an unset-but-present env
+    // var) to the default; `??` alone would keep "" and build a relative URL.
+    const root = options.apiRoot?.trim();
+    this.apiRoot = (root ? root : DEFAULT_API_ROOT).replace(/\/+$/, "");
     const fetchImpl = options.fetch ?? globalThis.fetch;
     if (typeof fetchImpl !== "function") {
       throw new NetworkError("No fetch implementation available; pass options.fetch");

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -103,8 +103,7 @@ export class Transport {
     options: TransportOptions = {},
   ) {
     if (!token) throw new TelegramBotError("A bot token is required", { code: "EPARAM" });
-    // Coalesce an empty/whitespace-only apiRoot (e.g. an unset-but-present env
-    // var) to the default; `??` alone would keep "" and build a relative URL.
+    // Empty/whitespace apiRoot falls back to the default; `??` would keep "".
     const root = options.apiRoot?.trim();
     this.apiRoot = (root ? root : DEFAULT_API_ROOT).replace(/\/+$/, "");
     const fetchImpl = options.fetch ?? globalThis.fetch;

--- a/test/e2e/methods.test.ts
+++ b/test/e2e/methods.test.ts
@@ -78,8 +78,7 @@ const chatId: number | string = /^-?\d+$/.test(GROUP_ID) ? Number(GROUP_ID) : GR
 // limits. Against a local emulator (TEST_API_ROOT set) there are no such limits,
 // so cap per-chat instead (~1 send / 3s) - enough to stay under TDLib's own send
 // anti-flood while leaving reads at full speed. maxRetries:2 bounds 429 retries.
-// Derive the toggle and the option from one normalized value so they cannot
-// disagree: an empty/whitespace TEST_API_ROOT reads as unset (live API).
+// One normalized value so EMULATOR and apiRoot cannot disagree (empty -> live).
 const API_ROOT = process.env.TEST_API_ROOT?.trim() || undefined;
 const EMULATOR = Boolean(API_ROOT);
 const api = new Api(TOKEN ?? "0:placeholder", {

--- a/test/e2e/methods.test.ts
+++ b/test/e2e/methods.test.ts
@@ -78,12 +78,15 @@ const chatId: number | string = /^-?\d+$/.test(GROUP_ID) ? Number(GROUP_ID) : GR
 // limits. Against a local emulator (TEST_API_ROOT set) there are no such limits,
 // so cap per-chat instead (~1 send / 3s) - enough to stay under TDLib's own send
 // anti-flood while leaving reads at full speed. maxRetries:2 bounds 429 retries.
-const EMULATOR = Boolean(process.env.TEST_API_ROOT);
+// Derive the toggle and the option from one normalized value so they cannot
+// disagree: an empty/whitespace TEST_API_ROOT reads as unset (live API).
+const API_ROOT = process.env.TEST_API_ROOT?.trim() || undefined;
+const EMULATOR = Boolean(API_ROOT);
 const api = new Api(TOKEN ?? "0:placeholder", {
   rateLimit: EMULATOR ? { perChat: 1 / 3 } : { global: 1 },
   maxRetries: 2,
   timeoutMs: 30_000,
-  apiRoot: process.env.TEST_API_ROOT, // local telegram-bot-api when set, else the default
+  apiRoot: API_ROOT, // local telegram-bot-api when set, else the default
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -339,4 +339,20 @@ describe("Transport", () => {
     assert.strictEqual(calls[0]!.url, `https://api.telegram.org/bot${TOKEN}/getMe`);
     assert.strictEqual(calls[0]!.init?.method, "POST");
   });
+
+  test("empty/whitespace apiRoot falls back to the default instead of a relative URL", async () => {
+    for (const apiRoot of ["", "   "]) {
+      const { fetch, calls } = jsonFetch([{ ok: true, result: {} }]);
+      const tr = new Transport(TOKEN, { fetch, apiRoot });
+      await tr.request("getMe");
+      assert.strictEqual(calls[0]!.url, `https://api.telegram.org/bot${TOKEN}/getMe`);
+    }
+  });
+
+  test("a non-empty apiRoot is used verbatim (trailing slashes trimmed)", async () => {
+    const { fetch, calls } = jsonFetch([{ ok: true, result: {} }]);
+    const tr = new Transport(TOKEN, { fetch, apiRoot: "http://localhost:8081//" });
+    await tr.request("getMe");
+    assert.strictEqual(calls[0]!.url, `http://localhost:8081/bot${TOKEN}/getMe`);
+  });
 });


### PR DESCRIPTION
Closes #1354

<!-- michi:plan -->
- [x] T1 <!--m:a1c7--> Transport: coalesce empty/whitespace `apiRoot` to the default so an env-driven value is safe, with a unit test
- [x] T2 <!--m:b2f9--> e2e: derive both `EMULATOR` and `apiRoot` from one normalized `process.env.TEST_API_ROOT || undefined` so they cannot disagree
<!-- /michi:plan -->
