### PR TITLE
reply-tracking: rename size budgets to maxEntriesPerChat / maxBytesPerChat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][Unreleased]
 
+### Reply and callback tracking
+
+- Renamed the reply-tracking size budgets to denote their scope:
+  `replyTracking.maxEntries` -> `maxEntriesPerChat` and `maxBytes` ->
+  `maxBytesPerChat` (each bounds one session key's tables, per chat with the
+  default key). Breaking rename within the `2.2.0` prerelease line; the old names
+  shipped only in `2.2.0-rc1`.
+
 ## [2.2.0-rc1][2.2.0-rc1] - 2026-09-07
 
 ### Long polling

--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ TTL bounds a marker's *age*, not the table's *size* - a chat that fires many sho
 createSession<Session>({
   store: new MemorySessionStorage(),
   replyTracking: {
-    maxEntries: 50, // cap the live markers per chat...
-    maxBytes: 8192, // ...and their serialized size
+    maxEntriesPerChat: 50, // cap the live markers per chat...
+    maxBytesPerChat: 8192, // ...and their serialized size
     defaultTtlSeconds: 3600, // a TTL for every expectation that sets none
     slidingTtl: true, // ...refreshed each time the marker is used
   },

--- a/doc/api.md
+++ b/doc/api.md
@@ -6557,8 +6557,8 @@ unbounded (the historic behavior) and grow until entries are matched, forgotten,
 or expire.
 
 TTL caps a marker's *age* but not the table's *size*: a chat that fires many
-short-lived keyboards can still balloon between prunes. `maxEntries` /
-`maxBytes` bound the size, evicting the least-recently-used markers once a
+short-lived keyboards can still balloon between prunes. `maxEntriesPerChat` /
+`maxBytesPerChat` bound the size, evicting the least-recently-used markers once a
 budget is exceeded - "least-recently-used", not "oldest", because an active old
 keyboard must outlive an idle newer one. Recency (`lastUsedAt`) is stamped on
 both record and match, so a matched-but-kept press marker (a live inline
@@ -6567,8 +6567,8 @@ keyboard) counts as fresh.
 ```ts
 type ReplyTrackingOptions = {
   defaultTtlSeconds?: number;
-  maxBytes?: number;
-  maxEntries?: number;
+  maxBytesPerChat?: number;
+  maxEntriesPerChat?: number;
   now?: () => number;
   slidingTtl?: boolean;
 };

--- a/examples/18-reply-tracking-lru.ts
+++ b/examples/18-reply-tracking-lru.ts
@@ -11,7 +11,7 @@
  * one with a marker `callback_data` could not hold (a private, oversized payload).
  * Nobody presses most of them, so without a bound the markers pile up. With it:
  *
- * - `maxEntries` / `maxBytes` cap the tables; over budget, the
+ * - `maxEntriesPerChat` / `maxBytesPerChat` cap the tables; over budget, the
  *   **least-recently-used** markers are evicted - recency, not age, so a keyboard
  *   the user is still pressing outlives an older idle one. Pressing a keyboard is
  *   a "use" too (it refreshes recency), not only sending it.
@@ -43,8 +43,8 @@ bot.use(
     store: new MemorySessionStorage(),
     // The whole point of this example: a hard per-chat bound on the press table.
     replyTracking: {
-      maxEntries: 5, // at most 5 live markers per chat...
-      maxBytes: 4096, // ...and never more than 4 KB serialized, whichever bites first
+      maxEntriesPerChat: 5, // at most 5 live markers per chat...
+      maxBytesPerChat: 4096, // ...and never more than 4 KB serialized, whichever bites first
       defaultTtlSeconds: 3600, // every marker expires after an idle hour...
       slidingTtl: true, // ...but each press pushes that hour out again
     },

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ relative `../src` paths.
 | [`15-rich-message.ts`](./15-rich-message.ts) | `RichMessageBuilder`, `RichTextBuilder`, `richMessageButton`/`richListItem`, `sendRichMessage` (blocks + `html` mode) | `BOT_TOKEN=... CHAT_ID=... bun examples/15-rich-message.ts` |
 | [`16-sessions.ts`](./16-sessions.ts) | `createSession()` + `session.get(ctx)`, durable `FileSessionStorage` (`/node`), `taggedReplies` for a name->email reply flow | `BOT_TOKEN=... bun examples/16-sessions.ts` |
 | [`17-callback-tracking.ts`](./17-callback-tracking.ts) | Routing button presses two ways: stateless `callback_data` paging, vs. `expectCallback`/`matchCallback(ctx, { once: true })` for an oversized, private, one-shot confirmation | `BOT_TOKEN=... bun examples/17-callback-tracking.ts` |
-| [`18-reply-tracking-lru.ts`](./18-reply-tracking-lru.ts) | Bounding the reply/press tables with a per-chat LRU: `createSession({ replyTracking: { maxEntries, maxBytes, defaultTtlSeconds, slidingTtl } })`, evicting least-recently-used markers | `BOT_TOKEN=... bun examples/18-reply-tracking-lru.ts` |
+| [`18-reply-tracking-lru.ts`](./18-reply-tracking-lru.ts) | Bounding the reply/press tables with a per-chat LRU: `createSession({ replyTracking: { maxEntriesPerChat, maxBytesPerChat, defaultTtlSeconds, slidingTtl } })`, evicting least-recently-used markers | `BOT_TOKEN=... bun examples/18-reply-tracking-lru.ts` |
 
 The framework webhook examples (03-05) target serverless/framework platforms and
 aren't standalone-runnable here, but they typecheck and show the exact wiring.

--- a/src/core/reply-tracking.ts
+++ b/src/core/reply-tracking.ts
@@ -31,7 +31,7 @@
  *
  * TTL bounds a marker's age, not the table's size. For a hard per-chat cap pass
  * {@link ReplyTrackingOptions} to `createSession({ store, replyTracking })`:
- * `maxEntries` / `maxBytes` evict the least-recently-used markers once a budget
+ * `maxEntriesPerChat` / `maxBytesPerChat` evict the least-recently-used markers once a budget
  * is exceeded (recency, not age, so an active old keyboard outlives an idle newer
  * one), `defaultTtlSeconds` gives every expectation a TTL, and `slidingTtl`
  * re-arms it on use. All opt-in; with no `replyTracking` the tables are unbounded.
@@ -82,8 +82,8 @@ export type ExpectOptions = {
  * or expire.
  *
  * TTL caps a marker's *age* but not the table's *size*: a chat that fires many
- * short-lived keyboards can still balloon between prunes. `maxEntries` /
- * `maxBytes` bound the size, evicting the least-recently-used markers once a
+ * short-lived keyboards can still balloon between prunes. `maxEntriesPerChat` /
+ * `maxBytesPerChat` bound the size, evicting the least-recently-used markers once a
  * budget is exceeded - "least-recently-used", not "oldest", because an active old
  * keyboard must outlive an idle newer one. Recency (`lastUsedAt`) is stamped on
  * both record and match, so a matched-but-kept press marker (a live inline
@@ -95,12 +95,12 @@ export type ReplyTrackingOptions = {
    * a record pushes past it, the least-recently-used markers are evicted down to
    * the cap.
    */
-  maxEntries?: number;
+  maxEntriesPerChat?: number;
   /**
    * Cap on the serialized (UTF-8) byte size of this key's reply namespace. After
    * a record, least-recently-used markers are evicted until the namespace fits.
    */
-  maxBytes?: number;
+  maxBytesPerChat?: number;
   /** TTL (seconds) applied to any expectation recorded without its own `ttlSeconds`. */
   defaultTtlSeconds?: number;
   /**
@@ -185,7 +185,7 @@ function record(
 
 /** Whether an LRU size budget is configured - the only thing that reads `lastUsedAt`. */
 function hasBudget(config: ReplyTrackingOptions | undefined): boolean {
-  return config !== undefined && (config.maxEntries !== undefined || config.maxBytes !== undefined);
+  return config !== undefined && (config.maxEntriesPerChat !== undefined || config.maxBytesPerChat !== undefined);
 }
 
 /** Mark a kept marker as just used: slide its TTL if it has one, and bump recency for the LRU. */
@@ -217,11 +217,11 @@ function lruOrder(state: ReplyState): Ref[] {
 
 /**
  * Evict the least-recently-used markers across both tables until the configured
- * `maxEntries` and `maxBytes` budgets are met. A no-op when neither is set.
+ * `maxEntriesPerChat` and `maxBytesPerChat` budgets are met. A no-op when neither is set.
  */
 function evict(state: ReplyState, config: ReplyTrackingOptions | undefined): void {
-  const { maxEntries, maxBytes } = config ?? {};
-  if (maxEntries === undefined && maxBytes === undefined) return;
+  const { maxEntriesPerChat, maxBytesPerChat } = config ?? {};
+  if (maxEntriesPerChat === undefined && maxBytesPerChat === undefined) return;
 
   const victims = lruOrder(state);
   let i = 0;
@@ -230,10 +230,10 @@ function evict(state: ReplyState, config: ReplyTrackingOptions | undefined): voi
     if (ref !== undefined) delete ref.table[ref.id];
   };
 
-  // `i < victims.length` also guards a negative/NaN `maxEntries` from underflowing
+  // `i < victims.length` also guards a negative/NaN `maxEntriesPerChat` from underflowing
   // past the last victim (which would deref `undefined`); it just evicts down to empty.
-  while (maxEntries !== undefined && i < victims.length && victims.length - i > maxEntries) dropNext();
-  while (maxBytes !== undefined && i < victims.length && byteLength(state) > maxBytes) dropNext();
+  while (maxEntriesPerChat !== undefined && i < victims.length && victims.length - i > maxEntriesPerChat) dropNext();
+  while (maxBytesPerChat !== undefined && i < victims.length && byteLength(state) > maxBytesPerChat) dropNext();
 }
 
 /**

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -161,7 +161,7 @@ export type SessionOptions<T> = {
   ttlSeconds?: number;
   /**
    * Per-chat bounds for the reply-tracking layer (`expectReply` / `expectCallback`
-   * and friends): `maxEntries` / `maxBytes` cap the tables with LRU eviction,
+   * and friends): `maxEntriesPerChat` / `maxBytesPerChat` cap the tables with LRU eviction,
    * `defaultTtlSeconds` / `slidingTtl` control expiry. Omit to leave the tables
    * unbounded. Surfaced unchanged on the handle as `.replyTracking`.
    */

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -734,9 +734,9 @@ describe("reply-tracking LRU budgets", () => {
     } as unknown as Update;
   }
 
-  test("maxEntries evicts the least-recently-used marker across both tables", async () => {
+  test("maxEntriesPerChat evicts the least-recently-used marker across both tables", async () => {
     let clock = 1000;
-    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxEntries: 2, now: () => clock } });
+    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxEntriesPerChat: 2, now: () => clock } });
 
     const ask = new Context(msg("q"), api);
     await mw(ask, async () => {
@@ -757,7 +757,7 @@ describe("reply-tracking LRU budgets", () => {
 
   test("a recently-used keeper outlives an idle newer marker (recency, not age)", async () => {
     let clock = 1000;
-    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxEntries: 2, now: () => clock } });
+    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxEntriesPerChat: 2, now: () => clock } });
 
     const setup = new Context(msg("q"), api);
     await mw(setup, async () => {
@@ -782,10 +782,10 @@ describe("reply-tracking LRU budgets", () => {
     await mw(p2, async () => assert.equal(matchCallback(p2), undefined, "idle marker evicted"));
   });
 
-  test("maxBytes evicts LRU markers until the namespace fits", async () => {
+  test("maxBytesPerChat evicts LRU markers until the namespace fits", async () => {
     let clock = 1000;
     const big = "x".repeat(200);
-    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxBytes: 300, now: () => clock } });
+    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxBytesPerChat: 300, now: () => clock } });
 
     const ask = new Context(msg("q"), api);
     await mw(ask, async () => {
@@ -855,12 +855,12 @@ describe("reply-tracking LRU budgets", () => {
     await mw(ask, async () => expectCallback(ask, 1, { n: 1 }));
 
     const stored = store.writes.at(-1)?.[1] as string;
-    assert.doesNotMatch(stored, /lastUsedAt/, "lastUsedAt is dead weight with no maxEntries/maxBytes");
+    assert.doesNotMatch(stored, /lastUsedAt/, "lastUsedAt is dead weight with no maxEntriesPerChat/maxBytesPerChat");
     assert.match(stored, /expiresAt/, "the TTL is still applied");
   });
 
-  test("a negative maxEntries evicts everything instead of throwing", async () => {
-    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxEntries: -1 } });
+  test("a negative maxEntriesPerChat evicts everything instead of throwing", async () => {
+    const mw = createSession({ store: new MemorySessionStorage(), replyTracking: { maxEntriesPerChat: -1 } });
 
     const ask = new Context(msg("q"), api);
     await mw(ask, async () => {


### PR DESCRIPTION
`replyTracking.maxEntries` / `maxBytes` didn't convey scope: each budget bounds **one session key's** reply tables (per chat with the default `getSessionKey`), not a global total. Rename to `maxEntriesPerChat` / `maxBytesPerChat`.

```ts
createSession({ store, replyTracking: { maxEntriesPerChat: 50, maxBytesPerChat: 8192 } });
```

`defaultTtlSeconds` / `slidingTtl` are per-marker time semantics and keep their names.

Breaking rename within the 2.2.0 prerelease line — the old names shipped only in `2.2.0-rc1` (under the `next` dist-tag), so no stable release is affected. Source, example, tests, README and CHANGELOG updated; `doc/api.md` regenerated. `npm run check` clean (248 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)