### PR TITLE
session: drop ??= in ext(), plus a biome format pass over ./src

### DIFF
--- a/src/bun/redis-storage.ts
+++ b/src/bun/redis-storage.ts
@@ -41,8 +41,7 @@ export class RedisSessionStorage implements SessionStore {
 
   constructor(options: RedisSessionStorageOptions = {}) {
     this.owned = options.client === undefined && options.url !== undefined;
-    this.client =
-      options.client ?? (options.url !== undefined ? this.createClient(options.url) : redis);
+    this.client = options.client ?? (options.url !== undefined ? this.createClient(options.url) : redis);
     this.prefix = options.prefix ?? "session:";
     this.ttlSeconds = options.ttlSeconds;
   }

--- a/src/bun/sql-storage.ts
+++ b/src/bun/sql-storage.ts
@@ -31,7 +31,7 @@
  * `./node` (a CI guard enforces it).
  */
 
-import { SQL, sql as bunSql } from "bun";
+import { sql as bunSql, SQL } from "bun";
 import type { SessionStore } from "../core/session.js";
 
 export type SqlSessionStorageOptions = {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -29,14 +29,14 @@ export * from "./files.js";
 export * from "./keyboard.js";
 export * from "./longpoll.js";
 export * from "./media.js";
-// Opt-in rate limiting (ADR-004 §10, M3)
-export * from "./ratelimiter.js";
 // Opt-in session middleware + its core store and the reply-tracking layer
 export * from "./memory-session-storage.js";
+// Opt-in rate limiting (ADR-004 §10, M3)
+export * from "./ratelimiter.js";
 export * from "./reply-tracking.js";
-export * from "./session.js";
 export * from "./richmessage.js";
 export * from "./richtext.js";
+export * from "./session.js";
 // Transport (ADR-005, ADR-008)
 export * from "./transport.js";
 // Webhooks (ADR-005, §6.7)

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -53,7 +53,15 @@ type RetryContext = {
 /** Decide how to handle a getUpdates failure. Throws the error to stop the loop
  *  (non-retryable, or the conflict budget is exhausted); otherwise returns the
  *  wait before re-polling and the new consecutive-conflict count. */
-function planRetry({ err, conflicts, retry, retryDelayMs, conflictRetryDelayMs, maxConflictRetries, onError }: RetryContext): RetryPlan {
+function planRetry({
+  err,
+  conflicts,
+  retry,
+  retryDelayMs,
+  conflictRetryDelayMs,
+  maxConflictRetries,
+  onError,
+}: RetryContext): RetryPlan {
   const pollConflict = isPollConflict(err);
   if (!retry || !(isTransientError(err) || pollConflict)) throw err;
   // A conflict advances its own bounded counter; any other transient breaks the streak.
@@ -63,7 +71,11 @@ function planRetry({ err, conflicts, retry, retryDelayMs, conflictRetryDelayMs, 
   // A conflict waits its own longer delay; otherwise honor `retry_after`
   // (e.g. a 429 flood-wait) when present, else the default delay.
   const wait = pollConflict ? conflictRetryDelayMs : (retryAfterMs(err) ?? retryDelayMs);
-  log("getUpdates %s; retry in %dms", pollConflict ? `conflict ${next}/${maxConflictRetries}` : "failed", Math.round(wait));
+  log(
+    "getUpdates %s; retry in %dms",
+    pollConflict ? `conflict ${next}/${maxConflictRetries}` : "failed",
+    Math.round(wait),
+  );
   return { wait, conflicts: next };
 }
 
@@ -112,7 +124,16 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
       // A 409 (another instance polling the same token) is transient for polling
       // but bounded, so an overlapping redeploy heals while a real two-instance
       // deployment still surfaces. `recover` throws for anything non-retryable.
-      const outcome = await recover({ err, conflicts, retry, retryDelayMs, conflictRetryDelayMs, maxConflictRetries, onError, signal });
+      const outcome = await recover({
+        err,
+        conflicts,
+        retry,
+        retryDelayMs,
+        conflictRetryDelayMs,
+        maxConflictRetries,
+        onError,
+        signal,
+      });
       if (outcome === "stop") return;
       conflicts = outcome.conflicts;
       // retry WITHOUT advancing offset

--- a/src/core/richmessage.ts
+++ b/src/core/richmessage.ts
@@ -60,9 +60,7 @@ function resolveBlocks(content: BlockContent): InputRichBlock[] {
 
 /** A block caption (`text`, optional `credit`) with rich `text`. */
 export function richCaption(text: RichTextContent, credit?: RichTextContent): RichBlockCaption {
-  return credit === undefined
-    ? { text: asRichText(text) }
-    : { text: asRichText(text), credit: asRichText(credit) };
+  return credit === undefined ? { text: asRichText(text) } : { text: asRichText(text), credit: asRichText(credit) };
 }
 
 /** A table cell; `align` defaults to `"left"`, `valign` to `"top"`. */
@@ -165,7 +163,11 @@ export class RichMessageBuilder {
 
   /** A slideshow of nested media blocks. */
   slideshow(blocks: BlockContent, caption?: RichBlockCaption): this {
-    return this.push({ type: "slideshow", blocks: resolveBlocks(blocks), ...(caption !== undefined ? { caption } : {}) });
+    return this.push({
+      type: "slideshow",
+      blocks: resolveBlocks(blocks),
+      ...(caption !== undefined ? { caption } : {}),
+    });
   }
 
   /** A table; `cells` is a rows-of-cells grid (see `richTableCell`). */

--- a/src/core/richtext.ts
+++ b/src/core/richtext.ts
@@ -11,13 +11,7 @@
  * `RichTextBuilder`) so trees nest without hand-writing `type`/`text`. `.build()`
  * returns the plain `RichText`, ready for a `text`/caption/button field.
  */
-import type {
-  LoginUrl,
-  RichMessageButton,
-  RichText,
-  SwitchInlineQueryChosenChat,
-  User,
-} from "../types/index.js";
+import type { LoginUrl, RichMessageButton, RichText, SwitchInlineQueryChosenChat, User } from "../types/index.js";
 
 /** Anything a rich-text `content` parameter accepts. */
 export type RichTextContent = RichText | RichTextBuilder;

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -292,7 +292,8 @@ export function createSession<T = Record<string, unknown>>(options: SessionOptio
           makeInitial: () => E,
           isValid?: (slot: Record<string, unknown>) => boolean,
         ): E {
-          const ext = (envelope.ext ??= {});
+          if (envelope.ext === undefined) envelope.ext = {};
+          const ext = envelope.ext;
           const current = ext[namespace];
           if (!isPlainObject(current) || (isValid !== undefined && !isValid(current))) {
             const fresh = makeInitial();

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -9,7 +9,7 @@
 export * from "../core/index.js";
 // Side effect: reads `DEBUG` and enables stderr tracing (debug-pkg convention).
 export * from "./debug.js";
+export * from "./file-session-storage.js";
 export * from "./from-path.js";
 export * from "./run.js";
 export * from "./server.js";
-export * from "./file-session-storage.js";


### PR DESCRIPTION
Two commits:

1. **`session.ts` fix** — `bun run format` (biome) flagged `noAssignInExpressions` on `const ext = (envelope.ext ??= {})` in `SessionHandle.ext()`. Replaced with an explicit statement (no `??=`, no assignment-in-expression):
   ```ts
   if (envelope.ext === undefined) envelope.ext = {};
   const ext = envelope.ext;
   ```
   Behavior identical.

2. **biome format pass** over `./src` — 7 files that had drifted (biome isn't run in CI, only `lint:core`/`check:edge` are). Pure formatting: line-wrapping to 120 cols, no behavior change.

Together these make `bun run format` exit clean. `npm run typecheck` + 56 session tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)