### PR TITLE
longPoll: a 409 Conflict permanently stops the polling loop (#1350)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## What this is
 
 `node-telegram-bot-api` v2: a from-scratch, runtime-agnostic TypeScript Telegram Bot API client.
-Node 18+, also runs on Bun, Deno, Cloudflare Workers, and Vercel/Deno Edge. The source is
+Node 18.2+, also runs on Bun, Deno, Cloudflare Workers, and Vercel/Deno Edge. The source is
 ESM/web-standard; the **published** package is dual-module - `zshy` emits both ESM (`*.js`/`*.d.ts`)
 and CJS (`*.cjs`/`*.d.cts`), exposed via the `exports` map's `import`/`require` conditions, so it can
 be `import`ed or `require`d. `src/core` stays Node-free, so the edge story is unchanged. There is
@@ -51,7 +51,7 @@ src/
           serializeParams + encodeForm, InputFile, the markup / entity / media builders
           (optional sugar), longPoll, webhookCallback, framework webhook adapters
           (Express / Next.js), errors. Web-standard APIs only.
-          -> zero node:* imports; runs on Node 18+ / Bun / Deno / Workers / edge.
+          -> zero node:* imports; runs on Node 18.2+ / Bun / Deno / Workers / edge.
   node/   the ONLY folder allowed to import node:*. Node-only sugar: fromPath() (fs
           uploads), createWebhookServer() (node:http -> delegates to core's
           webhookCallback), the managed run() polling runner, the DEBUG stderr sink.

--- a/doc/api.md
+++ b/doc/api.md
@@ -1212,7 +1212,9 @@ field name and attaches each part - it still stringifies nothing (ADR-011).
 | Property | Type |
 | --- | --- |
 | `allowedUpdates`? | string[] |
+| `conflictRetryDelayMs`? | number |
 | `limit`? | number |
+| `maxConflictRetries`? | number |
 | `offset`? | number |
 | `onError`? | (err: unknown) => void |
 | `retry`? | boolean |

--- a/doc/api.md
+++ b/doc/api.md
@@ -1079,6 +1079,13 @@ setup runs first (via `bot.startPolling` -> `bot.init()`), so a bad session
 store fails before the first poll; teardown (`bot.close()`) runs on the way
 out, whether the loop stopped or threw.
 
+A fatal poll-stop (the pump threw - a non-retriable error, or 409 conflicts
+past `maxConflictRetries`) is surfaced to stderr before it re-throws. As the
+managed lifecycle runner this is deliberate: a rejection alone can be dropped
+(fire-and-forget, or a `.catch` that swallows), and would then leave the
+process alive but no longer polling - the exact silent-hang #1350 describes.
+The error is still re-thrown unchanged, so an awaiting caller sees it too.
+
 | Param | Type |
 | --- | --- |
 | `bot` | [Bot](#bot) |
@@ -1107,6 +1114,12 @@ Managed webhook runner: create a `node:http` webhook server, start listening,
 and resolve when it shuts down. Installs `SIGINT`/`SIGTERM` handlers that close
 the server for a graceful exit (cleaned up in a `finally`), mirroring `run()` for
 long polling. Rejects if the server fails (e.g. the port is in use).
+
+Shutdown cannot hang: `server.close()` alone waits for every existing
+connection to end, so a single idle keep-alive socket would keep the `"close"`
+event (and this promise) pending forever - a stopped-but-never-exiting process.
+So we also drop idle connections immediately and force-close any still busy
+past `shutdownTimeoutMs`.
 
 You still register the webhook with Telegram yourself, pointing at this server's
 public URL (terminate TLS at a proxy/tunnel in front of it):
@@ -1291,6 +1304,7 @@ Options for a table block; `caption` is rich text.
 | `path`? | string |
 | `port` | number |
 | `secretToken`? | string |
+| `shutdownTimeoutMs`? | number |
 | `waitUntil`? | (promise: Promise<unknown>) => void |
 
 ### `TransportOptions`

--- a/doc/api.md
+++ b/doc/api.md
@@ -873,6 +873,21 @@ basename; pass `meta.filename` / `meta.contentType` to override.
 
 **Returns:** Promise<[InputFile](#inputfile)>
 
+### `gracefulClose()`
+
+Begin a non-hanging shutdown of `server`: stop accepting, drop idle keep-alive
+sockets at once (else `close` waits for them forever), and force-close anything
+still busy past `timeoutMs`. Returns the force-close timer so the caller can
+cancel it once `close` completes on its own. The connection helpers need Node
+18.2+ and are optional-chained so a non-Node runtime is a safe no-op.
+
+| Param | Type |
+| --- | --- |
+| `server` | Server |
+| `timeoutMs` | number |
+
+**Returns:** Timeout
+
 ### `isAbortError()`
 
 True for an `AbortController`/timeout abort, across runtimes. Matches both the
@@ -902,6 +917,18 @@ Cloudflare Workers), so the transport classifies our own client timeout as a
 | `value` | unknown |
 
 **Returns:** value is [InputFile](#inputfile)
+
+### `isPollConflict()`
+
+A 409 from `getUpdates` - another instance is polling the same token.
+Recoverable for polling (the competing poller usually exits), not for a plain
+request, so it is classified separately from `isTransientError`.
+
+| Param | Type |
+| --- | --- |
+| `err` | unknown |
+
+**Returns:** boolean
 
 ### `isTransientError()`
 
@@ -9681,6 +9708,14 @@ const EntityType: {
   readonly Underline: "underline";
   readonly Url: "url";
 };
+```
+
+### `HTTP_STATUS_CONFLICT`
+
+HTTP 409 "Conflict" - `getUpdates` reports another instance is polling the same token.
+
+```ts
+const HTTP_STATUS_CONFLICT: 409;
 ```
 
 ### `HTTP_STATUS_TOO_MANY_REQUESTS`

--- a/doc/api.md
+++ b/doc/api.md
@@ -1079,12 +1079,10 @@ setup runs first (via `bot.startPolling` -> `bot.init()`), so a bad session
 store fails before the first poll; teardown (`bot.close()`) runs on the way
 out, whether the loop stopped or threw.
 
-A fatal poll-stop (the pump threw - a non-retriable error, or 409 conflicts
-past `maxConflictRetries`) is surfaced to stderr before it re-throws. As the
-managed lifecycle runner this is deliberate: a rejection alone can be dropped
-(fire-and-forget, or a `.catch` that swallows), and would then leave the
-process alive but no longer polling - the exact silent-hang #1350 describes.
-The error is still re-thrown unchanged, so an awaiting caller sees it too.
+A fatal poll-stop is also written to stderr before being re-thrown: a bare
+rejection can be dropped (fire-and-forget, or a swallowing `.catch`), which
+would leave the process alive but no longer polling - the silent hang #1350
+describes.
 
 | Param | Type |
 | --- | --- |
@@ -1115,11 +1113,9 @@ and resolve when it shuts down. Installs `SIGINT`/`SIGTERM` handlers that close
 the server for a graceful exit (cleaned up in a `finally`), mirroring `run()` for
 long polling. Rejects if the server fails (e.g. the port is in use).
 
-Shutdown cannot hang: `server.close()` alone waits for every existing
-connection to end, so a single idle keep-alive socket would keep the `"close"`
-event (and this promise) pending forever - a stopped-but-never-exiting process.
-So we also drop idle connections immediately and force-close any still busy
-past `shutdownTimeoutMs`.
+Shutdown cannot hang: `server.close()` waits for existing connections to end,
+so we also drop idle keep-alive sockets at once and force-close anything still
+busy past `shutdownTimeoutMs`.
 
 You still register the webhook with Telegram yourself, pointing at this server's
 public URL (terminate TLS at a proxy/tunnel in front of it):

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "author": "Yago Pérez <yagoperezs@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=18.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -20,6 +20,9 @@ export interface ApiErrorParameters {
  */
 export const HTTP_STATUS_TOO_MANY_REQUESTS = 429;
 
+/** HTTP 409 "Conflict" - `getUpdates` reports another instance is polling the same token. */
+export const HTTP_STATUS_CONFLICT = 409;
+
 export class TelegramBotError extends Error {
   /** Stable, machine-readable code (e.g. `ETELEGRAM`, `EFETCH`). */
   readonly code: string;
@@ -103,4 +106,13 @@ export function isTransientError(err: unknown): boolean {
   if (err instanceof NetworkError || err instanceof TimeoutError) return true;
   if (err instanceof TelegramApiError) return err.errorCode === HTTP_STATUS_TOO_MANY_REQUESTS || err.errorCode >= 500;
   return false;
+}
+
+/**
+ * A 409 from `getUpdates` - another instance is polling the same token.
+ * Recoverable for polling (the competing poller usually exits), not for a plain
+ * request, so it is classified separately from `isTransientError`.
+ */
+export function isPollConflict(err: unknown): boolean {
+  return err instanceof TelegramApiError && err.errorCode === HTTP_STATUS_CONFLICT;
 }

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -10,18 +10,30 @@ export interface LongPollOptions {
   /** Long-poll seconds passed to Telegram. Default 30. */
   timeout?: number;
   allowedUpdates?: string[];
-  /** Resume the loop on transient errors (network / timeout / 5xx / 429). Default true. */
+  /** Resume the loop on transient errors (network / timeout / 5xx / 429) and 409 poll conflicts. Default true. */
   retry?: boolean;
   /** Delay before re-polling after a transient error that carries no `retry_after`, in ms. Default 1000. */
   retryDelayMs?: number;
+  /** Delay before re-polling after a 409 conflict, in ms - longer, since the competing poller needs time to exit. Default 5000. */
+  conflictRetryDelayMs?: number;
+  /** Give up after this many consecutive 409 conflicts (a genuine two-instance deploy), then throw. Default 10. */
+  maxConflictRetries?: number;
   /** Observe each transient error before the loop waits and resumes. */
   onError?: (err: unknown) => void;
 }
 
 const DEFAULT_POLL_TIMEOUT = 30; // 30 seconds
 const DEFAULT_RETRY_DELAY = 1000; // 1 second, when the error carries no retry_after
+const DEFAULT_CONFLICT_RETRY_DELAY = 5000; // 5 seconds; the other poller needs time to exit
+const DEFAULT_MAX_CONFLICT_RETRIES = 10;
+const HTTP_STATUS_CONFLICT = 409;
 
 const log = debug("polling");
+
+/** A 409 from `getUpdates` - another instance is polling the same token. Recoverable for polling, not for a plain request. */
+function isPollConflict(err: unknown): boolean {
+  return err instanceof TelegramApiError && err.errorCode === HTTP_STATUS_CONFLICT;
+}
 
 /** A transient error's `retry_after` in ms (only `TelegramApiError` carries one), or undefined. */
 function retryAfterMs(err: unknown): number | undefined {
@@ -37,7 +49,10 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
   const allowed = options.allowedUpdates;
   const retry = options.retry ?? true;
   const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY;
+  const conflictRetryDelayMs = options.conflictRetryDelayMs ?? DEFAULT_CONFLICT_RETRY_DELAY;
+  const maxConflictRetries = options.maxConflictRetries ?? DEFAULT_MAX_CONFLICT_RETRIES;
   const onError = options.onError;
+  let conflicts = 0; // consecutive 409s; reset on any successful poll
 
   log("started (timeout=%ds)", timeout);
   while (!signal?.aborted) {
@@ -55,13 +70,19 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
     } catch (err) {
       // cancelled - swallow the abort error
       if (signal?.aborted) return;
+      // A 409 means another instance is polling the same token: usually temporary
+      // (an overlapping redeploy), so back off and resume - but bound it, so a real
+      // two-instance deployment eventually surfaces instead of looping forever.
+      const pollConflict = isPollConflict(err);
       // fatal - surface it
-      if (!retry || !isTransientError(err)) throw err;
+      if (!retry || !(isTransientError(err) || pollConflict)) throw err;
+      if (pollConflict && ++conflicts > maxConflictRetries) throw err;
       onError?.(err);
-      // Honor the error's retry_after (e.g. a 429 flood-wait) when present, else
-      // the default delay; re-poll WITHOUT advancing the offset.
-      const wait = retryAfterMs(err) ?? retryDelayMs;
-      log("getUpdates failed; retry in %dms", Math.round(wait));
+      // A conflict waits its own longer delay; otherwise honor the error's
+      // retry_after (e.g. a 429 flood-wait) when present, else the default delay.
+      const wait = pollConflict ? conflictRetryDelayMs : (retryAfterMs(err) ?? retryDelayMs);
+      if (pollConflict) log("getUpdates conflict (%d/%d); retry in %dms", conflicts, maxConflictRetries, Math.round(wait));
+      else log("getUpdates failed; retry in %dms", Math.round(wait));
       try {
         await delay(wait, signal);
       } catch {
@@ -72,6 +93,7 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
       continue;
     }
 
+    conflicts = 0; // a successful poll clears the conflict streak
     if (updates.length > 0) log("%d update(s)", updates.length);
     for (const update of updates) {
       yield update;

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -69,7 +69,11 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
       // deployment still surfaces. Everything else uses `isTransientError`.
       const pollConflict = isPollConflict(err);
       if (!retry || !(isTransientError(err) || pollConflict)) throw err;
-      if (pollConflict && ++conflicts > maxConflictRetries) throw err;
+      if (pollConflict) {
+        if (++conflicts > maxConflictRetries) throw err;
+      } else {
+        conflicts = 0; // a non-conflict transient breaks the *consecutive*-conflict streak
+      }
       onError?.(err);
       // A conflict waits its own longer delay; otherwise honor `retry_after`
       // (e.g. a 429 flood-wait) when present, else the default delay.

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -16,7 +16,7 @@ export interface LongPollOptions {
   retryDelayMs?: number;
   /** Delay before re-polling after a 409 conflict, in ms - longer, since the competing poller needs time to exit. Default 5000. */
   conflictRetryDelayMs?: number;
-  /** Give up after this many consecutive 409 conflicts (a genuine two-instance deploy), then throw. Default 10. */
+  /** Retry on up to this many consecutive 409 conflicts; the next one (a genuine two-instance deploy) throws. Default 10. */
   maxConflictRetries?: number;
   /** Observe each transient error before the loop waits and resumes. */
   onError?: (err: unknown) => void;

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -2,7 +2,7 @@ import type { Update } from "../types/index.js";
 import type { Api } from "./api.js";
 import { debug } from "./debug.js";
 import { delay } from "./delay.js";
-import { isTransientError, TelegramApiError } from "./errors.js";
+import { isPollConflict, isTransientError, TelegramApiError } from "./errors.js";
 
 export interface LongPollOptions {
   offset?: number;
@@ -26,14 +26,8 @@ const DEFAULT_POLL_TIMEOUT = 30; // 30 seconds
 const DEFAULT_RETRY_DELAY = 1000; // 1 second, when the error carries no retry_after
 const DEFAULT_CONFLICT_RETRY_DELAY = 5000; // 5 seconds; the other poller needs time to exit
 const DEFAULT_MAX_CONFLICT_RETRIES = 10;
-const HTTP_STATUS_CONFLICT = 409;
 
 const log = debug("polling");
-
-/** A 409 from `getUpdates` - another instance is polling the same token. Recoverable for polling, not for a plain request. */
-function isPollConflict(err: unknown): boolean {
-  return err instanceof TelegramApiError && err.errorCode === HTTP_STATUS_CONFLICT;
-}
 
 /** A transient error's `retry_after` in ms (only `TelegramApiError` carries one), or undefined. */
 function retryAfterMs(err: unknown): number | undefined {

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -70,19 +70,17 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
     } catch (err) {
       // cancelled - swallow the abort error
       if (signal?.aborted) return;
-      // A 409 means another instance is polling the same token: usually temporary
-      // (an overlapping redeploy), so back off and resume - but bound it, so a real
-      // two-instance deployment eventually surfaces instead of looping forever.
+      // A 409 (another instance polling the same token) is transient for polling
+      // but bounded, so an overlapping redeploy heals while a real two-instance
+      // deployment still surfaces. Everything else uses `isTransientError`.
       const pollConflict = isPollConflict(err);
-      // fatal - surface it
       if (!retry || !(isTransientError(err) || pollConflict)) throw err;
       if (pollConflict && ++conflicts > maxConflictRetries) throw err;
       onError?.(err);
-      // A conflict waits its own longer delay; otherwise honor the error's
-      // retry_after (e.g. a 429 flood-wait) when present, else the default delay.
+      // A conflict waits its own longer delay; otherwise honor `retry_after`
+      // (e.g. a 429 flood-wait) when present, else the default delay.
       const wait = pollConflict ? conflictRetryDelayMs : (retryAfterMs(err) ?? retryDelayMs);
-      if (pollConflict) log("getUpdates conflict (%d/%d); retry in %dms", conflicts, maxConflictRetries, Math.round(wait));
-      else log("getUpdates failed; retry in %dms", Math.round(wait));
+      log("getUpdates %s; retry in %dms", pollConflict ? `conflict ${conflicts}/${maxConflictRetries}` : "failed", Math.round(wait));
       try {
         await delay(wait, signal);
       } catch {

--- a/src/node/run.ts
+++ b/src/node/run.ts
@@ -20,6 +20,13 @@ import type { LongPollOptions } from "../core/longpoll.js";
  * setup runs first (via `bot.startPolling` -> `bot.init()`), so a bad session
  * store fails before the first poll; teardown (`bot.close()`) runs on the way
  * out, whether the loop stopped or threw.
+ *
+ * A fatal poll-stop (the pump threw - a non-retriable error, or 409 conflicts
+ * past `maxConflictRetries`) is surfaced to stderr before it re-throws. As the
+ * managed lifecycle runner this is deliberate: a rejection alone can be dropped
+ * (fire-and-forget, or a `.catch` that swallows), and would then leave the
+ * process alive but no longer polling - the exact silent-hang #1350 describes.
+ * The error is still re-thrown unchanged, so an awaiting caller sees it too.
  */
 export async function run(bot: Bot, options?: LongPollOptions): Promise<void> {
   const stop = (): void => {
@@ -36,6 +43,10 @@ export async function run(bot: Bot, options?: LongPollOptions): Promise<void> {
   const owned = !bot.isRunning();
   try {
     return await bot.startPolling(undefined, options);
+  } catch (err) {
+    // Never let a fatal poll-stop be silent (see the doc comment above).
+    process.stderr.write(`node-telegram-bot-api: polling stopped on a fatal error: ${String(err)}\n`);
+    throw err;
   } finally {
     process.off("SIGINT", stop);
     process.off("SIGTERM", stop);

--- a/src/node/run.ts
+++ b/src/node/run.ts
@@ -21,12 +21,10 @@ import type { LongPollOptions } from "../core/longpoll.js";
  * store fails before the first poll; teardown (`bot.close()`) runs on the way
  * out, whether the loop stopped or threw.
  *
- * A fatal poll-stop (the pump threw - a non-retriable error, or 409 conflicts
- * past `maxConflictRetries`) is surfaced to stderr before it re-throws. As the
- * managed lifecycle runner this is deliberate: a rejection alone can be dropped
- * (fire-and-forget, or a `.catch` that swallows), and would then leave the
- * process alive but no longer polling - the exact silent-hang #1350 describes.
- * The error is still re-thrown unchanged, so an awaiting caller sees it too.
+ * A fatal poll-stop is also written to stderr before being re-thrown: a bare
+ * rejection can be dropped (fire-and-forget, or a swallowing `.catch`), which
+ * would leave the process alive but no longer polling - the silent hang #1350
+ * describes.
  */
 export async function run(bot: Bot, options?: LongPollOptions): Promise<void> {
   const stop = (): void => {

--- a/src/node/run.ts
+++ b/src/node/run.ts
@@ -12,6 +12,7 @@
 import process from "node:process";
 import type { Bot } from "../core/bot.js";
 import type { LongPollOptions } from "../core/longpoll.js";
+import { withShutdownSignals } from "./signals.js";
 
 /**
  * Start the bot's long-poll loop and resolve when it stops. Installs
@@ -27,27 +28,21 @@ import type { LongPollOptions } from "../core/longpoll.js";
  * describes.
  */
 export async function run(bot: Bot, options?: LongPollOptions): Promise<void> {
-  const stop = (): void => {
-    bot.stop();
-  };
-
-  process.on("SIGINT", stop);
-  process.on("SIGTERM", stop);
-
   // Only a call that actually owns the pump may close. `startPolling` refuses
   // when another run is already active (as a rejection - it is async - so the
   // loser cannot be told apart after the fact); checking first is what keeps this
   // call from closing stores under the run that is still using them.
   const owned = !bot.isRunning();
   try {
-    return await bot.startPolling(undefined, options);
+    return await withShutdownSignals(
+      () => bot.stop(),
+      () => bot.startPolling(undefined, options),
+    );
   } catch (err) {
     // Never let a fatal poll-stop be silent (see the doc comment above).
     process.stderr.write(`node-telegram-bot-api: polling stopped on a fatal error: ${String(err)}\n`);
     throw err;
   } finally {
-    process.off("SIGINT", stop);
-    process.off("SIGTERM", stop);
     if (owned) await bot.close();
   }
 }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -53,13 +53,23 @@ export interface StartWebhookOptions extends WebhookServerOptions {
   port: number;
   /** Hostname / interface to bind. Default: all interfaces. */
   hostname?: string;
+  /** Grace period before in-flight connections are force-closed on shutdown, in ms. Default 10000. */
+  shutdownTimeoutMs?: number;
 }
+
+const DEFAULT_SHUTDOWN_TIMEOUT = 10_000; // 10s, then force-close whatever is left
 
 /**
  * Managed webhook runner: create a `node:http` webhook server, start listening,
  * and resolve when it shuts down. Installs `SIGINT`/`SIGTERM` handlers that close
  * the server for a graceful exit (cleaned up in a `finally`), mirroring `run()` for
  * long polling. Rejects if the server fails (e.g. the port is in use).
+ *
+ * Shutdown cannot hang: `server.close()` alone waits for every existing
+ * connection to end, so a single idle keep-alive socket would keep the `"close"`
+ * event (and this promise) pending forever - a stopped-but-never-exiting process.
+ * So we also drop idle connections immediately and force-close any still busy
+ * past `shutdownTimeoutMs`.
  *
  * You still register the webhook with Telegram yourself, pointing at this server's
  * public URL (terminate TLS at a proxy/tunnel in front of it):
@@ -71,8 +81,16 @@ export interface StartWebhookOptions extends WebhookServerOptions {
  */
 export async function startWebhook(bot: Bot, options: StartWebhookOptions): Promise<void> {
   const server = createWebhookServer(bot, options);
+  const shutdownTimeoutMs = options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT;
+  let forceTimer: ReturnType<typeof setTimeout> | undefined;
   const stop = (): void => {
-    server.close();
+    server.close(); // stop accepting; resolves once existing connections end
+    server.closeIdleConnections?.(); // drop idle keep-alive sockets now
+    // A connection still busy past the grace period is force-closed, so a stuck
+    // client cannot leave the process hanging. `unref` so the timer itself does
+    // not hold the loop open.
+    forceTimer = setTimeout(() => server.closeAllConnections?.(), shutdownTimeoutMs);
+    forceTimer.unref?.();
   };
   process.on("SIGINT", stop);
   process.on("SIGTERM", stop);
@@ -83,6 +101,7 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
       server.listen(options.port, options.hostname);
     });
   } finally {
+    if (forceTimer) clearTimeout(forceTimer);
     process.off("SIGINT", stop);
     process.off("SIGTERM", stop);
   }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -10,10 +10,10 @@
  */
 
 import http from "node:http";
-import process from "node:process";
 import { type NodeLikeRequest, type NodeLikeResponse, nodeFrameworkWebhook } from "../core/adapters.js";
 import type { Bot } from "../core/bot.js";
 import type { WebhookOptions } from "../core/webhook.js";
+import { withShutdownSignals } from "./signals.js";
 
 export interface WebhookServerOptions extends WebhookOptions {
   /** Only requests to this path are handled; others get 404. Default `/`. */
@@ -93,17 +93,17 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
     forceTimer = setTimeout(() => server.closeAllConnections?.(), shutdownTimeoutMs);
     forceTimer.unref?.();
   };
-  process.on("SIGINT", stop);
-  process.on("SIGTERM", stop);
   try {
-    await new Promise<void>((resolve, reject) => {
-      server.on("error", reject);
-      server.on("close", () => resolve());
-      server.listen(options.port, options.hostname);
-    });
+    await withShutdownSignals(
+      stop,
+      () =>
+        new Promise<void>((resolve, reject) => {
+          server.on("error", reject);
+          server.on("close", () => resolve());
+          server.listen(options.port, options.hostname);
+        }),
+    );
   } finally {
     if (forceTimer) clearTimeout(forceTimer);
-    process.off("SIGINT", stop);
-    process.off("SIGTERM", stop);
   }
 }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -12,8 +12,11 @@
 import http from "node:http";
 import { type NodeLikeRequest, type NodeLikeResponse, nodeFrameworkWebhook } from "../core/adapters.js";
 import type { Bot } from "../core/bot.js";
+import { debug } from "../core/debug.js";
 import type { WebhookOptions } from "../core/webhook.js";
 import { withShutdownSignals } from "./signals.js";
+
+const log = debug("webhook");
 
 export interface WebhookServerOptions extends WebhookOptions {
   /** Only requests to this path are handled; others get 404. Default `/`. */
@@ -44,7 +47,21 @@ export function createWebhookServer(bot: Bot, options: WebhookServerOptions = {}
     }
     // node:http's IncomingMessage / ServerResponse structurally satisfy the
     // core's NodeLike shapes.
-    void handler(req as unknown as NodeLikeRequest, res as unknown as NodeLikeResponse);
+    handler(req as unknown as NodeLikeRequest, res as unknown as NodeLikeResponse).catch((err: unknown) => {
+      // Expected during a forced shutdown: `closeAllConnections()` destroys a
+      // socket whose request body was still arriving, so `readBody` rejects
+      // (ECONNRESET). Swallow it - an unhandled rejection here could crash the
+      // process mid-shutdown - and try a 500 while the socket is still writable.
+      log("handler error: %s", String(err));
+      if (!res.headersSent && res.writable) {
+        try {
+          res.statusCode = 500;
+          res.end();
+        } catch {
+          // socket already gone - nothing to send
+        }
+      }
+    });
   });
 }
 

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -83,8 +83,16 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
   const server = createWebhookServer(bot, options);
   const shutdownTimeoutMs = options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT;
   let forceTimer: ReturnType<typeof setTimeout> | undefined;
+  let shuttingDown = false;
   const stop = (): void => {
+    // Idempotent: a second signal (SIGINT then SIGTERM, or a repeat) must not
+    // schedule another force-timer - the earlier one would then be lost by the
+    // finally's single `clearTimeout` and fire after this promise resolved.
+    if (shuttingDown) return;
+    shuttingDown = true;
     server.close(); // stop accepting; resolves once existing connections end
+    // `closeIdleConnections` / `closeAllConnections` exist on Node 18.2+ (the
+    // package minimum); optional-chained so a non-Node runtime is a safe no-op.
     server.closeIdleConnections?.(); // drop idle keep-alive sockets now
     // A connection still busy past the grace period is force-closed, so a stuck
     // client cannot leave the process hanging. `unref` so the timer itself does

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -93,9 +93,10 @@ export function gracefulClose(server: http.Server, timeoutMs: number): ReturnTyp
 
 /**
  * Managed webhook runner: create a `node:http` webhook server, start listening,
- * and resolve when it shuts down. Installs `SIGINT`/`SIGTERM` handlers that close
- * the server for a graceful exit (cleaned up in a `finally`), mirroring `run()` for
- * long polling. Rejects if the server fails (e.g. the port is in use).
+ * and resolve when it shuts down. Once listening, installs `SIGINT`/`SIGTERM`
+ * handlers that close the server for a graceful exit (cleaned up in a `finally`),
+ * mirroring `run()` for long polling. Rejects if the server fails to start (e.g.
+ * the port is in use).
  *
  * Shutdown cannot hang: `server.close()` waits for existing connections to end,
  * so we also drop idle keep-alive sockets at once and force-close anything still
@@ -112,6 +113,19 @@ export function gracefulClose(server: http.Server, timeoutMs: number): ReturnTyp
 export async function startWebhook(bot: Bot, options: StartWebhookOptions): Promise<void> {
   const server = createWebhookServer(bot, options);
   const shutdownTimeoutMs = options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT;
+
+  // 1) Listen first; reject on an early error (e.g. the port is in use). No
+  //    shutdown handlers yet - a signal during startup keeps Node's default
+  //    (exit), which is right: there is nothing listening to gracefully close.
+  //    This also means `stop` can never run `server.close()` on a server that
+  //    has not started (which would throw ERR_SERVER_NOT_RUNNING).
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.once("listening", () => resolve());
+    server.listen(options.port, options.hostname);
+  });
+
+  // 2) Now that it is listening, wire graceful shutdown and wait for `close`.
   let forceTimer: ReturnType<typeof setTimeout> | undefined;
   let shuttingDown = false;
   const stop = (): void => {
@@ -124,9 +138,8 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
       stop,
       () =>
         new Promise<void>((resolve, reject) => {
-          server.on("error", reject);
-          server.on("close", () => resolve());
-          server.listen(options.port, options.hostname);
+          server.once("error", reject);
+          server.once("close", () => resolve());
         }),
     );
   } finally {

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -60,6 +60,21 @@ export interface StartWebhookOptions extends WebhookServerOptions {
 const DEFAULT_SHUTDOWN_TIMEOUT = 10_000; // 10s, then force-close whatever is left
 
 /**
+ * Begin a non-hanging shutdown of `server`: stop accepting, drop idle keep-alive
+ * sockets at once (else `close` waits for them forever), and force-close anything
+ * still busy past `timeoutMs`. Returns the force-close timer so the caller can
+ * cancel it once `close` completes on its own. The connection helpers need Node
+ * 18.2+ and are optional-chained so a non-Node runtime is a safe no-op.
+ */
+export function gracefulClose(server: http.Server, timeoutMs: number): ReturnType<typeof setTimeout> {
+  server.close(); // stop accepting; resolves once existing connections end
+  server.closeIdleConnections?.(); // drop idle keep-alive sockets now
+  const forceTimer = setTimeout(() => server.closeAllConnections?.(), timeoutMs);
+  forceTimer.unref?.(); // don't let the timer itself hold the loop open
+  return forceTimer;
+}
+
+/**
  * Managed webhook runner: create a `node:http` webhook server, start listening,
  * and resolve when it shuts down. Installs `SIGINT`/`SIGTERM` handlers that close
  * the server for a graceful exit (cleaned up in a `finally`), mirroring `run()` for
@@ -85,13 +100,7 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
   const stop = (): void => {
     if (shuttingDown) return; // idempotent: a repeat signal must not schedule a second timer
     shuttingDown = true;
-    server.close(); // stop accepting; resolves once existing connections end
-    // Node 18.2+ (the package minimum); optional-chained as a no-op elsewhere.
-    server.closeIdleConnections?.(); // drop idle keep-alive sockets now
-    // Force-close whatever is still busy past the grace period. `unref` so the
-    // timer itself does not hold the loop open.
-    forceTimer = setTimeout(() => server.closeAllConnections?.(), shutdownTimeoutMs);
-    forceTimer.unref?.();
+    forceTimer = gracefulClose(server, shutdownTimeoutMs);
   };
   try {
     await withShutdownSignals(

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -65,11 +65,9 @@ const DEFAULT_SHUTDOWN_TIMEOUT = 10_000; // 10s, then force-close whatever is le
  * the server for a graceful exit (cleaned up in a `finally`), mirroring `run()` for
  * long polling. Rejects if the server fails (e.g. the port is in use).
  *
- * Shutdown cannot hang: `server.close()` alone waits for every existing
- * connection to end, so a single idle keep-alive socket would keep the `"close"`
- * event (and this promise) pending forever - a stopped-but-never-exiting process.
- * So we also drop idle connections immediately and force-close any still busy
- * past `shutdownTimeoutMs`.
+ * Shutdown cannot hang: `server.close()` waits for existing connections to end,
+ * so we also drop idle keep-alive sockets at once and force-close anything still
+ * busy past `shutdownTimeoutMs`.
  *
  * You still register the webhook with Telegram yourself, pointing at this server's
  * public URL (terminate TLS at a proxy/tunnel in front of it):
@@ -85,18 +83,13 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
   let forceTimer: ReturnType<typeof setTimeout> | undefined;
   let shuttingDown = false;
   const stop = (): void => {
-    // Idempotent: a second signal (SIGINT then SIGTERM, or a repeat) must not
-    // schedule another force-timer - the earlier one would then be lost by the
-    // finally's single `clearTimeout` and fire after this promise resolved.
-    if (shuttingDown) return;
+    if (shuttingDown) return; // idempotent: a repeat signal must not schedule a second timer
     shuttingDown = true;
     server.close(); // stop accepting; resolves once existing connections end
-    // `closeIdleConnections` / `closeAllConnections` exist on Node 18.2+ (the
-    // package minimum); optional-chained so a non-Node runtime is a safe no-op.
+    // Node 18.2+ (the package minimum); optional-chained as a no-op elsewhere.
     server.closeIdleConnections?.(); // drop idle keep-alive sockets now
-    // A connection still busy past the grace period is force-closed, so a stuck
-    // client cannot leave the process hanging. `unref` so the timer itself does
-    // not hold the loop open.
+    // Force-close whatever is still busy past the grace period. `unref` so the
+    // timer itself does not hold the loop open.
     forceTimer = setTimeout(() => server.closeAllConnections?.(), shutdownTimeoutMs);
     forceTimer.unref?.();
   };

--- a/src/node/signals.ts
+++ b/src/node/signals.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared graceful-shutdown plumbing for the managed Node runners (`run` and
+ * `startWebhook`). Both install the same `SIGINT`/`SIGTERM` -> `stop` handlers
+ * around a long-lived body and must remove them on the way out; this is the one
+ * place that knows which signals mean "shut down".
+ */
+
+import process from "node:process";
+
+const SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM"] as const;
+
+/**
+ * Run `body` with `stop` registered on the shutdown signals, guaranteeing the
+ * handlers are removed afterwards (so repeated runs don't leak listeners),
+ * whether `body` resolves or throws.
+ */
+export async function withShutdownSignals<T>(stop: () => void, body: () => Promise<T>): Promise<T> {
+  for (const sig of SHUTDOWN_SIGNALS) process.on(sig, stop);
+  try {
+    return await body();
+  } finally {
+    for (const sig of SHUTDOWN_SIGNALS) process.off(sig, stop);
+  }
+}

--- a/test/unit/longpoll.test.ts
+++ b/test/unit/longpoll.test.ts
@@ -133,4 +133,71 @@ describe("longPoll", () => {
     }
     assert.ok(caught instanceof NetworkError);
   });
+
+  test("resumes after a 409 conflict without advancing offset, then yields", async () => {
+    const controller = new AbortController();
+    const { api, offsets } = fakeApi([
+      () => {
+        throw new TelegramApiError(409, "Conflict: terminated by other getUpdates request");
+      },
+      () => [upd(100)],
+      () => {
+        controller.abort();
+        return [];
+      },
+    ]);
+
+    const seen: number[] = [];
+    for await (const update of longPoll(api, { conflictRetryDelayMs: 1 }, controller.signal)) {
+      seen.push(update.update_id);
+    }
+    assert.deepStrictEqual(seen, [100]);
+    // Poll 1 (409) and poll 2 both use the same (undefined) offset - no advance on conflict.
+    assert.deepStrictEqual(offsets.slice(0, 2), [undefined, undefined]);
+  });
+
+  test("throws after maxConflictRetries consecutive 409s", async () => {
+    const onError: unknown[] = [];
+    const { api } = fakeApi([
+      () => {
+        throw new TelegramApiError(409, "Conflict");
+      },
+    ]);
+
+    let caught: unknown;
+    try {
+      for await (const _ of longPoll(api, {
+        conflictRetryDelayMs: 1,
+        maxConflictRetries: 3,
+        onError: (e) => onError.push(e),
+      })) {
+        // no-op
+      }
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught instanceof TelegramApiError);
+    assert.strictEqual((caught as TelegramApiError).errorCode, 409);
+    // 3 conflicts were observed and waited on; the 4th throws without an onError call.
+    assert.strictEqual(onError.length, 3);
+  });
+
+  test("a 409 conflict is fatal when retry is disabled", async () => {
+    const { api } = fakeApi([
+      () => {
+        throw new TelegramApiError(409, "Conflict");
+      },
+    ]);
+
+    let caught: unknown;
+    try {
+      for await (const _ of longPoll(api, { retry: false })) {
+        // no-op
+      }
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught instanceof TelegramApiError);
+    assert.strictEqual((caught as TelegramApiError).errorCode, 409);
+  });
 });

--- a/test/unit/longpoll.test.ts
+++ b/test/unit/longpoll.test.ts
@@ -200,4 +200,44 @@ describe("longPoll", () => {
     assert.ok(caught instanceof TelegramApiError);
     assert.strictEqual((caught as TelegramApiError).errorCode, 409);
   });
+
+  test("a successful (empty) poll resets the consecutive-conflict counter", async () => {
+    const controller = new AbortController();
+    // With maxConflictRetries:2, three conflicts *in a row* would throw. Here an
+    // empty successful poll sits between two bursts, so the streak resets and the
+    // loop keeps going instead of throwing on the fourth conflict overall.
+    const { api } = fakeApi([
+      () => {
+        throw new TelegramApiError(409, "Conflict"); // burst 1: conflict 1
+      },
+      () => {
+        throw new TelegramApiError(409, "Conflict"); // burst 1: conflict 2
+      },
+      () => [], // success -> resets the counter
+      () => {
+        throw new TelegramApiError(409, "Conflict"); // burst 2: conflict 1 (would be #3 without the reset)
+      },
+      () => {
+        controller.abort(); // stop cleanly on the next poll
+        return [upd(200)];
+      },
+    ]);
+
+    const seen: number[] = [];
+    let caught: unknown;
+    try {
+      for await (const update of longPoll(
+        api,
+        { conflictRetryDelayMs: 1, maxConflictRetries: 2 },
+        controller.signal,
+      )) {
+        seen.push(update.update_id);
+      }
+    } catch (err) {
+      caught = err;
+    }
+    // Never threw (the reset kept burst 2 under the bound) and reached the yield.
+    assert.strictEqual(caught, undefined);
+    assert.deepStrictEqual(seen, [200]);
+  });
 });

--- a/test/unit/longpoll.test.ts
+++ b/test/unit/longpoll.test.ts
@@ -240,4 +240,41 @@ describe("longPoll", () => {
     assert.strictEqual(caught, undefined);
     assert.deepStrictEqual(seen, [200]);
   });
+
+  test("a non-conflict transient error between 409s breaks the consecutive-conflict streak", async () => {
+    const controller = new AbortController();
+    // maxConflictRetries:1 -> two conflicts in a row would throw. A 5xx transient
+    // sits between them, so the streak resets and the second 409 stays in bounds.
+    const { api } = fakeApi([
+      () => {
+        throw new TelegramApiError(409, "Conflict"); // conflict 1
+      },
+      () => {
+        throw new TelegramApiError(500, "Internal Server Error"); // transient -> resets streak
+      },
+      () => {
+        throw new TelegramApiError(409, "Conflict"); // conflict 1 again (would be #2 without the reset)
+      },
+      () => {
+        controller.abort();
+        return [upd(300)];
+      },
+    ]);
+
+    const seen: number[] = [];
+    let caught: unknown;
+    try {
+      for await (const update of longPoll(
+        api,
+        { conflictRetryDelayMs: 1, retryDelayMs: 1, maxConflictRetries: 1 },
+        controller.signal,
+      )) {
+        seen.push(update.update_id);
+      }
+    } catch (err) {
+      caught = err;
+    }
+    assert.strictEqual(caught, undefined);
+    assert.deepStrictEqual(seen, [300]);
+  });
 });

--- a/test/unit/run.test.ts
+++ b/test/unit/run.test.ts
@@ -1,0 +1,67 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import process from "node:process";
+import { Bot } from "../../src/core/bot.js";
+import { TelegramApiError } from "../../src/core/errors.js";
+import { run } from "../../src/node/run.js";
+
+/** A fetch that always answers with the given Bot API envelope. */
+function envelopeFetch(body: unknown): typeof fetch {
+  return (async () => new Response(JSON.stringify(body))) as unknown as typeof fetch;
+}
+
+/** Capture everything written to stderr for the duration of `fn`. */
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    captured += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return captured;
+}
+
+describe("run", () => {
+  test("surfaces a fatal poll-stop to stderr and re-throws", async () => {
+    // 401 is non-retriable; retry:false makes longPoll throw on the first poll.
+    const bot = new Bot("123:abc", {
+      fetch: envelopeFetch({ ok: false, error_code: 401, description: "Unauthorized" }),
+    });
+
+    let caught: unknown;
+    const stderr = await captureStderr(async () => {
+      try {
+        await run(bot, { retry: false });
+      } catch (err) {
+        caught = err;
+      }
+    });
+
+    // Re-thrown unchanged, so an awaiting caller still sees it...
+    assert.ok(caught instanceof TelegramApiError);
+    assert.strictEqual((caught as TelegramApiError).errorCode, 401);
+    // ...and it was surfaced to stderr, so a dropped rejection can't be silent.
+    assert.match(stderr, /polling stopped on a fatal error/);
+    assert.strictEqual(bot.isRunning(), false);
+  });
+
+  test("a clean stop resolves without writing to stderr", async () => {
+    const bot = new Bot("123:abc", {
+      fetch: envelopeFetch({ ok: true, result: [] }),
+    });
+
+    const stderr = await captureStderr(async () => {
+      const running = run(bot);
+      bot.stop(); // abort before/while the first poll is in flight
+      await running;
+    });
+
+    assert.strictEqual(stderr, "");
+    assert.strictEqual(bot.isRunning(), false);
+  });
+});

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -1,0 +1,84 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Bot } from "../../src/core/bot.js";
+import { createWebhookServer, startWebhook } from "../../src/node/server.js";
+import type { Update } from "../../src/types/index.js";
+
+/** A fake Bot exposing only handleUpdate (all that the webhook path needs). */
+function fakeBot(): Bot {
+  return {
+    handleUpdate: async (_update: Update) => {},
+  } as unknown as Bot;
+}
+
+/** Listen on an ephemeral port and resolve with the assigned port number. */
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
+describe("webhook server shutdown", () => {
+  // The hang #1350's second half describes: `server.close()` alone waits for
+  // every existing connection to end, so an idle keep-alive socket keeps the
+  // server (and a `startWebhook` promise) open forever. Dropping idle
+  // connections lets `close` complete.
+  test("close() completes despite an idle keep-alive connection once idle sockets are dropped", async (t) => {
+    const server = createWebhookServer(fakeBot(), { path: "/", secretToken: "s" });
+    if (typeof server.closeIdleConnections !== "function") {
+      t.skip("runtime has no closeIdleConnections");
+      return;
+    }
+    const port = await listen(server);
+
+    // Make one request over a keep-alive agent (to a non-webhook path, so the
+    // server 404s without invoking the handler), then leave the socket idle-open.
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request({ host: "127.0.0.1", port, path: "/nope", method: "GET", agent }, (res) => {
+        res.on("data", () => {});
+        res.on("end", () => resolve());
+      });
+      req.on("error", reject);
+      req.end();
+    });
+
+    let closed = false;
+    server.on("close", () => {
+      closed = true;
+    });
+
+    server.close(); // would hang here alone: the keep-alive socket is still open
+    server.closeIdleConnections(); // ...so drop it, letting `close` fire
+
+    // Wait briefly for the close event (poll, no fixed sleep).
+    for (let i = 0; i < 50 && !closed; i++) await new Promise((r) => setTimeout(r, 10));
+    agent.destroy();
+    assert.strictEqual(closed, true);
+  });
+
+  test("startWebhook rejects on a listen error and removes its signal handlers", async () => {
+    // Occupy a port, then point startWebhook at it so `listen` errors (EADDRINUSE).
+    const blocker = http.createServer();
+    const port = await listen(blocker);
+
+    const beforeInt = process.listenerCount("SIGINT");
+    const beforeTerm = process.listenerCount("SIGTERM");
+
+    let caught: unknown;
+    try {
+      await startWebhook(fakeBot(), { port, hostname: "127.0.0.1", secretToken: "s" });
+    } catch (err) {
+      caught = err;
+    }
+
+    assert.ok(caught instanceof Error);
+    // The finally ran: no leaked signal listeners.
+    assert.strictEqual(process.listenerCount("SIGINT"), beforeInt);
+    assert.strictEqual(process.listenerCount("SIGTERM"), beforeTerm);
+
+    await new Promise<void>((resolve) => blocker.close(() => resolve()));
+  });
+});

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -20,6 +20,26 @@ function listen(server: http.Server): Promise<number> {
   });
 }
 
+/** Grab a free ephemeral port by briefly binding and releasing one. */
+async function freePort(): Promise<number> {
+  const s = http.createServer();
+  const port = await listen(s);
+  await new Promise<void>((resolve) => s.close(() => resolve()));
+  return port;
+}
+
+/** GET the given path over a keep-alive agent, resolving once the response ends. */
+function keepAliveGet(port: number, path: string, agent: http.Agent): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path, method: "GET", agent }, (res) => {
+      res.on("data", () => {});
+      res.on("end", () => resolve());
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
 describe("webhook server shutdown", () => {
   // The hang #1350's second half describes: `server.close()` alone waits for
   // every existing connection to end, so an idle keep-alive socket keeps the
@@ -80,5 +100,58 @@ describe("webhook server shutdown", () => {
     assert.strictEqual(process.listenerCount("SIGTERM"), beforeTerm);
 
     await new Promise<void>((resolve) => blocker.close(() => resolve()));
+  });
+
+  test("startWebhook shuts down on a signal, dropping an idle connection, and is idempotent", async (t) => {
+    // Needs the Node 18.2+ connection helpers; skip where a runtime lacks them
+    // (without them the idle socket would keep close() pending and this hangs).
+    if (typeof http.createServer().closeIdleConnections !== "function") {
+      t.skip("runtime has no closeIdleConnections");
+      return;
+    }
+
+    // Detach any pre-existing signal listeners (e.g. the test runner's) so our
+    // synthetic emit reaches only startWebhook's handler; restored in finally.
+    const savedInt = process.listeners("SIGINT");
+    const savedTerm = process.listeners("SIGTERM");
+    process.removeAllListeners("SIGINT");
+    process.removeAllListeners("SIGTERM");
+
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    try {
+      const port = await freePort();
+      const running = startWebhook(fakeBot(), {
+        port,
+        hostname: "127.0.0.1",
+        secretToken: "s",
+        shutdownTimeoutMs: 50,
+      });
+
+      // Wait for the server to accept, then leave an idle keep-alive socket open.
+      for (let i = 0; i < 50; i++) {
+        try {
+          await keepAliveGet(port, "/nope", agent);
+          break;
+        } catch {
+          await new Promise((r) => setTimeout(r, 10));
+        }
+      }
+      assert.strictEqual(process.listenerCount("SIGTERM"), 1); // handler installed
+
+      // Two signals in a row: the second must be a no-op (idempotent stop).
+      process.emit("SIGTERM");
+      process.emit("SIGTERM");
+
+      // Resolves rather than hanging: the idle keep-alive socket was dropped.
+      await running;
+
+      // finally ran: startWebhook removed its own handlers.
+      assert.strictEqual(process.listenerCount("SIGINT"), 0);
+      assert.strictEqual(process.listenerCount("SIGTERM"), 0);
+    } finally {
+      agent.destroy();
+      for (const l of savedInt) process.on("SIGINT", l as (...a: unknown[]) => void);
+      for (const l of savedTerm) process.on("SIGTERM", l as (...a: unknown[]) => void);
+    }
   });
 });

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo } from "node:net";
 import type { Bot } from "../../src/core/bot.js";
 import { createWebhookServer, gracefulClose, startWebhook } from "../../src/node/server.js";
 import type { Update } from "../../src/types/index.js";
@@ -70,6 +70,47 @@ describe("webhook server shutdown", () => {
     clearTimeout(forceTimer);
     agent.destroy();
     assert.strictEqual(closed, true);
+  });
+
+  test("force-closing a socket mid-body does not raise an unhandled rejection", async (t) => {
+    const server = createWebhookServer(fakeBot(), { path: "/", secretToken: "s" });
+    if (typeof server.closeAllConnections !== "function") {
+      t.skip("runtime has no closeAllConnections");
+      return;
+    }
+    const port = await listen(server);
+
+    const rejections: unknown[] = [];
+    const onRejection = (err: unknown): void => {
+      rejections.push(err);
+    };
+    process.on("unhandledRejection", onRejection);
+
+    // Open a raw POST that promises 100 bytes but sends only a few, so the
+    // server's readBody() is still awaiting the body when we tear the socket down.
+    const sock = net.connect(port, "127.0.0.1");
+    await new Promise<void>((resolve) => sock.on("connect", () => resolve()));
+    sock.write(
+      "POST / HTTP/1.1\r\nHost: x\r\nx-telegram-bot-api-secret-token: s\r\n" +
+        'Content-Type: application/json\r\nContent-Length: 100\r\n\r\n{"partial":',
+    );
+    sock.on("error", () => {}); // ignore the reset our own force-close causes
+
+    // Let the request reach the server, then force-close: destroys the socket
+    // after ~1ms, making readBody reject with ECONNRESET on the discarded handler
+    // promise. Without the `.catch` that would surface as an unhandled rejection.
+    await new Promise((r) => setTimeout(r, 30));
+    const forceTimer = gracefulClose(server, 1);
+
+    // Give the force-close and any pending rejection time to surface.
+    await new Promise((r) => setTimeout(r, 80));
+
+    clearTimeout(forceTimer);
+    sock.destroy();
+    server.closeAllConnections?.();
+    process.off("unhandledRejection", onRejection);
+
+    assert.deepStrictEqual(rejections, []);
   });
 
   test("startWebhook rejects on a listen error and removes its signal handlers", async () => {

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Bot } from "../../src/core/bot.js";
-import { createWebhookServer, startWebhook } from "../../src/node/server.js";
+import { createWebhookServer, gracefulClose, startWebhook } from "../../src/node/server.js";
 import type { Update } from "../../src/types/index.js";
 
 /** A fake Bot exposing only handleUpdate (all that the webhook path needs). */
@@ -43,9 +43,9 @@ function keepAliveGet(port: number, path: string, agent: http.Agent): Promise<vo
 describe("webhook server shutdown", () => {
   // The hang #1350's second half describes: `server.close()` alone waits for
   // every existing connection to end, so an idle keep-alive socket keeps the
-  // server (and a `startWebhook` promise) open forever. Dropping idle
-  // connections lets `close` complete.
-  test("close() completes despite an idle keep-alive connection once idle sockets are dropped", async (t) => {
+  // server (and a `startWebhook` promise) open forever. `gracefulClose` drops
+  // idle connections so `close` can complete.
+  test("gracefulClose completes despite an idle keep-alive connection", async (t) => {
     const server = createWebhookServer(fakeBot(), { path: "/", secretToken: "s" });
     if (typeof server.closeIdleConnections !== "function") {
       t.skip("runtime has no closeIdleConnections");
@@ -56,25 +56,18 @@ describe("webhook server shutdown", () => {
     // Make one request over a keep-alive agent (to a non-webhook path, so the
     // server 404s without invoking the handler), then leave the socket idle-open.
     const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
-    await new Promise<void>((resolve, reject) => {
-      const req = http.request({ host: "127.0.0.1", port, path: "/nope", method: "GET", agent }, (res) => {
-        res.on("data", () => {});
-        res.on("end", () => resolve());
-      });
-      req.on("error", reject);
-      req.end();
-    });
+    await keepAliveGet(port, "/nope", agent);
 
     let closed = false;
     server.on("close", () => {
       closed = true;
     });
 
-    server.close(); // would hang here alone: the keep-alive socket is still open
-    server.closeIdleConnections(); // ...so drop it, letting `close` fire
+    const forceTimer = gracefulClose(server, 10_000); // would hang without dropping the idle socket
 
     // Wait briefly for the close event (poll, no fixed sleep).
     for (let i = 0; i < 50 && !closed; i++) await new Promise((r) => setTimeout(r, 10));
+    clearTimeout(forceTimer);
     agent.destroy();
     assert.strictEqual(closed, true);
   });

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -136,7 +136,7 @@ describe("webhook server shutdown", () => {
     await new Promise<void>((resolve) => blocker.close(() => resolve()));
   });
 
-  test("startWebhook shuts down on a signal, dropping an idle connection, and is idempotent", async (t) => {
+  test("startWebhook shuts down via its signal handler, dropping an idle connection, and is idempotent", async (t) => {
     // Needs the Node 18.2+ connection helpers; skip where a runtime lacks them
     // (without them the idle socket would keep close() pending and this hangs).
     if (typeof http.createServer().closeIdleConnections !== "function") {
@@ -144,12 +144,10 @@ describe("webhook server shutdown", () => {
       return;
     }
 
-    // Detach any pre-existing signal listeners (e.g. the test runner's) so our
-    // synthetic emit reaches only startWebhook's handler; restored in finally.
-    const savedInt = process.listeners("SIGINT");
-    const savedTerm = process.listeners("SIGTERM");
-    process.removeAllListeners("SIGINT");
-    process.removeAllListeners("SIGTERM");
+    // Rather than mutating process-global signal state (removeAllListeners /
+    // emit, which can disturb other tests or the runner), snapshot the SIGTERM
+    // listeners, let startWebhook add its own, then invoke *that* handler directly.
+    const before = new Set(process.listeners("SIGTERM"));
 
     const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
     try {
@@ -170,22 +168,27 @@ describe("webhook server shutdown", () => {
           await new Promise((r) => setTimeout(r, 10));
         }
       }
-      assert.strictEqual(process.listenerCount("SIGTERM"), 1); // handler installed
 
-      // Two signals in a row: the second must be a no-op (idempotent stop).
-      process.emit("SIGTERM");
-      process.emit("SIGTERM");
+      // Grab the handler startWebhook installed (poll: it may appear a tick after
+      // the socket is accepted), without touching anyone else's listeners.
+      let stop: (() => void) | undefined;
+      for (let i = 0; i < 50 && !stop; i++) {
+        stop = process.listeners("SIGTERM").find((l) => !before.has(l)) as (() => void) | undefined;
+        if (!stop) await new Promise((r) => setTimeout(r, 10));
+      }
+      assert.ok(stop, "startWebhook installed a SIGTERM handler");
+
+      // Call it twice: the second is a no-op (idempotent stop).
+      stop();
+      stop();
 
       // Resolves rather than hanging: the idle keep-alive socket was dropped.
       await running;
 
-      // finally ran: startWebhook removed its own handlers.
-      assert.strictEqual(process.listenerCount("SIGINT"), 0);
-      assert.strictEqual(process.listenerCount("SIGTERM"), 0);
+      // finally ran: startWebhook removed its own handler (back to the snapshot).
+      assert.ok(!process.listeners("SIGTERM").some((l) => !before.has(l)));
     } finally {
       agent.destroy();
-      for (const l of savedInt) process.on("SIGINT", l as (...a: unknown[]) => void);
-      for (const l of savedTerm) process.on("SIGTERM", l as (...a: unknown[]) => void);
     }
   });
 });


### PR DESCRIPTION
Closes #1350

<!-- michi:plan -->
- [x] T1 <!--m:c9p1--> `longPoll`: treat a 409 poll conflict as recoverable - back off (its own longer delay) and resume, bounded by a max consecutive-conflict count that then throws; log + `onError`, counter resets on any successful poll
- [x] T2 <!--m:d4t2--> Unit tests: resume after a transient 409, throw after N consecutive conflicts, and respect `retry: false`
- [x] T3 <!--m:e7d3--> Regenerate `doc/api.md` for the new `LongPollOptions` fields
- [x] T4 <!--m:f8h4--> `run()`: a fatal poll-stop must not be silent - the managed runner surfaces it to stderr before re-throwing, so a dropped/late-observed rejection can't leave the process alive with dead polling; unit test
- [x] T5 <!--m:g5w5--> `startWebhook`: cap graceful shutdown so an idle keep-alive (or stuck) connection can't leave a stopped-but-never-exiting process - drop idle connections, force-close past `shutdownTimeoutMs`; unit test + docs
- [x] T6 <!--m:h6a1--> Bump the documented minimum to Node 18.2 (`engines`, docs) - `closeIdleConnections`/`closeAllConnections` need 18.2, so `>=18` could still hang (Codex P2)
- [x] T7 <!--m:i7b2--> Make `startWebhook`'s shutdown idempotent: a `shuttingDown` guard schedules a single force-timer, so repeated signals can't leak a timer that fires after resolve (Codex)
- [x] T8 <!--m:j8c3--> Fix the off-by-one wording in the conflict-retry comment (N retries, throw on conflict N+1) (Codex)
- [x] T9 <!--m:k9d4--> Close test gaps: `startWebhook` signal-driven shutdown (idle close, force-close on timeout, repeated signals, handler cleanup) and `longPoll` conflict counter resets on a successful (incl. empty) poll (Codex)
- [x] T10 <!--m:l0e5--> Simplify: trim the verbose polling/shutdown comments and JSDoc, collapse the conflict/plain log into one line (no behavior change)
- [x] T11 <!--m:m1f6--> Refactor: move 409 classification (`isPollConflict` + `HTTP_STATUS_CONFLICT`) into `errors.ts` next to `isTransientError`, so all error taxonomy lives in one module
- [x] T12 <!--m:n2g7--> Refactor: extract the shared SIGINT/SIGTERM install-run-cleanup into `src/node/withShutdownSignals`, used by both `run()` and `startWebhook()` (one place for the signal set)
- [x] T13 <!--m:o3h8--> Refactor: extract `gracefulClose(server, timeoutMs)` in `server.ts` (close + drop idle + bounded force-close) so shutdown mechanics are self-contained and directly unit-testable
- [x] T14 <!--m:p4j9--> Handle request aborts from a forced shutdown: `createWebhookServer` now `.catch`es the handler promise, so a socket destroyed mid-body (ECONNRESET from `readBody`) can't become an unhandled rejection that crashes the process mid-shutdown; regression test (Codex P2)
- [x] T15 <!--m:q5k0--> Install `startWebhook`'s shutdown handlers only after the server is listening, so an early signal can't call `server.close()` on a not-yet-listening server (ERR_SERVER_NOT_RUNNING) - no try/catch needed (Copilot)
- [x] T16 <!--m:r6l1--> `longPoll`: reset the conflict counter on a non-conflict transient error so the bound is on truly *consecutive* 409s (409 -> 5xx -> 409 no longer counts as two); test (Copilot)
- [x] T17 <!--m:s7m2--> Stop mutating process-global signal listeners in the shutdown test: snapshot + diff to invoke startWebhook's own handler directly, avoiding flakiness under concurrent test runs (Copilot)
<!-- /michi:plan -->
