### PR TITLE
2.2.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+## [2.2.0-rc1][2.2.0-rc1] - 2026-09-07
+
 ### Long polling
 
 - A `409 Conflict` is now treated as a recoverable poll error instead of
@@ -1244,4 +1246,5 @@ Fixed:
 [2.0.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.0.0
 [2.1.0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.1.0
 [2.2.0-rc0]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.2.0-rc0
-[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v2.2.0-rc0...master
+[2.2.0-rc1]:https://github.com/yagop/node-telegram-bot-api/releases/tag/v2.2.0-rc1
+[Unreleased]:https://github.com/yagop/node-telegram-bot-api/compare/v2.2.0-rc1...master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot-api",
-  "version": "2.2.0-rc0",
+  "version": "2.2.0-rc1",
   "description": "Telegram Bot API - runtime-agnostic TypeScript client (v2).",
   "type": "module",
   "main": "./dist/core/index.cjs",


### PR DESCRIPTION
Release 2.2.0-rc1 (prerelease, publishes under the `next` dist-tag).

Bumps `package.json` to 2.2.0-rc1 and promotes the CHANGELOG `Unreleased` section to a dated `2.2.0-rc1` entry.

Since 2.2.0-rc0:
- **Long polling** - 409 Conflict is now recoverable/bounded; `conflictRetryDelayMs` / `maxConflictRetries`; public `isPollConflict()` + `HTTP_STATUS_CONFLICT` (#1350).
- **Transport** - empty/whitespace `apiRoot` falls back to the default (#1354).
- **Node helpers** - `run({ exitOnError })`; `RedisSessionStorage` owns/closes a `url`-constructed client (#1351).
- **Reply/callback tracking** - opt-in per-chat LRU bound (`replyTracking: { maxEntries, maxBytes, defaultTtlSeconds, slidingTtl }`), least-recently-used eviction; new `examples/18-reply-tracking-lru.ts` (#1357).
- **Sessions** - dropped the unused `createdAt` / `updatedAt` envelope timestamps (and the `now` clock option); these shipped only in rc0.

`npm run check` + `npm run build` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)