### PR TITLE
ci: enforce biome (format + complexity + ??= ban) via src/biome.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: npm run lint:core
       - name: Core bundles edge-safe (check:edge)
         run: npm run check:edge
+      - name: Formatting is clean (lint:format)
+        run: npm run lint:format
 
   unit-bun:
     name: Unit tests (Bun)

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "lint:core": "node scripts/check-core-imports.mjs",
     "lint:bun-isolation": "node scripts/check-bun-isolation.mjs",
     "check:edge": "bun scripts/check-edge-bundle.mjs",
-    "format": "biome check --write --indent-style=space --line-width=120 ./src",
-    "check": "npm run typecheck && npm run typecheck:bun && npm run typecheck:test && npm run typecheck:examples && npm run lint:core && npm run lint:bun-isolation && npm run check:edge && npm test",
+    "lint:format": "biome check --indent-style=space --line-width=100 --trailing-commas=es5 ./src",
+    "check": "npm run typecheck && npm run typecheck:bun && npm run typecheck:test && npm run typecheck:examples && npm run lint:core && npm run lint:bun-isolation && npm run check:edge && npm run lint:format && npm test",
     "generate:types": "bun scripts/api-parser.ts",
     "prepublishOnly": "npm run build",
     "generate:docs": "bun scripts/generate-docs.ts"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lint:core": "node scripts/check-core-imports.mjs",
     "lint:bun-isolation": "node scripts/check-bun-isolation.mjs",
     "check:edge": "bun scripts/check-edge-bundle.mjs",
-    "lint:format": "biome check --indent-style=space --line-width=100 --trailing-commas=es5 ./src",
+    "lint:format": "biome check ./src",
     "check": "npm run typecheck && npm run typecheck:bun && npm run typecheck:test && npm run typecheck:examples && npm run lint:core && npm run lint:bun-isolation && npm run check:edge && npm run lint:format && npm test",
     "generate:types": "bun scripts/api-parser.ts",
     "prepublishOnly": "npm run build",

--- a/src/biome.json
+++ b/src/biome.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "root": false,
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "trailingCommas": "es5"
+    }
+  },
+  "plugins": ["./no-nullish-assign.grit"]
+}

--- a/src/biome.json
+++ b/src/biome.json
@@ -22,7 +22,8 @@
         }
       },
       "style": {
-        "useBlockStatements": "error"
+        "useBlockStatements": "error",
+        "useAtIndex": "error"
       }
     }
   },

--- a/src/biome.json
+++ b/src/biome.json
@@ -20,6 +20,9 @@
             "maxAllowedComplexity": 15
           }
         }
+      },
+      "style": {
+        "useBlockStatements": "error"
       }
     }
   },

--- a/src/biome.json
+++ b/src/biome.json
@@ -11,5 +11,17 @@
       "trailingCommas": "es5"
     }
   },
+  "linter": {
+    "rules": {
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 15
+          }
+        }
+      }
+    }
+  },
   "plugins": ["./no-nullish-assign.grit"]
 }

--- a/src/bun/redis-storage.ts
+++ b/src/bun/redis-storage.ts
@@ -41,7 +41,8 @@ export class RedisSessionStorage implements SessionStore {
 
   constructor(options: RedisSessionStorageOptions = {}) {
     this.owned = options.client === undefined && options.url !== undefined;
-    this.client = options.client ?? (options.url !== undefined ? this.createClient(options.url) : redis);
+    this.client =
+      options.client ?? (options.url !== undefined ? this.createClient(options.url) : redis);
     this.prefix = options.prefix ?? "session:";
     this.ttlSeconds = options.ttlSeconds;
   }

--- a/src/bun/sql-storage.ts
+++ b/src/bun/sql-storage.ts
@@ -84,7 +84,9 @@ export class SqlSessionStorage implements SessionStore {
    */
   init(): Promise<void> {
     if (this.closed) {
-      return Promise.reject(new Error("SqlSessionStorage: this store was closed; construct a new one"));
+      return Promise.reject(
+        new Error("SqlSessionStorage: this store was closed; construct a new one")
+      );
     }
     if (this.ensured === undefined) {
       this.ensured = (async () => {
@@ -119,14 +121,18 @@ export class SqlSessionStorage implements SessionStore {
 
   async read(key: string): Promise<string | undefined> {
     await this.init();
-    const [row] = (await this.sql`SELECT value FROM ${this.ref} WHERE key = ${key}`) as Array<{ value: unknown }>;
+    const [row] = (await this.sql`SELECT value FROM ${this.ref} WHERE key = ${key}`) as Array<{
+      value: unknown;
+    }>;
     if (row === undefined) return undefined;
     // `CREATE TABLE IF NOT EXISTS` adopts a pre-existing table of that name, so
     // the column may not be the TEXT we assume - a JSON/JSONB one comes back
     // already parsed. Say so here rather than letting a non-string reach the
     // codec and fail as a baffling JSON.parse error.
     if (typeof row.value !== "string") {
-      throw new TypeError(`SqlSessionStorage: ${this.table}.value must be TEXT, got ${typeof row.value}`);
+      throw new TypeError(
+        `SqlSessionStorage: ${this.table}.value must be TEXT, got ${typeof row.value}`
+      );
     }
     return row.value;
   }

--- a/src/bun/sql-storage.ts
+++ b/src/bun/sql-storage.ts
@@ -124,7 +124,9 @@ export class SqlSessionStorage implements SessionStore {
     const [row] = (await this.sql`SELECT value FROM ${this.ref} WHERE key = ${key}`) as Array<{
       value: unknown;
     }>;
-    if (row === undefined) return undefined;
+    if (row === undefined) {
+      return undefined;
+    }
     // `CREATE TABLE IF NOT EXISTS` adopts a pre-existing table of that name, so
     // the column may not be the TEXT we assume - a JSON/JSONB one comes back
     // already parsed. Say so here rather than letting a non-string reach the

--- a/src/bun/sqlite-storage.ts
+++ b/src/bun/sqlite-storage.ts
@@ -80,7 +80,9 @@ export class SqliteSessionStorage implements SessionStore {
   read(key: string): string | undefined {
     this.assertUsable();
     const row = this.getStmt.get(key) as { value: unknown } | null;
-    if (row === null) return undefined;
+    if (row === null) {
+      return undefined;
+    }
     // `CREATE TABLE IF NOT EXISTS` adopts a pre-existing table of that name, so
     // the column may not hold the TEXT we assume (SQLite stores whatever a
     // foreign writer bound). Say so here rather than letting a non-string reach

--- a/src/bun/sqlite-storage.ts
+++ b/src/bun/sqlite-storage.ts
@@ -51,19 +51,22 @@ export class SqliteSessionStorage implements SessionStore {
     }
     this.table = table;
     this.owned = typeof options.database !== "object";
-    this.db = typeof options.database === "object" ? options.database : new Database(options.database ?? ":memory:");
+    this.db =
+      typeof options.database === "object"
+        ? options.database
+        : new Database(options.database ?? ":memory:");
     this.db.run(
       `CREATE TABLE IF NOT EXISTS "${table}" (
          key TEXT PRIMARY KEY,
          value TEXT NOT NULL,
          created_at TEXT NOT NULL,
          updated_at TEXT NOT NULL
-       )`,
+       )`
     );
     this.getStmt = this.db.query(`SELECT value FROM "${table}" WHERE key = ?`);
     this.insertStmt = this.db.query(
       `INSERT INTO "${table}" (key, value, created_at, updated_at) VALUES (?, ?, ?, ?)
-       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
     );
     this.delStmt = this.db.query(`DELETE FROM "${table}" WHERE key = ?`);
   }
@@ -83,7 +86,9 @@ export class SqliteSessionStorage implements SessionStore {
     // foreign writer bound). Say so here rather than letting a non-string reach
     // the codec and fail as a baffling JSON.parse error.
     if (typeof row.value !== "string") {
-      throw new TypeError(`SqliteSessionStorage: ${this.table}.value must be TEXT, got ${typeof row.value}`);
+      throw new TypeError(
+        `SqliteSessionStorage: ${this.table}.value must be TEXT, got ${typeof row.value}`
+      );
     }
     return row.value;
   }

--- a/src/core/adapters.ts
+++ b/src/core/adapters.ts
@@ -49,7 +49,10 @@ export interface NodeLikeResponse {
  * export const POST = nextAppWebhook(bot);
  * ```
  */
-export function nextAppWebhook(bot: Bot, options?: WebhookOptions): (request: Request) => Promise<Response> {
+export function nextAppWebhook(
+  bot: Bot,
+  options?: WebhookOptions
+): (request: Request) => Promise<Response> {
   return webhookCallback(bot, options);
 }
 
@@ -91,7 +94,7 @@ async function readBody(req: NodeLikeRequest): Promise<string> {
  */
 export function nodeFrameworkWebhook(
   bot: Bot,
-  options?: WebhookOptions,
+  options?: WebhookOptions
 ): (req: NodeLikeRequest, res: NodeLikeResponse) => Promise<void> {
   const handle = webhookCallback(bot, options);
 
@@ -128,8 +131,10 @@ export function nodeFrameworkWebhook(
  */
 export function registerExpressWebhook(
   bot: Bot,
-  app: { post(path: string, handler: (req: NodeLikeRequest, res: NodeLikeResponse) => unknown): unknown },
-  options: WebhookOptions & { path: string },
+  app: {
+    post(path: string, handler: (req: NodeLikeRequest, res: NodeLikeResponse) => unknown): unknown;
+  },
+  options: WebhookOptions & { path: string }
 ): void {
   app.post(options.path, nodeFrameworkWebhook(bot, options));
 }

--- a/src/core/adapters.ts
+++ b/src/core/adapters.ts
@@ -68,8 +68,12 @@ export function nextAppWebhook(
 async function readBody(req: NodeLikeRequest): Promise<string> {
   const pre = req.body;
   if (pre !== undefined && pre !== null) {
-    if (typeof pre === "string") return pre;
-    if (pre instanceof Uint8Array) return new TextDecoder().decode(pre);
+    if (typeof pre === "string") {
+      return pre;
+    }
+    if (pre instanceof Uint8Array) {
+      return new TextDecoder().decode(pre);
+    }
     return JSON.stringify(pre);
   }
 
@@ -105,7 +109,9 @@ export function nodeFrameworkWebhook(
     // (rare for webhook requests) are joined per the HTTP convention.
     const headers = new Headers();
     for (const [name, value] of Object.entries(req.headers)) {
-      if (value === undefined) continue;
+      if (value === undefined) {
+        continue;
+      }
       headers.set(name, Array.isArray(value) ? value.join(", ") : value);
     }
 

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -215,21 +215,10 @@ export class Bot {
     return this.use((ctx, next) => {
       const text = ctx.message?.text;
       if (text === undefined) return next();
-      for (const t of triggers) {
-        if (typeof t === "string") {
-          if (text === t) {
-            ctx.match = text;
-            return run(ctx, next);
-          }
-        } else {
-          const m = text.match(t);
-          if (m) {
-            ctx.match = m;
-            return run(ctx, next);
-          }
-        }
-      }
-      return next();
+      const m = matchTriggers(text, triggers);
+      if (m === null) return next();
+      ctx.match = m;
+      return run(ctx, next);
     });
   }
 
@@ -310,4 +299,25 @@ export class Bot {
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The `ctx.match` value for the first `hears` trigger that matches `text`, or
+ * `null` when none do. A string trigger matches exactly (match value = the
+ * text); a RegExp matches via `text.match(re)` (match value = the
+ * `RegExpMatchArray`).
+ */
+function matchTriggers(
+  text: string,
+  triggers: ReadonlyArray<string | RegExp>
+): string | RegExpMatchArray | null {
+  for (const t of triggers) {
+    if (typeof t === "string") {
+      if (text === t) return text;
+    } else {
+      const m = text.match(t);
+      if (m) return m;
+    }
+  }
+  return null;
 }

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -88,10 +88,14 @@ export class Bot {
   private register(mw: ReadonlyArray<Middleware<Context>>): void {
     for (const fn of mw) {
       const plugin = fn as Middleware<Context> & MiddlewarePlugin;
-      if (typeof plugin.init !== "function" && typeof plugin.close !== "function") continue;
+      if (typeof plugin.init !== "function" && typeof plugin.close !== "function") {
+        continue;
+      }
       // The same middleware can reach us twice (`bot.use(session)` and then
       // `bot.on(..., session)`); it is one resource, so it gets one lifecycle.
-      if (!this.plugins.includes(plugin)) this.plugins.push(plugin);
+      if (!this.plugins.includes(plugin)) {
+        this.plugins.push(plugin);
+      }
     }
   }
 
@@ -110,7 +114,9 @@ export class Bot {
     if (this.started === undefined) {
       this.started = (async () => {
         for (const plugin of this.plugins) {
-          if (this.initialized.has(plugin)) continue;
+          if (this.initialized.has(plugin)) {
+            continue;
+          }
           await plugin.init?.();
           // Marked only on success: a plugin that threw never finished opening,
           // so `close()` must not try to close it.
@@ -147,7 +153,9 @@ export class Bot {
         // Skip what never initialized; unmark before closing, so that even a
         // failed teardown leaves the plugin eligible for a later init() rather
         // than stranded as "open" forever.
-        if (!this.initialized.delete(plugin)) continue;
+        if (!this.initialized.delete(plugin)) {
+          continue;
+        }
         try {
           await plugin.close?.();
         } catch (err) {
@@ -161,7 +169,9 @@ export class Bot {
       // init() from ever running setup again.
       this.started = undefined;
     }
-    if (failures.length === 1) throw failures[0];
+    if (failures.length === 1) {
+      throw failures[0];
+    }
     if (failures.length > 1) {
       throw new AggregateError(failures, "Bot.close: some middleware failed to close");
     }
@@ -192,9 +202,13 @@ export class Bot {
     const run = compose(handlers) satisfies Composed;
     return this.use((ctx, next) => {
       const text = ctx.message?.text ?? ctx.channelPost?.text;
-      if (text === undefined) return next();
+      if (text === undefined) {
+        return next();
+      }
       const m = re.exec(text);
-      if (!m) return next();
+      if (!m) {
+        return next();
+      }
       ctx.match = m[3] ?? "";
       return run(ctx, next);
     });
@@ -214,9 +228,13 @@ export class Bot {
     const run = compose(handlers) satisfies Composed;
     return this.use((ctx, next) => {
       const text = ctx.message?.text;
-      if (text === undefined) return next();
+      if (text === undefined) {
+        return next();
+      }
       const m = matchTriggers(text, triggers);
-      if (m === null) return next();
+      if (m === null) {
+        return next();
+      }
       ctx.match = m;
       return run(ctx, next);
     });
@@ -279,7 +297,9 @@ export class Bot {
       await this.init(); // fail fast on a bad store/plugin before the first poll
       const iterable = source ?? longPoll(this.api, options, controller.signal);
       for await (const update of iterable) {
-        if (controller.signal.aborted) break;
+        if (controller.signal.aborted) {
+          break;
+        }
         await this.handleUpdate(update);
       }
     } finally {
@@ -313,10 +333,14 @@ function matchTriggers(
 ): string | RegExpMatchArray | null {
   for (const t of triggers) {
     if (typeof t === "string") {
-      if (text === t) return text;
+      if (text === t) {
+        return text;
+      }
     } else {
       const m = text.match(t);
-      if (m) return m;
+      if (m) {
+        return m;
+      }
     }
   }
   return null;

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -205,7 +205,10 @@ export class Bot {
    * a RegExp matches when `text.match(re)` is non-null (sets `ctx.match` to the
    * `RegExpMatchArray`).
    */
-  hears(trigger: string | RegExp | Array<string | RegExp>, ...handlers: Middleware<Context>[]): this {
+  hears(
+    trigger: string | RegExp | Array<string | RegExp>,
+    ...handlers: Middleware<Context>[]
+  ): this {
     const triggers = Array.isArray(trigger) ? trigger : [trigger];
     this.register(handlers);
     const run = compose(handlers) satisfies Composed;
@@ -274,7 +277,9 @@ export class Bot {
    */
   async startPolling(source?: AsyncIterable<Update>, options?: LongPollOptions): Promise<void> {
     if (this.running) {
-      throw new Error("startPolling is already running; call stop() and await the previous run first");
+      throw new Error(
+        "startPolling is already running; call stop() and await the previous run first"
+      );
     }
     const controller = new AbortController();
     this.controller = controller;

--- a/src/core/compose.ts
+++ b/src/core/compose.ts
@@ -33,7 +33,9 @@ export function compose<C>(
       lastIndex = i;
 
       const fn: Middleware<C> | undefined = i === middleware.length ? next : middleware[i];
-      if (!fn) return Promise.resolve();
+      if (!fn) {
+        return Promise.resolve();
+      }
 
       try {
         return Promise.resolve(fn(ctx, () => dispatch(i + 1))).then(() => undefined);

--- a/src/core/compose.ts
+++ b/src/core/compose.ts
@@ -19,7 +19,9 @@ export type Middleware<C> = (ctx: C, next: NextFn) => unknown | Promise<unknown>
  * The composed function resolves when the whole chain (including the optional
  * trailing `next`) has settled.
  */
-export function compose<C>(middleware: ReadonlyArray<Middleware<C>>): (ctx: C, next?: NextFn) => Promise<void> {
+export function compose<C>(
+  middleware: ReadonlyArray<Middleware<C>>
+): (ctx: C, next?: NextFn) => Promise<void> {
   return function composed(ctx: C, next?: NextFn): Promise<void> {
     // `index` is the last middleware that was invoked; guards double `next()`.
     let lastIndex = -1;

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -116,7 +116,10 @@ const fromOf: { [K in UpdateType]: (u: Variant<K>) => User | undefined } = {
  * is the single controlled bridge from the per-row narrowed type to a uniform
  * `(u: Update) => R` (TS can't track the narrowing through the loop variable).
  */
-function resolve<K extends UpdateType, R>(update: Update, table: { [P in K]: (u: Variant<P>) => R }): R | undefined {
+function resolve<K extends UpdateType, R>(
+  update: Update,
+  table: { [P in K]: (u: Variant<P>) => R }
+): R | undefined {
   for (const k of UPDATE_TYPES) {
     if (k in update) {
       return (table as Record<UpdateType, (u: Update) => R>)[k](update);
@@ -193,7 +196,10 @@ export class Context {
    * Send a message to the inferred chat. Throws if no chat id can be derived
    * from the update (e.g. an inline query carries no chat).
    */
-  reply(text: string, other?: Omit<SendMessageParams, "chat_id" | "text">): Promise<SendMessageResult> {
+  reply(
+    text: string,
+    other?: Omit<SendMessageParams, "chat_id" | "text">
+  ): Promise<SendMessageResult> {
     const chatId = this.chatId;
     if (chatId === undefined) {
       throw new Error("ctx.reply: cannot infer a chat id from this update");
@@ -206,7 +212,7 @@ export class Context {
    * is not a callback query.
    */
   answerCallbackQuery(
-    other?: Omit<AnswerCallbackQueryParams, "callback_query_id">,
+    other?: Omit<AnswerCallbackQueryParams, "callback_query_id">
   ): Promise<AnswerCallbackQueryResult> {
     const cq = this.callbackQuery;
     if (!cq) {
@@ -228,7 +234,9 @@ export class Context {
   getSession<T = Record<string, unknown>>(): SessionHandle<T> {
     const handle = this.state[SESSION_STATE_KEY];
     if (handle === undefined) {
-      throw new Error("ctx.getSession: no session for this update (session middleware not installed, or no key)");
+      throw new Error(
+        "ctx.getSession: no session for this update (session middleware not installed, or no key)"
+      );
     }
     return handle as SessionHandle<T>;
   }

--- a/src/core/debug.ts
+++ b/src/core/debug.ts
@@ -54,7 +54,9 @@ export function debug(area: string): Debugger {
 
 /** JSON-stringify a value for a trace, never throwing (falls back to `String`). */
 function stringify(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") {
+    return value;
+  }
   try {
     return JSON.stringify(value) ?? String(value);
   } catch {
@@ -67,11 +69,17 @@ function stringify(value: unknown): string {
  * `%j`/`%o`/`%O` (JSON), `%%` (literal `%`). Unconsumed args are appended.
  */
 function format(message: string, args: unknown[]): string {
-  if (args.length === 0) return message;
+  if (args.length === 0) {
+    return message;
+  }
   let i = 0;
   let out = message.replace(/%([sdijoO%])/g, (match, spec: string) => {
-    if (spec === "%") return "%";
-    if (i >= args.length) return match;
+    if (spec === "%") {
+      return "%";
+    }
+    if (i >= args.length) {
+      return match;
+    }
     const arg = args[i++];
     switch (spec) {
       case "s":
@@ -83,6 +91,8 @@ function format(message: string, args: unknown[]): string {
         return stringify(arg);
     }
   });
-  for (; i < args.length; i++) out += ` ${stringify(args[i])}`;
+  for (; i < args.length; i++) {
+    out += ` ${stringify(args[i])}`;
+  }
   return out;
 }

--- a/src/core/delay.ts
+++ b/src/core/delay.ts
@@ -10,8 +10,12 @@
  */
 export function delay(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    if (signal?.aborted) return reject(signal.reason);
-    if (ms <= 0) return resolve();
+    if (signal?.aborted) {
+      return reject(signal.reason);
+    }
+    if (ms <= 0) {
+      return resolve();
+    }
     const timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);
       resolve();

--- a/src/core/encode.ts
+++ b/src/core/encode.ts
@@ -40,7 +40,7 @@ export interface EncodedRequest {
 export async function encodeForm(
   fields: Record<string, WireValue>,
   // Test seam: force the buffered-Blob fallback a streaming runtime never takes.
-  streaming: boolean = supportsRequestStreams(),
+  streaming: boolean = supportsRequestStreams()
 ): Promise<EncodedRequest> {
   const strings: Array<[string, string]> = [];
   const files: Array<readonly [string, InputFile]> = [];

--- a/src/core/encode.ts
+++ b/src/core/encode.ts
@@ -46,8 +46,9 @@ export async function encodeForm(
   const files: Array<readonly [string, InputFile]> = [];
 
   for (const [key, value] of Object.entries(fields)) {
-    if (isInputFile(value)) files.push([key, value]);
-    else if (isFormPart(value)) {
+    if (isInputFile(value)) {
+      files.push([key, value]);
+    } else if (isFormPart(value)) {
       strings.push([key, value.json]);
       files.push(...value.files);
     } else {
@@ -69,7 +70,9 @@ export async function encodeForm(
 
   const { boundary, pieces, replayable } = multipartBody(strings, files);
   const headers = { "content-type": `multipart/form-data; boundary=${boundary}` };
-  if (streaming) return { headers, body: () => streamBody(pieces), replayable };
+  if (streaming) {
+    return { headers, body: () => streamBody(pieces), replayable };
+  }
 
   // No request-body streaming on this runtime: buffer the same bytes once into
   // a Blob. A Blob re-reads for free, so the body is replayable even when a

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -89,7 +89,9 @@ export class TelegramApiError extends TelegramBotError {
  * `TimeoutError` rather than falling through to `NetworkError`.
  */
 export function isAbortError(err: unknown): boolean {
-  if (typeof err !== "object" || err === null || !("name" in err)) return false;
+  if (typeof err !== "object" || err === null || !("name" in err)) {
+    return false;
+  }
   const name = (err as { name?: unknown }).name;
   return name === "AbortError" || name === "TimeoutError";
 }
@@ -103,9 +105,12 @@ export function isAbortError(err: unknown): boolean {
  * default delay.
  */
 export function isTransientError(err: unknown): boolean {
-  if (err instanceof NetworkError || err instanceof TimeoutError) return true;
-  if (err instanceof TelegramApiError)
+  if (err instanceof NetworkError || err instanceof TimeoutError) {
+    return true;
+  }
+  if (err instanceof TelegramApiError) {
     return err.errorCode === HTTP_STATUS_TOO_MANY_REQUESTS || err.errorCode >= 500;
+  }
   return false;
 }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -104,7 +104,8 @@ export function isAbortError(err: unknown): boolean {
  */
 export function isTransientError(err: unknown): boolean {
   if (err instanceof NetworkError || err instanceof TimeoutError) return true;
-  if (err instanceof TelegramApiError) return err.errorCode === HTTP_STATUS_TOO_MANY_REQUESTS || err.errorCode >= 500;
+  if (err instanceof TelegramApiError)
+    return err.errorCode === HTTP_STATUS_TOO_MANY_REQUESTS || err.errorCode >= 500;
   return false;
 }
 

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -28,7 +28,9 @@ export type InputFileData = Blob | Uint8Array | ReadableStream<Uint8Array> | Inp
  * A replayable stream source: return a fresh, unread stream on every call.
  * The upload stays retryable - each send attempt opens a new stream.
  */
-export type InputFileStreamFactory = () => ReadableStream<Uint8Array> | Promise<ReadableStream<Uint8Array>>;
+export type InputFileStreamFactory = () =>
+  | ReadableStream<Uint8Array>
+  | Promise<ReadableStream<Uint8Array>>;
 
 export interface InputFileMeta {
   filename?: string;
@@ -43,7 +45,7 @@ export const ATTACH_PREFIX = "attach://";
 export class InputFile {
   constructor(
     readonly data: InputFileData,
-    readonly meta?: InputFileMeta,
+    readonly meta?: InputFileMeta
   ) {}
 
   /**
@@ -76,10 +78,17 @@ export interface FormPart {
 }
 
 export function isFormPart(value: unknown): value is FormPart {
-  return typeof value === "object" && value !== null && (value as { __formPart?: unknown }).__formPart === true;
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __formPart?: unknown }).__formPart === true
+  );
 }
 
 /** Build a `FormPart` from a serialized JSON string and the files its refs point at. */
-export function formPart(json: string, files: ReadonlyArray<readonly [string, InputFile]>): FormPart {
+export function formPart(
+  json: string,
+  files: ReadonlyArray<readonly [string, InputFile]>
+): FormPart {
   return { __formPart: true, json, files };
 }

--- a/src/core/keyboard.ts
+++ b/src/core/keyboard.ts
@@ -75,7 +75,9 @@ export class InlineKeyboardBuilder {
   /** The keyboard as a plain `InlineKeyboardMarkup`, dropping trailing empty rows. */
   build(): InlineKeyboardMarkup {
     const rows = this.rows.slice();
-    while (rows.at(-1)?.length === 0) rows.pop();
+    while (rows.at(-1)?.length === 0) {
+      rows.pop();
+    }
     return { inline_keyboard: rows };
   }
 }
@@ -131,7 +133,9 @@ export class ReplyKeyboardBuilder {
   /** The keyboard as a plain `ReplyKeyboardMarkup`, dropping trailing empty rows. */
   build(options?: ReplyKeyboardBuildOptions): ReplyKeyboardMarkup {
     const keyboard = this.rows.slice();
-    while (keyboard.at(-1)?.length === 0) keyboard.pop();
+    while (keyboard.at(-1)?.length === 0) {
+      keyboard.pop();
+    }
     return { keyboard, ...options };
   }
 }

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -74,7 +74,7 @@ function planRetry({
   log(
     "getUpdates %s; retry in %dms",
     pollConflict ? `conflict ${next}/${maxConflictRetries}` : "failed",
-    Math.round(wait),
+    Math.round(wait)
   );
   return { wait, conflicts: next };
 }
@@ -95,7 +95,11 @@ async function recover(ctx: RetryContext): Promise<{ conflicts: number } | "stop
 }
 
 /** Async-generator update source (ADR-004): long-polls `getUpdates` and yields each update until the signal aborts. */
-export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?: AbortSignal): AsyncGenerator<Update> {
+export async function* longPoll(
+  api: Api,
+  options: LongPollOptions = {},
+  signal?: AbortSignal
+): AsyncGenerator<Update> {
   let offset = options.offset;
   const timeout = options.timeout ?? DEFAULT_POLL_TIMEOUT;
   const limit = options.limit;
@@ -118,7 +122,7 @@ export async function* longPoll(api: Api, options: LongPollOptions = {}, signal?
           timeout,
           allowed_updates: allowed,
         },
-        signal,
+        signal
       );
     } catch (err) {
       // A 409 (another instance polling the same token) is transient for polling

--- a/src/core/longpoll.ts
+++ b/src/core/longpoll.ts
@@ -63,10 +63,14 @@ function planRetry({
   onError,
 }: RetryContext): RetryPlan {
   const pollConflict = isPollConflict(err);
-  if (!retry || !(isTransientError(err) || pollConflict)) throw err;
+  if (!retry || !(isTransientError(err) || pollConflict)) {
+    throw err;
+  }
   // A conflict advances its own bounded counter; any other transient breaks the streak.
   const next = pollConflict ? conflicts + 1 : 0;
-  if (pollConflict && next > maxConflictRetries) throw err;
+  if (pollConflict && next > maxConflictRetries) {
+    throw err;
+  }
   onError?.(err);
   // A conflict waits its own longer delay; otherwise honor `retry_after`
   // (e.g. a 429 flood-wait) when present, else the default delay.
@@ -84,7 +88,9 @@ function planRetry({
  *  wait). `planRetry` may throw here to stop the loop on a non-retryable error. */
 async function recover(ctx: RetryContext): Promise<{ conflicts: number } | "stop"> {
   const { signal } = ctx;
-  if (signal?.aborted) return "stop"; // cancelled - swallow the abort error
+  if (signal?.aborted) {
+    return "stop"; // cancelled - swallow the abort error
+  }
   const plan = planRetry(ctx);
   try {
     await delay(plan.wait, signal);
@@ -138,14 +144,18 @@ export async function* longPoll(
         onError,
         signal,
       });
-      if (outcome === "stop") return;
+      if (outcome === "stop") {
+        return;
+      }
       conflicts = outcome.conflicts;
       // retry WITHOUT advancing offset
       continue;
     }
 
     conflicts = 0; // a successful poll clears the conflict streak
-    if (updates.length > 0) log("%d update(s)", updates.length);
+    if (updates.length > 0) {
+      log("%d update(s)", updates.length);
+    }
     for (const update of updates) {
       yield update;
       offset = update.update_id + 1;

--- a/src/core/memory-session-storage.ts
+++ b/src/core/memory-session-storage.ts
@@ -22,7 +22,9 @@ export class MemorySessionStorage implements SessionStore {
 
   read(key: string): string | undefined {
     const row = this.map.get(key);
-    if (row === undefined) return undefined;
+    if (row === undefined) {
+      return undefined;
+    }
     if (row.expiresAt !== undefined && row.expiresAt <= Date.now()) {
       this.map.delete(key);
       return undefined;
@@ -40,7 +42,9 @@ export class MemorySessionStorage implements SessionStore {
     // read again - so sweep here, where the cost is bounded by how often a TTL
     // bot writes at all.
     for (const [k, row] of this.map) {
-      if (row.expiresAt !== undefined && row.expiresAt <= nowMs) this.map.delete(k);
+      if (row.expiresAt !== undefined && row.expiresAt <= nowMs) {
+        this.map.delete(k);
+      }
     }
     this.map.set(key, { value, expiresAt: nowMs + options.ttlSeconds * 1000 });
   }
@@ -48,7 +52,9 @@ export class MemorySessionStorage implements SessionStore {
   /** Refresh an existing key's expiry without rewriting its value. */
   touch(key: string, ttlSeconds: number): void {
     const row = this.map.get(key);
-    if (row === undefined) return;
+    if (row === undefined) {
+      return;
+    }
     row.expiresAt = Date.now() + ttlSeconds * 1000;
   }
 

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -134,7 +134,7 @@ async function* pieceChunks(
       yield piece;
       continue;
     }
-    // Await a factory (as before); a Blob or plain stream resolves synchronously.
+    // Await a factory; a Blob or plain stream resolves synchronously.
     if (typeof piece === "function") {
       yield* drainStream(await piece());
       continue;

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -98,7 +98,10 @@ export function multipartBody(
 }
 
 /** Drain a stream to completion, cancelling the source if the consumer tears
- *  us down mid-piece (via a `return()` propagated through the `yield*`). */
+ *  us down mid-piece (via a `return()` propagated through the `yield*`). The
+ *  `yield*` adds one microtask when a piece's stream starts; only a stream that
+ *  errors on an exactly-timed microtask sees it - real Blob/file/caller streams
+ *  do not. */
 async function* drainStream(
   stream: ReadableStream<Uint8Array>
 ): AsyncGenerator<Uint8Array, void, undefined> {

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -134,8 +134,7 @@ async function* pieceChunks(
       yield piece;
       continue;
     }
-    // Always await a factory result (an observable microtask hop the original
-    // kept); resolve a Blob or plain stream synchronously.
+    // Await a factory (as before); a Blob or plain stream resolves synchronously.
     if (typeof piece === "function") {
       yield* drainStream(await piece());
       continue;

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -131,10 +131,8 @@ async function* pieceChunks(
       yield piece;
       continue;
     }
-    // A factory result is always awaited (as before), even when it returns a
-    // stream synchronously - that await is an observable microtask hop. A Blob
-    // or plain stream resolves synchronously so the reader is acquired in the
-    // same tick, so a stream erroring on a queued microtask keeps its chunks.
+    // Always await a factory result (an observable microtask hop the original
+    // kept); resolve a Blob or plain stream synchronously.
     if (typeof piece === "function") {
       yield* drainStream(await piece());
       continue;

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -93,6 +93,38 @@ export function multipartBody(
   return { boundary, pieces, replayable };
 }
 
+/** Resolve a non-inline piece to a readable stream for this build (a factory
+ *  opens a fresh stream; a Blob streams from its store; a stream is itself). */
+async function resolvePieceStream(
+  piece: Exclude<BodyPiece, Uint8Array>
+): Promise<ReadableStream<Uint8Array>> {
+  if (typeof piece === "function") return piece();
+  if (piece instanceof Blob) return piece.stream();
+  return piece;
+}
+
+/** Drain a stream to completion, cancelling the source if the consumer tears
+ *  us down mid-piece (via a `return()` propagated through the `yield*`). */
+async function* drainStream(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<Uint8Array, void, undefined> {
+  const reader = stream.getReader();
+  let finished = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        finished = true;
+        break;
+      }
+      yield value;
+    }
+  } finally {
+    if (!finished) await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
 /** Walk the pieces in order, yielding raw chunks (a Blob streams from its
  *  store; a factory opens a fresh stream for this build). */
 async function* pieceChunks(
@@ -103,24 +135,7 @@ async function* pieceChunks(
       yield piece;
       continue;
     }
-    const stream =
-      typeof piece === "function" ? await piece() : piece instanceof Blob ? piece.stream() : piece;
-    const reader = stream.getReader();
-    let finished = false;
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          finished = true;
-          break;
-        }
-        yield value;
-      }
-    } finally {
-      // Torn down mid-piece (the consumer cancelled): stop the source too.
-      if (!finished) await reader.cancel().catch(() => {});
-      reader.releaseLock();
-    }
+    yield* drainStream(await resolvePieceStream(piece));
   }
 }
 

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -36,7 +36,9 @@ function randomBoundary(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
   let hex = "";
-  for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, "0");
+  }
   return `----NodeTelegramBotApi${hex}`;
 }
 
@@ -84,7 +86,9 @@ export function multipartBody(
           `filename="${filename}"\r\nContent-Type: ${contentType}\r\n\r\n`
       )
     );
-    if (file.data instanceof ReadableStream) replayable = false;
+    if (file.data instanceof ReadableStream) {
+      replayable = false;
+    }
     pieces.push(file.data);
     pieces.push(CRLF);
   }
@@ -98,8 +102,12 @@ export function multipartBody(
 async function resolvePieceStream(
   piece: Exclude<BodyPiece, Uint8Array>
 ): Promise<ReadableStream<Uint8Array>> {
-  if (typeof piece === "function") return piece();
-  if (piece instanceof Blob) return piece.stream();
+  if (typeof piece === "function") {
+    return piece();
+  }
+  if (piece instanceof Blob) {
+    return piece.stream();
+  }
   return piece;
 }
 
@@ -120,7 +128,9 @@ async function* drainStream(
       yield value;
     }
   } finally {
-    if (!finished) await reader.cancel().catch(() => {});
+    if (!finished) {
+      await reader.cancel().catch(() => {});
+    }
     reader.releaseLock();
   }
 }
@@ -145,8 +155,11 @@ export function streamBody(pieces: ReadonlyArray<BodyPiece>): ReadableStream<Uin
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
       const { done, value } = await chunks.next();
-      if (done) controller.close();
-      else controller.enqueue(value);
+      if (done) {
+        controller.close();
+      } else {
+        controller.enqueue(value);
+      }
     },
     async cancel() {
       await chunks.return();
@@ -163,7 +176,9 @@ let requestStreamsSupported: boolean | undefined;
 
 /** The proxy env vars Bun's `fetch` honors automatically. */
 function proxyConfigured(env: Record<string, string | undefined> | undefined): boolean {
-  if (!env) return false;
+  if (!env) {
+    return false;
+  }
   return Boolean(
     env.HTTPS_PROXY ??
       env.https_proxy ??
@@ -189,7 +204,9 @@ function bunStreamBodyBroken(bun: {
   env?: Record<string, string | undefined>;
 }): boolean {
   const [major = 0, minor = 0] = (bun.version ?? "0.0.0").split(".").map(Number);
-  if (major > 1 || (major === 1 && minor >= 4)) return false;
+  if (major > 1 || (major === 1 && minor >= 4)) {
+    return false;
+  }
   return proxyConfigured(bun.env);
 }
 

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -97,24 +97,6 @@ export function multipartBody(
   return { boundary, pieces, replayable };
 }
 
-/** Resolve a non-inline piece to a readable stream for this build (a factory
- *  opens a fresh stream; a Blob streams from its store; a stream is itself). */
-// Not async on purpose: only a factory piece yields a promise (awaited by the
-// caller). A Blob or a plain stream resolves synchronously, so the reader is
-// acquired in the same tick - inserting an extra microtask here would let a
-// stream that errors on a queued microtask drop an already-enqueued chunk.
-function resolvePieceStream(
-  piece: Exclude<BodyPiece, Uint8Array>
-): ReadableStream<Uint8Array> | Promise<ReadableStream<Uint8Array>> {
-  if (typeof piece === "function") {
-    return piece();
-  }
-  if (piece instanceof Blob) {
-    return piece.stream();
-  }
-  return piece;
-}
-
 /** Drain a stream to completion, cancelling the source if the consumer tears
  *  us down mid-piece (via a `return()` propagated through the `yield*`). */
 async function* drainStream(
@@ -149,8 +131,15 @@ async function* pieceChunks(
       yield piece;
       continue;
     }
-    const resolved = resolvePieceStream(piece);
-    yield* drainStream(resolved instanceof ReadableStream ? resolved : await resolved);
+    // A factory result is always awaited (as before), even when it returns a
+    // stream synchronously - that await is an observable microtask hop. A Blob
+    // or plain stream resolves synchronously so the reader is acquired in the
+    // same tick, so a stream erroring on a queued microtask keeps its chunks.
+    if (typeof piece === "function") {
+      yield* drainStream(await piece());
+      continue;
+    }
+    yield* drainStream(piece instanceof Blob ? piece.stream() : piece);
   }
 }
 

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -58,7 +58,7 @@ function safeContentType(value: string): string {
  */
 export function multipartBody(
   strings: ReadonlyArray<readonly [string, string]>,
-  files: ReadonlyArray<readonly [string, InputFile]>,
+  files: ReadonlyArray<readonly [string, InputFile]>
 ): MultipartBody {
   const boundary = randomBoundary();
   const enc = new TextEncoder();
@@ -68,19 +68,21 @@ export function multipartBody(
   for (const [name, value] of strings) {
     pieces.push(
       enc.encode(
-        `--${boundary}\r\nContent-Disposition: form-data; name="${escapeHeaderValue(name)}"\r\n\r\n${value}\r\n`,
-      ),
+        `--${boundary}\r\nContent-Disposition: form-data; name="${escapeHeaderValue(name)}"\r\n\r\n${value}\r\n`
+      )
     );
   }
   for (const [name, file] of files) {
     const filename = escapeHeaderValue(file.meta?.filename ?? name);
     const blobType = file.data instanceof Blob ? file.data.type : "";
-    const contentType = safeContentType(file.meta?.contentType ?? (blobType || "application/octet-stream"));
+    const contentType = safeContentType(
+      file.meta?.contentType ?? (blobType || "application/octet-stream")
+    );
     pieces.push(
       enc.encode(
         `--${boundary}\r\nContent-Disposition: form-data; name="${escapeHeaderValue(name)}"; ` +
-          `filename="${filename}"\r\nContent-Type: ${contentType}\r\n\r\n`,
-      ),
+          `filename="${filename}"\r\nContent-Type: ${contentType}\r\n\r\n`
+      )
     );
     if (file.data instanceof ReadableStream) replayable = false;
     pieces.push(file.data);
@@ -93,13 +95,16 @@ export function multipartBody(
 
 /** Walk the pieces in order, yielding raw chunks (a Blob streams from its
  *  store; a factory opens a fresh stream for this build). */
-async function* pieceChunks(pieces: ReadonlyArray<BodyPiece>): AsyncGenerator<Uint8Array, void, undefined> {
+async function* pieceChunks(
+  pieces: ReadonlyArray<BodyPiece>
+): AsyncGenerator<Uint8Array, void, undefined> {
   for (const piece of pieces) {
     if (piece instanceof Uint8Array) {
       yield piece;
       continue;
     }
-    const stream = typeof piece === "function" ? await piece() : piece instanceof Blob ? piece.stream() : piece;
+    const stream =
+      typeof piece === "function" ? await piece() : piece instanceof Blob ? piece.stream() : piece;
     const reader = stream.getReader();
     let finished = false;
     try {
@@ -145,7 +150,12 @@ let requestStreamsSupported: boolean | undefined;
 function proxyConfigured(env: Record<string, string | undefined> | undefined): boolean {
   if (!env) return false;
   return Boolean(
-    env.HTTPS_PROXY ?? env.https_proxy ?? env.HTTP_PROXY ?? env.http_proxy ?? env.ALL_PROXY ?? env.all_proxy,
+    env.HTTPS_PROXY ??
+      env.https_proxy ??
+      env.HTTP_PROXY ??
+      env.http_proxy ??
+      env.ALL_PROXY ??
+      env.all_proxy
   );
 }
 
@@ -159,7 +169,10 @@ function proxyConfigured(env: Record<string, string | undefined> | undefined): b
  * 1.3.x fix would be buffered too - conservative, never wrong. Read via
  * `Bun.env`/`Bun.version` (not `process`) so core stays free of Node globals.
  */
-function bunStreamBodyBroken(bun: { version?: string; env?: Record<string, string | undefined> }): boolean {
+function bunStreamBodyBroken(bun: {
+  version?: string;
+  env?: Record<string, string | undefined>;
+}): boolean {
   const [major = 0, minor = 0] = (bun.version ?? "0.0.0").split(".").map(Number);
   if (major > 1 || (major === 1 && minor >= 4)) return false;
   return proxyConfigured(bun.env);
@@ -175,7 +188,9 @@ function bunStreamBodyBroken(bun: { version?: string; env?: Record<string, strin
  */
 export function supportsRequestStreams(): boolean {
   if (requestStreamsSupported === undefined) {
-    const bun = (globalThis as { Bun?: { version?: string; env?: Record<string, string | undefined> } }).Bun;
+    const bun = (
+      globalThis as { Bun?: { version?: string; env?: Record<string, string | undefined> } }
+    ).Bun;
     if (bun !== undefined && bunStreamBodyBroken(bun)) {
       requestStreamsSupported = false;
       return requestStreamsSupported;

--- a/src/core/multipart.ts
+++ b/src/core/multipart.ts
@@ -99,9 +99,13 @@ export function multipartBody(
 
 /** Resolve a non-inline piece to a readable stream for this build (a factory
  *  opens a fresh stream; a Blob streams from its store; a stream is itself). */
-async function resolvePieceStream(
+// Not async on purpose: only a factory piece yields a promise (awaited by the
+// caller). A Blob or a plain stream resolves synchronously, so the reader is
+// acquired in the same tick - inserting an extra microtask here would let a
+// stream that errors on a queued microtask drop an already-enqueued chunk.
+function resolvePieceStream(
   piece: Exclude<BodyPiece, Uint8Array>
-): Promise<ReadableStream<Uint8Array>> {
+): ReadableStream<Uint8Array> | Promise<ReadableStream<Uint8Array>> {
   if (typeof piece === "function") {
     return piece();
   }
@@ -145,7 +149,8 @@ async function* pieceChunks(
       yield piece;
       continue;
     }
-    yield* drainStream(await resolvePieceStream(piece));
+    const resolved = resolvePieceStream(piece);
+    yield* drainStream(resolved instanceof ReadableStream ? resolved : await resolved);
   }
 }
 

--- a/src/core/ratelimiter.ts
+++ b/src/core/ratelimiter.ts
@@ -114,24 +114,35 @@ export class RateLimiter {
   async acquire(chatId: string | number | undefined, signal?: AbortSignal): Promise<void> {
     if (this.global) await this.global.take(signal);
     if (this.perChatRate !== undefined && chatId !== undefined) {
-      const key = String(chatId);
-      let bucket = this.chats.get(key);
-      if (bucket) {
-        // LRU touch: Map preserves insertion order, so delete + re-set moves this
-        // chat to the most-recently-used end. Without this a hot chat could be
-        // evicted while cold chats lingered.
-        this.chats.delete(key);
-        this.chats.set(key, bucket);
-      } else {
-        if (this.chats.size >= this.maxChatBuckets) {
-          // Evict the oldest (least-recently-used) bucket to bound memory.
-          const oldest = this.chats.keys().next().value;
-          if (oldest !== undefined) this.chats.delete(oldest);
-        }
-        bucket = new TokenBucket(this.perChatRate, this.now ? { now: this.now } : {});
-        this.chats.set(key, bucket);
-      }
-      await bucket.take(signal);
+      await this.chatBucket(String(chatId)).take(signal);
     }
+  }
+
+  /**
+   * The per-chat bucket for `key`, created on first use. Existing buckets are
+   * touched to most-recently-used; when the cache is full a new bucket evicts
+   * the least-recently-used one. `perChatRate` is guaranteed set by the caller.
+   */
+  private chatBucket(key: string): TokenBucket {
+    const existing = this.chats.get(key);
+    if (existing) {
+      // LRU touch: Map preserves insertion order, so delete + re-set moves this
+      // chat to the most-recently-used end. Without this a hot chat could be
+      // evicted while cold chats lingered.
+      this.chats.delete(key);
+      this.chats.set(key, existing);
+      return existing;
+    }
+    this.evictIfFull();
+    const bucket = new TokenBucket(this.perChatRate as number, this.now ? { now: this.now } : {});
+    this.chats.set(key, bucket);
+    return bucket;
+  }
+
+  /** Drop the least-recently-used chat bucket when the cache is at capacity. */
+  private evictIfFull(): void {
+    if (this.chats.size < this.maxChatBuckets) return;
+    const oldest = this.chats.keys().next().value;
+    if (oldest !== undefined) this.chats.delete(oldest);
   }
 }

--- a/src/core/ratelimiter.ts
+++ b/src/core/ratelimiter.ts
@@ -145,7 +145,9 @@ export class RateLimiter {
 
   /** Drop the least-recently-used chat bucket when the cache is at capacity. */
   private evictIfFull(): void {
-    if (this.chats.size < this.maxChatBuckets) {
+    // Negated `>=` (not `<`) so a NaN budget never evicts, matching the original
+    // `size >= max` guard: `NaN >= x` is false, whereas `NaN < x` is also false.
+    if (!(this.chats.size >= this.maxChatBuckets)) {
       return;
     }
     const oldest = this.chats.keys().next().value;

--- a/src/core/ratelimiter.ts
+++ b/src/core/ratelimiter.ts
@@ -145,8 +145,7 @@ export class RateLimiter {
 
   /** Drop the least-recently-used chat bucket when the cache is at capacity. */
   private evictIfFull(): void {
-    // Negated `>=` (not `<`) so a NaN budget never evicts, matching the original
-    // `size >= max` guard: `NaN >= x` is false, whereas `NaN < x` is also false.
+    // Negated `>=` (not `<`) so a NaN budget never evicts (`NaN >= x` is false).
     if (!(this.chats.size >= this.maxChatBuckets)) {
       return;
     }

--- a/src/core/ratelimiter.ts
+++ b/src/core/ratelimiter.ts
@@ -42,7 +42,9 @@ export class TokenBucket {
 
   /** Milliseconds until at least one token is available. */
   private waitMs(): number {
-    if (this.tokens >= 1) return 0;
+    if (this.tokens >= 1) {
+      return 0;
+    }
     const missing = 1 - this.tokens;
     return Math.ceil((missing / this.ratePerSec) * 1000);
   }
@@ -112,7 +114,9 @@ export class RateLimiter {
   }
 
   async acquire(chatId: string | number | undefined, signal?: AbortSignal): Promise<void> {
-    if (this.global) await this.global.take(signal);
+    if (this.global) {
+      await this.global.take(signal);
+    }
     if (this.perChatRate !== undefined && chatId !== undefined) {
       await this.chatBucket(String(chatId)).take(signal);
     }
@@ -141,8 +145,12 @@ export class RateLimiter {
 
   /** Drop the least-recently-used chat bucket when the cache is at capacity. */
   private evictIfFull(): void {
-    if (this.chats.size < this.maxChatBuckets) return;
+    if (this.chats.size < this.maxChatBuckets) {
+      return;
+    }
     const oldest = this.chats.keys().next().value;
-    if (oldest !== undefined) this.chats.delete(oldest);
+    if (oldest !== undefined) {
+      this.chats.delete(oldest);
+    }
   }
 }

--- a/src/core/reply-tracking.ts
+++ b/src/core/reply-tracking.ts
@@ -150,7 +150,7 @@ function touch(ctx: Context): Touched {
   const state = handle.ext<ReplyState>(
     REPLY_NAMESPACE,
     () => ({ replies: {}, presses: {} }),
-    (slot) => isTable(slot.replies) && isTable(slot.presses),
+    (slot) => isTable(slot.replies) && isTable(slot.presses)
   );
   // Pruned here rather than on a timer: this is the only moment the layer is
   // guaranteed to be looking at the session, and the flush that follows persists
@@ -169,7 +169,7 @@ function record(
   marker: ReplyMarker,
   options: ExpectOptions | undefined,
   config: ReplyTrackingOptions | undefined,
-  now: number,
+  now: number
 ): void {
   const ttlSeconds = options?.ttlSeconds ?? config?.defaultTtlSeconds;
   const entry: Entry = { marker };
@@ -185,7 +185,10 @@ function record(
 
 /** Whether an LRU size budget is configured - the only thing that reads `lastUsedAt`. */
 function hasBudget(config: ReplyTrackingOptions | undefined): boolean {
-  return config !== undefined && (config.maxEntriesPerChat !== undefined || config.maxBytesPerChat !== undefined);
+  return (
+    config !== undefined &&
+    (config.maxEntriesPerChat !== undefined || config.maxBytesPerChat !== undefined)
+  );
 }
 
 /** Mark a kept marker as just used: slide its TTL if it has one, and bump recency for the LRU. */
@@ -232,8 +235,14 @@ function evict(state: ReplyState, config: ReplyTrackingOptions | undefined): voi
 
   // `i < victims.length` also guards a negative/NaN `maxEntriesPerChat` from underflowing
   // past the last victim (which would deref `undefined`); it just evicts down to empty.
-  while (maxEntriesPerChat !== undefined && i < victims.length && victims.length - i > maxEntriesPerChat) dropNext();
-  while (maxBytesPerChat !== undefined && i < victims.length && byteLength(state) > maxBytesPerChat) dropNext();
+  while (
+    maxEntriesPerChat !== undefined &&
+    i < victims.length &&
+    victims.length - i > maxEntriesPerChat
+  )
+    dropNext();
+  while (maxBytesPerChat !== undefined && i < victims.length && byteLength(state) > maxBytesPerChat)
+    dropNext();
 }
 
 /**
@@ -253,7 +262,12 @@ function evict(state: ReplyState, config: ReplyTrackingOptions | undefined): voi
  * to the group, and any member's reply matches it. Put the asker's id in the
  * marker and check it, or key sessions per user, when that matters.
  */
-export function expectReply(ctx: Context, messageId: number, marker: ReplyMarker = {}, options?: ExpectOptions): void {
+export function expectReply(
+  ctx: Context,
+  messageId: number,
+  marker: ReplyMarker = {},
+  options?: ExpectOptions
+): void {
   const { state, config, now } = touch(ctx);
   record(state.replies, messageId, marker, options, config, now);
   evict(state, config);
@@ -304,7 +318,7 @@ export function expectCallback(
   ctx: Context,
   messageId: number,
   marker: ReplyMarker = {},
-  options?: ExpectOptions,
+  options?: ExpectOptions
 ): void {
   const { state, config, now } = touch(ctx);
   record(state.presses, messageId, marker, options, config, now);
@@ -329,7 +343,7 @@ export function expectCallback(
  */
 export function matchCallback<M extends ReplyMarker = ReplyMarker>(
   ctx: Context,
-  options?: { once?: boolean },
+  options?: { once?: boolean }
 ): M | undefined {
   // `message` is absent when the keyboard is on an inline-mode message or one
   // too old for Telegram to send along (only `inline_message_id` arrives), so
@@ -366,7 +380,7 @@ export function forgetCallback(ctx: Context, messageId: number): void {
  * const tag = taggedReplies<"NAME" | "EMAIL">(ctx).match(); // "NAME" | "EMAIL" | undefined
  */
 export function taggedReplies<Tag extends string>(
-  ctx: Context,
+  ctx: Context
 ): {
   expect(messageId: number, tag: Tag, options?: ExpectOptions): void;
   match(): Tag | undefined;

--- a/src/core/reply-tracking.ts
+++ b/src/core/reply-tracking.ts
@@ -157,7 +157,9 @@ function touch(ctx: Context): Touched {
   // the smaller table.
   for (const table of [state.replies, state.presses]) {
     for (const [id, entry] of Object.entries(table)) {
-      if (entry?.expiresAt !== undefined && entry.expiresAt <= now) delete table[Number(id)];
+      if (entry?.expiresAt !== undefined && entry.expiresAt <= now) {
+        delete table[Number(id)];
+      }
     }
   }
   return { state, config, now };
@@ -175,11 +177,15 @@ function record(
   const entry: Entry = { marker };
   if (ttlSeconds !== undefined) {
     entry.expiresAt = now + ttlSeconds * 1000;
-    if (config?.slidingTtl === true) entry.ttlMs = ttlSeconds * 1000;
+    if (config?.slidingTtl === true) {
+      entry.ttlMs = ttlSeconds * 1000;
+    }
   }
   // Recency is only worth its bytes when a size budget (the only reader of
   // `lastUsedAt`) is set; sliding TTL rides on `ttlMs` / `expiresAt` instead.
-  if (hasBudget(config)) entry.lastUsedAt = now;
+  if (hasBudget(config)) {
+    entry.lastUsedAt = now;
+  }
   table[messageId] = entry;
 }
 
@@ -193,9 +199,15 @@ function hasBudget(config: ReplyTrackingOptions | undefined): boolean {
 
 /** Mark a kept marker as just used: slide its TTL if it has one, and bump recency for the LRU. */
 function used(entry: Entry, config: ReplyTrackingOptions | undefined, now: number): void {
-  if (config === undefined) return;
-  if (entry.ttlMs !== undefined) entry.expiresAt = now + entry.ttlMs;
-  if (hasBudget(config)) entry.lastUsedAt = now;
+  if (config === undefined) {
+    return;
+  }
+  if (entry.ttlMs !== undefined) {
+    entry.expiresAt = now + entry.ttlMs;
+  }
+  if (hasBudget(config)) {
+    entry.lastUsedAt = now;
+  }
 }
 
 function byteLength(state: ReplyState): number {
@@ -213,7 +225,9 @@ type Ref = { table: Record<number, Entry>; id: number; entry: Entry };
 function lruOrder(state: ReplyState): Ref[] {
   const refs: Ref[] = [];
   for (const table of [state.replies, state.presses]) {
-    for (const [id, entry] of Object.entries(table)) refs.push({ table, id: Number(id), entry });
+    for (const [id, entry] of Object.entries(table)) {
+      refs.push({ table, id: Number(id), entry });
+    }
   }
   return refs.sort((a, b) => (a.entry.lastUsedAt ?? 0) - (b.entry.lastUsedAt ?? 0) || a.id - b.id);
 }
@@ -224,13 +238,17 @@ function lruOrder(state: ReplyState): Ref[] {
  */
 function evict(state: ReplyState, config: ReplyTrackingOptions | undefined): void {
   const { maxEntriesPerChat, maxBytesPerChat } = config ?? {};
-  if (maxEntriesPerChat === undefined && maxBytesPerChat === undefined) return;
+  if (maxEntriesPerChat === undefined && maxBytesPerChat === undefined) {
+    return;
+  }
 
   const victims = lruOrder(state);
   let i = 0;
   const dropNext = (): void => {
     const ref = victims[i++];
-    if (ref !== undefined) delete ref.table[ref.id];
+    if (ref !== undefined) {
+      delete ref.table[ref.id];
+    }
   };
 
   // `i < victims.length` also guards a negative/NaN `maxEntriesPerChat` from underflowing
@@ -239,10 +257,16 @@ function evict(state: ReplyState, config: ReplyTrackingOptions | undefined): voi
     maxEntriesPerChat !== undefined &&
     i < victims.length &&
     victims.length - i > maxEntriesPerChat
-  )
+  ) {
     dropNext();
-  while (maxBytesPerChat !== undefined && i < victims.length && byteLength(state) > maxBytesPerChat)
+  }
+  while (
+    maxBytesPerChat !== undefined &&
+    i < victims.length &&
+    byteLength(state) > maxBytesPerChat
+  ) {
     dropNext();
+  }
 }
 
 /**
@@ -287,10 +311,14 @@ export function expectReply(
  */
 export function matchReply<M extends ReplyMarker = ReplyMarker>(ctx: Context): M | undefined {
   const repliedTo = ctx.message?.reply_to_message?.message_id;
-  if (repliedTo === undefined) return undefined;
+  if (repliedTo === undefined) {
+    return undefined;
+  }
   const table = touch(ctx).state.replies;
   const entry = table[repliedTo];
-  if (entry === undefined) return undefined;
+  if (entry === undefined) {
+    return undefined;
+  }
   delete table[repliedTo];
   return entry.marker as M;
 }
@@ -349,15 +377,22 @@ export function matchCallback<M extends ReplyMarker = ReplyMarker>(
   // too old for Telegram to send along (only `inline_message_id` arrives), so
   // there is nothing to key on - route those by `callback_data` instead.
   const pressed = ctx.callbackQuery?.message?.message_id;
-  if (pressed === undefined) return undefined;
+  if (pressed === undefined) {
+    return undefined;
+  }
   const { state, config, now } = touch(ctx);
   const table = state.presses;
   const entry = table[pressed];
-  if (entry === undefined) return undefined;
+  if (entry === undefined) {
+    return undefined;
+  }
   // A live keyboard is kept, so count this press as a use (recency + sliding TTL);
   // a `once` press is consumed and needs neither.
-  if (options?.once === true) delete table[pressed];
-  else used(entry, config, now);
+  if (options?.once === true) {
+    delete table[pressed];
+  } else {
+    used(entry, config, now);
+  }
   return entry.marker as M;
 }
 

--- a/src/core/richmessage.ts
+++ b/src/core/richmessage.ts
@@ -32,7 +32,10 @@ import type {
 import { asRichText, type RichTextContent } from "./richtext.js";
 
 /** A nested-blocks argument: a plain array, a nested builder, or a callback. */
-export type BlockContent = InputRichBlock[] | RichMessageBuilder | ((builder: RichMessageBuilder) => void);
+export type BlockContent =
+  | InputRichBlock[]
+  | RichMessageBuilder
+  | ((builder: RichMessageBuilder) => void);
 
 /** Options shared by `RichMessageBuilder.build()` beyond the blocks. */
 export interface RichMessageBuildOptions {
@@ -60,13 +63,15 @@ function resolveBlocks(content: BlockContent): InputRichBlock[] {
 
 /** A block caption (`text`, optional `credit`) with rich `text`. */
 export function richCaption(text: RichTextContent, credit?: RichTextContent): RichBlockCaption {
-  return credit === undefined ? { text: asRichText(text) } : { text: asRichText(text), credit: asRichText(credit) };
+  return credit === undefined
+    ? { text: asRichText(text) }
+    : { text: asRichText(text), credit: asRichText(credit) };
 }
 
 /** A table cell; `align` defaults to `"left"`, `valign` to `"top"`. */
 export function richTableCell(
   text?: RichTextContent,
-  options: Omit<RichBlockTableCell, "text"> = { align: "left", valign: "top" },
+  options: Omit<RichBlockTableCell, "text"> = { align: "left", valign: "top" }
 ): RichBlockTableCell {
   return text === undefined ? { ...options } : { text: asRichText(text), ...options };
 }
@@ -74,7 +79,7 @@ export function richTableCell(
 /** A list item; `blocks` accept a nested builder or callback. */
 export function richListItem(
   blocks: BlockContent,
-  options: Omit<InputRichBlockListItem, "blocks"> = {},
+  options: Omit<InputRichBlockListItem, "blocks"> = {}
 ): InputRichBlockListItem {
   return { blocks: resolveBlocks(blocks), ...options };
 }
@@ -101,7 +106,11 @@ export class RichMessageBuilder {
 
   /** A preformatted (code) block, optionally tagged with a `language`. */
   preformatted(text: RichTextContent, language?: string): this {
-    return this.push({ type: "pre", text: asRichText(text), ...(language !== undefined ? { language } : {}) });
+    return this.push({
+      type: "pre",
+      text: asRichText(text),
+      ...(language !== undefined ? { language } : {}),
+    });
   }
 
   /** A footer block. */
@@ -134,7 +143,7 @@ export class RichMessageBuilder {
     return this.push(
       credit === undefined
         ? { type: "blockquote", blocks: resolveBlocks(blocks) }
-        : { type: "blockquote", blocks: resolveBlocks(blocks), credit: asRichText(credit) },
+        : { type: "blockquote", blocks: resolveBlocks(blocks), credit: asRichText(credit) }
     );
   }
 
@@ -143,7 +152,7 @@ export class RichMessageBuilder {
     return this.push(
       credit === undefined
         ? { type: "expandable_blockquote", text: asRichText(text) }
-        : { type: "expandable_blockquote", text: asRichText(text), credit: asRichText(credit) },
+        : { type: "expandable_blockquote", text: asRichText(text), credit: asRichText(credit) }
     );
   }
 
@@ -152,13 +161,17 @@ export class RichMessageBuilder {
     return this.push(
       credit === undefined
         ? { type: "pullquote", text: asRichText(text) }
-        : { type: "pullquote", text: asRichText(text), credit: asRichText(credit) },
+        : { type: "pullquote", text: asRichText(text), credit: asRichText(credit) }
     );
   }
 
   /** A collage of nested media blocks. */
   collage(blocks: BlockContent, caption?: RichBlockCaption): this {
-    return this.push({ type: "collage", blocks: resolveBlocks(blocks), ...(caption !== undefined ? { caption } : {}) });
+    return this.push({
+      type: "collage",
+      blocks: resolveBlocks(blocks),
+      ...(caption !== undefined ? { caption } : {}),
+    });
   }
 
   /** A slideshow of nested media blocks. */
@@ -176,7 +189,7 @@ export class RichMessageBuilder {
     return this.push(
       caption === undefined
         ? { type: "table", cells, ...flags }
-        : { type: "table", cells, ...flags, caption: asRichText(caption) },
+        : { type: "table", cells, ...flags, caption: asRichText(caption) }
     );
   }
 
@@ -185,14 +198,19 @@ export class RichMessageBuilder {
     return this.push(
       isOpen === undefined
         ? { type: "details", summary: asRichText(summary), blocks: resolveBlocks(blocks) }
-        : { type: "details", summary: asRichText(summary), blocks: resolveBlocks(blocks), is_open: isOpen },
+        : {
+            type: "details",
+            summary: asRichText(summary),
+            blocks: resolveBlocks(blocks),
+            is_open: isOpen,
+          }
     );
   }
 
   /** A map centered on `location`. */
   map(
     location: Location,
-    options: { zoom?: number; width?: number; height?: number; caption?: RichBlockCaption } = {},
+    options: { zoom?: number; width?: number; height?: number; caption?: RichBlockCaption } = {}
   ): this {
     return this.push({ type: "map", location, ...options });
   }
@@ -204,7 +222,11 @@ export class RichMessageBuilder {
 
   /** An animation block. Its caption is ignored - use the `caption` argument. */
   animation(animation: InputMediaAnimation, caption?: RichBlockCaption): this {
-    return this.push({ type: "animation", animation, ...(caption !== undefined ? { caption } : {}) });
+    return this.push({
+      type: "animation",
+      animation,
+      ...(caption !== undefined ? { caption } : {}),
+    });
   }
 
   /** An audio block. */
@@ -229,7 +251,11 @@ export class RichMessageBuilder {
 
   /** A voice-note block. */
   voiceNote(voiceNote: InputMediaVoiceNote, caption?: RichBlockCaption): this {
-    return this.push({ type: "voice_note", voice_note: voiceNote, ...(caption !== undefined ? { caption } : {}) });
+    return this.push({
+      type: "voice_note",
+      voice_note: voiceNote,
+      ...(caption !== undefined ? { caption } : {}),
+    });
   }
 
   /** A "Thinking..." placeholder (only valid in `sendRichMessageDraft`). */

--- a/src/core/richmessage.ts
+++ b/src/core/richmessage.ts
@@ -52,7 +52,9 @@ export interface RichTableOptions {
 }
 
 function resolveBlocks(content: BlockContent): InputRichBlock[] {
-  if (content instanceof RichMessageBuilder) return content.buildBlocks();
+  if (content instanceof RichMessageBuilder) {
+    return content.buildBlocks();
+  }
   if (typeof content === "function") {
     const builder = new RichMessageBuilder();
     content(builder);
@@ -281,7 +283,9 @@ export class RichMessageBuilder {
   /** The plain `InputRichMessage` (blocks form) ready for `rich_message`. */
   build(options?: RichMessageBuildOptions): InputRichMessage {
     const message: InputRichMessage = { blocks: this.blocks.slice(), ...options };
-    if (this.mediaItems.length > 0) message.media = this.mediaItems.slice();
+    if (this.mediaItems.length > 0) {
+      message.media = this.mediaItems.slice();
+    }
     return message;
   }
 }

--- a/src/core/richtext.ts
+++ b/src/core/richtext.ts
@@ -11,7 +11,13 @@
  * `RichTextBuilder`) so trees nest without hand-writing `type`/`text`. `.build()`
  * returns the plain `RichText`, ready for a `text`/caption/button field.
  */
-import type { LoginUrl, RichMessageButton, RichText, SwitchInlineQueryChosenChat, User } from "../types/index.js";
+import type {
+  LoginUrl,
+  RichMessageButton,
+  RichText,
+  SwitchInlineQueryChosenChat,
+  User,
+} from "../types/index.js";
 
 /** Anything a rich-text `content` parameter accepts. */
 export type RichTextContent = RichText | RichTextBuilder;
@@ -99,15 +105,27 @@ export class RichTextBuilder {
   }
 
   email(content: RichTextContent, emailAddress: string): this {
-    return this.push({ type: "email_address", text: asRichText(content), email_address: emailAddress });
+    return this.push({
+      type: "email_address",
+      text: asRichText(content),
+      email_address: emailAddress,
+    });
   }
 
   phone(content: RichTextContent, phoneNumber: string): this {
-    return this.push({ type: "phone_number", text: asRichText(content), phone_number: phoneNumber });
+    return this.push({
+      type: "phone_number",
+      text: asRichText(content),
+      phone_number: phoneNumber,
+    });
   }
 
   bankCard(content: RichTextContent, bankCardNumber: string): this {
-    return this.push({ type: "bank_card_number", text: asRichText(content), bank_card_number: bankCardNumber });
+    return this.push({
+      type: "bank_card_number",
+      text: asRichText(content),
+      bank_card_number: bankCardNumber,
+    });
   }
 
   /** A mention by username (the `@handle` form). */
@@ -139,12 +157,20 @@ export class RichTextBuilder {
 
   /** A link to a reference by name. */
   referenceLink(content: RichTextContent, referenceName: string): this {
-    return this.push({ type: "reference_link", text: asRichText(content), reference_name: referenceName });
+    return this.push({
+      type: "reference_link",
+      text: asRichText(content),
+      reference_name: referenceName,
+    });
   }
 
   /** A custom emoji; `alternativeText` is the fallback emoji. */
   customEmoji(customEmojiId: string, alternativeText: string): this {
-    return this.push({ type: "custom_emoji", custom_emoji_id: customEmojiId, alternative_text: alternativeText });
+    return this.push({
+      type: "custom_emoji",
+      custom_emoji_id: customEmojiId,
+      alternative_text: alternativeText,
+    });
   }
 
   /** A mathematical expression in LaTeX format. */
@@ -175,7 +201,7 @@ export class RichTextBuilder {
  */
 export function richMessageButton(
   text: RichTextContent,
-  options: Omit<RichMessageButton, "text"> = {},
+  options: Omit<RichMessageButton, "text"> = {}
 ): RichMessageButton {
   return { text: asRichText(text), ...options };
 }

--- a/src/core/serialize.ts
+++ b/src/core/serialize.ts
@@ -43,7 +43,11 @@ export function serializeParams(params: Record<string, unknown>): Record<string,
       const files: Array<[string, InputFile]> = [];
       const json = JSON.stringify(resolve(value, slots, files, 0));
       out[key] = files.length ? formPart(json, files) : json;
-    } else if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    } else if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
       out[key] = value; // scalar, statically narrowed - no cast
     } else {
       // The generated param types only ever yield scalars/objects/arrays/InputFile,
@@ -56,7 +60,12 @@ export function serializeParams(params: Record<string, unknown>): Record<string,
 }
 
 /** Replace every nested `InputFile` with its `attach://` ref (collecting the part). */
-function resolve(node: unknown, slots: { next: number }, files: Array<[string, InputFile]>, depth: number): unknown {
+function resolve(
+  node: unknown,
+  slots: { next: number },
+  files: Array<[string, InputFile]>,
+  depth: number
+): unknown {
   if (depth > MAX_DEPTH) throw new TypeError("serializeParams: structure too deep (cyclic?)");
   if (isInputFile(node)) {
     const ref = node.build(slots.next++);
@@ -65,7 +74,9 @@ function resolve(node: unknown, slots: { next: number }, files: Array<[string, I
   }
   if (Array.isArray(node)) return node.map((child) => resolve(child, slots, files, depth + 1));
   if (node !== null && typeof node === "object") {
-    return Object.fromEntries(Object.entries(node).map(([k, v]) => [k, resolve(v, slots, files, depth + 1)]));
+    return Object.fromEntries(
+      Object.entries(node).map(([k, v]) => [k, resolve(v, slots, files, depth + 1)])
+    );
   }
   return node;
 }

--- a/src/core/serialize.ts
+++ b/src/core/serialize.ts
@@ -36,7 +36,9 @@ export function serializeParams(params: Record<string, unknown>): Record<string,
   const slots = { next: 0 };
   const out: Record<string, WireValue> = {};
   for (const [key, value] of Object.entries(params)) {
-    if (value == null) continue;
+    if (value == null) {
+      continue;
+    }
     if (isInputFile(value)) {
       out[key] = value; // top-level file: the encoder attaches it under the field name
     } else if (typeof value === "object") {
@@ -66,13 +68,17 @@ function resolve(
   files: Array<[string, InputFile]>,
   depth: number
 ): unknown {
-  if (depth > MAX_DEPTH) throw new TypeError("serializeParams: structure too deep (cyclic?)");
+  if (depth > MAX_DEPTH) {
+    throw new TypeError("serializeParams: structure too deep (cyclic?)");
+  }
   if (isInputFile(node)) {
     const ref = node.build(slots.next++);
     files.push([ref.slice(ATTACH_PREFIX.length), node]);
     return ref;
   }
-  if (Array.isArray(node)) return node.map((child) => resolve(child, slots, files, depth + 1));
+  if (Array.isArray(node)) {
+    return node.map((child) => resolve(child, slots, files, depth + 1));
+  }
   if (node !== null && typeof node === "object") {
     return Object.fromEntries(
       Object.entries(node).map(([k, v]) => [k, resolve(v, slots, files, depth + 1)])

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -128,7 +128,11 @@ export type SessionHandle<T> = {
    * layout), so pass `isValid` to have a slot that fails the check replaced by a
    * fresh `initial()` instead of reaching the layer half-formed.
    */
-  ext<E extends object>(namespace: string, initial: () => E, isValid?: (slot: Record<string, unknown>) => boolean): E;
+  ext<E extends object>(
+    namespace: string,
+    initial: () => E,
+    isValid?: (slot: Record<string, unknown>) => boolean
+  ): E;
   /**
    * Per-chat bounds for the reply-tracking layer, as passed to
    * {@link SessionOptions.replyTracking}. Read by `reply-tracking.ts` when it
@@ -245,7 +249,9 @@ function createKeyLock(): <R>(key: string, fn: () => Promise<R>) => Promise<R> {
  * The envelope is flushed after the handler even if it throws, so a marker
  * written before an error still persists - and only when it actually changed.
  */
-export function createSession<T = Record<string, unknown>>(options: SessionOptions<T>): SessionMiddleware<T> {
+export function createSession<T = Record<string, unknown>>(
+  options: SessionOptions<T>
+): SessionMiddleware<T> {
   const store = options.store;
   const getSessionKey = options.getSessionKey ?? defaultKey;
   const initial = options.initial ?? (() => ({}) as T);
@@ -263,7 +269,7 @@ export function createSession<T = Record<string, unknown>>(options: SessionOptio
         (err: unknown) => {
           setup = undefined; // a transient failure must not be cached forever
           throw err;
-        },
+        }
       );
     }
     return setup;
@@ -290,7 +296,7 @@ export function createSession<T = Record<string, unknown>>(options: SessionOptio
         ext<E extends object>(
           namespace: string,
           makeInitial: () => E,
-          isValid?: (slot: Record<string, unknown>) => boolean,
+          isValid?: (slot: Record<string, unknown>) => boolean
         ): E {
           if (envelope.ext === undefined) envelope.ext = {};
           const ext = envelope.ext;
@@ -355,7 +361,7 @@ export function createSession<T = Record<string, unknown>>(options: SessionOptio
     envelope: SessionEnvelope<T>,
     before: string,
     existed: boolean,
-    dropped: boolean,
+    dropped: boolean
   ): Promise<void> {
     if (dropped) return persistDrop(key, existed);
     // `handle.data` may have been reassigned to a fresh object; re-read it.
@@ -368,7 +374,9 @@ export function createSession<T = Record<string, unknown>>(options: SessionOptio
     get(ctx: Context): SessionHandle<T> {
       const handle = handles.get(ctx);
       if (handle === undefined) {
-        throw new Error("session.get: the session middleware did not run for this update (no key, or not registered)");
+        throw new Error(
+          "session.get: the session middleware did not run for this update (no key, or not registered)"
+        );
       }
       return handle;
     },

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -226,7 +226,9 @@ function createKeyLock(): <R>(key: string, fn: () => Promise<R>) => Promise<R> {
       // Nothing queued behind us (the map still holds our tail) -> drop the entry
       // so the map does not grow with every key ever seen. Runs synchronously
       // with `release()`, so no waiter can slip in between.
-      if (tails.get(key) === tail) tails.delete(key);
+      if (tails.get(key) === tail) {
+        tails.delete(key);
+      }
     }
   };
 }
@@ -298,7 +300,9 @@ export function createSession<T = Record<string, unknown>>(
           makeInitial: () => E,
           isValid?: (slot: Record<string, unknown>) => boolean
         ): E {
-          if (envelope.ext === undefined) envelope.ext = {};
+          if (envelope.ext === undefined) {
+            envelope.ext = {};
+          }
           const ext = envelope.ext;
           const current = ext[namespace];
           if (!isPlainObject(current) || (isValid !== undefined && !isValid(current))) {
@@ -344,7 +348,9 @@ export function createSession<T = Record<string, unknown>>(
   /** Write back the envelope - only if it changed, and only if not dropped. */
   /** Drop the key when the handler evicted the session (no-op if it was never stored). */
   async function persistDrop(key: string, existed: boolean): Promise<void> {
-    if (existed) await store.delete(key);
+    if (existed) {
+      await store.delete(key);
+    }
   }
 
   /**
@@ -352,7 +358,9 @@ export function createSession<T = Record<string, unknown>>(
    * lapse just because this update changed nothing, so refresh it in place.
    */
   async function refreshTtl(key: string, existed: boolean): Promise<void> {
-    if (existed && ttlSeconds !== undefined) await store.touch?.(key, ttlSeconds);
+    if (existed && ttlSeconds !== undefined) {
+      await store.touch?.(key, ttlSeconds);
+    }
   }
 
   async function flush(
@@ -363,10 +371,14 @@ export function createSession<T = Record<string, unknown>>(
     existed: boolean,
     dropped: boolean
   ): Promise<void> {
-    if (dropped) return persistDrop(key, existed);
+    if (dropped) {
+      return persistDrop(key, existed);
+    }
     // `handle.data` may have been reassigned to a fresh object; re-read it.
     envelope.data = handle.data;
-    if (codec.encode(envelope) === before) return refreshTtl(key, existed);
+    if (codec.encode(envelope) === before) {
+      return refreshTtl(key, existed);
+    }
     await store.write(key, codec.encode(envelope), { ttlSeconds });
   }
 

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -46,9 +46,28 @@ export interface TransportOptions {
   rateLimit?: RateLimitOptions;
 }
 
-type ApiResponse<R> =
-  | { ok: true; result: R }
-  | { ok: false; error_code: number; description: string; parameters?: ApiErrorParameters };
+type ApiError = {
+  ok: false;
+  error_code: number;
+  description: string;
+  parameters?: ApiErrorParameters;
+};
+type ApiResponse<R> = { ok: true; result: R } | ApiError;
+
+/** The wire-ready body factory + headers `encodeForm` produced, plus per-request context. */
+type RequestBody = URLSearchParams | ReadableStream<Uint8Array> | Blob;
+type RequestContext = {
+  url: string;
+  method: string;
+  makeBody: () => RequestBody;
+  headers: Record<string, string>;
+  timeoutMs: number;
+  signal: AbortSignal | undefined;
+  maxRetries: number;
+};
+
+/** The outcome of one send attempt: a bounded backoff-and-retry, or a final result. */
+type AttemptOutcome<R> = { retry: true; waitMs: number } | { retry: false; result: R };
 
 const DEFAULT_API_ROOT = "https://api.telegram.org";
 // Generous enough that a large upload on a slow link is not cut off mid-stream;
@@ -152,120 +171,167 @@ export class Transport {
     // caller-provided one-shot `ReadableStream` `InputFile`), retrying is
     // impossible - the first failure surfaces immediately.
     const { body: makeBody, headers, replayable } = await encodeForm(params ?? {});
-    const maxRetries = replayable ? this.maxRetries : 0;
+    const ctx: RequestContext = {
+      url,
+      method,
+      makeBody,
+      headers,
+      timeoutMs,
+      signal,
+      maxRetries: replayable ? this.maxRetries : 0,
+    };
 
     // Bounded: at most `maxRetries + 1` attempts (the first send plus one retry
     // per allowed retry). `attempt` doubles as the loop counter and the retry
-    // count; every error path either retries via `continue` or throws, so the
-    // bound is a hard ceiling rather than the termination condition.
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      const timeoutSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
-      const { signal: composed, cleanup } = combineSignals([signal, timeoutSignal]);
-
-      const body = makeBody();
-      // The fetch spec (and undici) require `duplex: "half"` to send a stream
-      // body; set it only then so runtimes that reject the member for ordinary
-      // bodies are unaffected.
-      const init: RequestInit & { duplex?: "half" } = {
-        method: "POST",
-        body,
-        headers,
-        signal: composed,
-      };
-      if (body instanceof ReadableStream) init.duplex = "half";
-
-      let response: Response;
-      let text: string;
-      try {
-        response = await this.fetchImpl(url, init);
-        // Read the body inside the try so a mid-stream read failure (connection
-        // dropped after the headers) is classified and retried like any other
-        // transient transport error, not thrown raw past the error hierarchy.
-        text = await response.text();
-      } catch (err) {
-        if (signal?.aborted) throw err; // caller cancelled - propagate verbatim
-        // Transient throws (fetch reject / body-read failure / our timeout): retry.
-        if (attempt < maxRetries) {
-          const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
-          log("%s transient error; retry %d/%d in %dms", method, attempt + 1, maxRetries, wait);
-          await delay(wait, signal);
-          continue;
-        }
-        if (isAbortError(err))
-          throw new TimeoutError(`Request timed out: ${method}`, { cause: err });
-        throw new NetworkError(`Network request failed: ${method}`, { cause: err });
-      } finally {
-        cleanup();
-      }
-
-      // Server-side 5xx is transient: retry without parsing the body.
-      if (response.status >= 500) {
-        if (attempt < maxRetries) {
-          const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
-          log(
-            "%s HTTP %d; retry %d/%d in %dms",
-            method,
-            response.status,
-            attempt + 1,
-            maxRetries,
-            wait
-          );
-          await delay(wait, signal);
-          continue;
-        }
-        // Exhausted: prefer the `{ ok: false }` envelope when the body is one.
-        const envelope = parseEnvelope<R>(text);
-        if (envelope && !envelope.ok) {
-          throw new TelegramApiError(
-            envelope.error_code,
-            envelope.description,
-            envelope.parameters
-          );
-        }
-        throw new NetworkError(`Server error ${response.status} on ${method}`);
-      }
-
-      let json: ApiResponse<R>;
-      try {
-        json = JSON.parse(text) as ApiResponse<R>;
-      } catch (err) {
-        throw new ParseError(`Invalid JSON in response to ${method}`, {
-          cause: err,
-          responseText: text,
-        });
-      }
-
-      if (json.ok) {
-        log("<- %s ok", method);
-        return json.result;
-      }
-
-      if (json.error_code === HTTP_STATUS_TOO_MANY_REQUESTS && attempt < maxRetries) {
-        const retryAfter = json.parameters?.retry_after ?? 1;
-        // Honor `retry_after` only up to the cap (0 = no cap). A longer flood-wait is
-        // surfaced immediately (caller reads err.retryAfter) rather than hanging the
-        // request for minutes; the per-request timeout does not bound this sleep.
-        if (this.maxRetryAfterMs === 0 || retryAfter * 1000 <= this.maxRetryAfterMs) {
-          log("%s 429; retry %d/%d after %ds", method, attempt + 1, maxRetries, retryAfter);
-          await delay(retryAfter * 1000, signal);
-          continue;
-        }
-        log(
-          "%s 429; retry_after %ds exceeds maxRetryAfterMs (%dms) - surfacing",
-          method,
-          retryAfter,
-          this.maxRetryAfterMs
-        );
-      }
-
-      log("<- %s error %d %s", method, json.error_code, json.description);
-      throw new TelegramApiError(json.error_code, json.description, json.parameters);
+    // count; every attempt returns a result, throws, or asks for a bounded
+    // backoff and loops, so the bound is a hard ceiling rather than the
+    // termination condition.
+    for (let attempt = 0; attempt <= ctx.maxRetries; attempt++) {
+      const outcome = await this.attempt<R>(ctx, attempt);
+      if (!outcome.retry) return outcome.result;
+      await delay(outcome.waitMs, signal);
     }
 
-    // Unreachable: the final iteration (attempt === maxRetries) takes a throwing
-    // branch on every error path, so the loop never falls through here. Present
-    // only to satisfy control-flow analysis now that the loop is bounded.
+    // Unreachable: the final iteration (attempt === maxRetries) never yields a
+    // `retry` outcome, so the loop never falls through here. Present only to
+    // satisfy control-flow analysis now that the loop is bounded.
     throw new TelegramBotError(`Retry loop exited without a result: ${method}`);
+  }
+
+  /** One send attempt: run the transport, then classify the response. */
+  private async attempt<R>(ctx: RequestContext, attempt: number): Promise<AttemptOutcome<R>> {
+    const timeoutSignal = ctx.timeoutMs > 0 ? AbortSignal.timeout(ctx.timeoutMs) : undefined;
+    const { signal: composed, cleanup } = combineSignals([ctx.signal, timeoutSignal]);
+    let response: Response;
+    let text: string;
+    try {
+      response = await this.fetchImpl(ctx.url, buildInit(ctx.makeBody(), ctx.headers, composed));
+      // Read the body inside the try so a mid-stream read failure (connection
+      // dropped after the headers) is classified and retried like any other
+      // transient transport error, not thrown raw past the error hierarchy.
+      text = await response.text();
+    } catch (err) {
+      return this.onTransportError<R>(err, ctx, attempt);
+    } finally {
+      cleanup();
+    }
+    return this.classify<R>(ctx, attempt, response, text);
+  }
+
+  /** Transient throw (fetch reject / body-read failure / our timeout): retry or surface. */
+  private onTransportError<R>(
+    err: unknown,
+    ctx: RequestContext,
+    attempt: number
+  ): AttemptOutcome<R> {
+    if (ctx.signal?.aborted) throw err; // caller cancelled - propagate verbatim
+    if (attempt < ctx.maxRetries) {
+      const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
+      log("%s transient error; retry %d/%d in %dms", ctx.method, attempt + 1, ctx.maxRetries, wait);
+      return { retry: true, waitMs: wait };
+    }
+    if (isAbortError(err))
+      throw new TimeoutError(`Request timed out: ${ctx.method}`, { cause: err });
+    throw new NetworkError(`Network request failed: ${ctx.method}`, { cause: err });
+  }
+
+  /** Map a completed HTTP response to a result, a bounded retry, or a thrown error. */
+  private classify<R>(
+    ctx: RequestContext,
+    attempt: number,
+    response: Response,
+    text: string
+  ): AttemptOutcome<R> {
+    // Server-side 5xx is transient: retry without parsing the body.
+    if (response.status >= 500) return this.onServerError<R>(ctx, attempt, response, text);
+
+    const json = parseJson<R>(text, ctx.method);
+    if (json.ok) {
+      log("<- %s ok", ctx.method);
+      return { retry: false, result: json.result };
+    }
+    return this.onApiError(ctx, attempt, json);
+  }
+
+  /** Handle a 5xx: retry while attempts remain, else surface an envelope/network error. */
+  private onServerError<R>(
+    ctx: RequestContext,
+    attempt: number,
+    response: Response,
+    text: string
+  ): AttemptOutcome<R> {
+    if (attempt < ctx.maxRetries) {
+      const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
+      log(
+        "%s HTTP %d; retry %d/%d in %dms",
+        ctx.method,
+        response.status,
+        attempt + 1,
+        ctx.maxRetries,
+        wait
+      );
+      return { retry: true, waitMs: wait };
+    }
+    // Exhausted: prefer the `{ ok: false }` envelope when the body is one.
+    const envelope = parseEnvelope<R>(text);
+    if (envelope && !envelope.ok) {
+      throw new TelegramApiError(envelope.error_code, envelope.description, envelope.parameters);
+    }
+    throw new NetworkError(`Server error ${response.status} on ${ctx.method}`);
+  }
+
+  /** Handle an `{ ok: false }` envelope: honor a capped 429 retry_after, else throw. */
+  private onApiError<R>(ctx: RequestContext, attempt: number, json: ApiError): AttemptOutcome<R> {
+    if (json.error_code === HTTP_STATUS_TOO_MANY_REQUESTS && attempt < ctx.maxRetries) {
+      const retryAfter = json.parameters?.retry_after ?? 1;
+      // Honor `retry_after` only up to the cap (0 = no cap). A longer flood-wait is
+      // surfaced immediately (caller reads err.retryAfter) rather than hanging the
+      // request for minutes; the per-request timeout does not bound this sleep.
+      if (this.maxRetryAfterMs === 0 || retryAfter * 1000 <= this.maxRetryAfterMs) {
+        log("%s 429; retry %d/%d after %ds", ctx.method, attempt + 1, ctx.maxRetries, retryAfter);
+        return { retry: true, waitMs: retryAfter * 1000 };
+      }
+      log(
+        "%s 429; retry_after %ds exceeds maxRetryAfterMs (%dms) - surfacing",
+        ctx.method,
+        retryAfter,
+        this.maxRetryAfterMs
+      );
+    }
+
+    log("<- %s error %d %s", ctx.method, json.error_code, json.description);
+    throw new TelegramApiError(json.error_code, json.description, json.parameters);
+  }
+}
+
+/** Build a POST init, tagging a stream body with `duplex: "half"` as the fetch spec requires. */
+function buildInit(
+  body: RequestBody,
+  headers: Record<string, string>,
+  signal: AbortSignal | undefined
+): RequestInit & { duplex?: "half" } {
+  const init: RequestInit & { duplex?: "half" } = {
+    method: "POST",
+    body,
+    headers,
+    signal,
+  };
+  // The fetch spec (and undici) require `duplex: "half"` to send a stream body;
+  // set it only then so runtimes that reject the member for ordinary bodies are
+  // unaffected.
+  if (body instanceof ReadableStream) init.duplex = "half";
+  return init;
+}
+
+/** Parse the `{ ok, result }` envelope, or throw a `ParseError` when the body is not JSON. */
+function parseJson<R>(text: string, method: string): ApiResponse<R> {
+  try {
+    return JSON.parse(text) as ApiResponse<R>;
+  } catch (err) {
+    throw new ParseError(`Invalid JSON in response to ${method}`, {
+      cause: err,
+      responseText: text,
+    });
   }
 }
 

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -214,10 +214,15 @@ export class Transport {
   private async attempt<R>(ctx: RequestContext, attempt: number): Promise<AttemptOutcome<R>> {
     const timeoutSignal = ctx.timeoutMs > 0 ? AbortSignal.timeout(ctx.timeoutMs) : undefined;
     const { signal: composed, cleanup } = combineSignals([ctx.signal, timeoutSignal]);
+    // Build the body/init BEFORE the try: a synchronous failure while creating
+    // the body (e.g. re-streaming a multipart source) must surface raw and
+    // unretried, exactly as it did before this was extracted - not get caught
+    // and reclassified as a transient transport error.
+    const init = buildInit(ctx.makeBody(), ctx.headers, composed);
     let response: Response;
     let text: string;
     try {
-      response = await this.fetchImpl(ctx.url, buildInit(ctx.makeBody(), ctx.headers, composed));
+      response = await this.fetchImpl(ctx.url, init);
       // Read the body inside the try so a mid-stream read failure (connection
       // dropped after the headers) is classified and retried like any other
       // transient transport error, not thrown raw past the error hierarchy.

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -86,8 +86,12 @@ function combineSignals(signals: Array<AbortSignal | undefined>): {
   cleanup: () => void;
 } {
   const list = signals.filter((s): s is AbortSignal => s != null);
-  if (list.length === 0) return { signal: undefined, cleanup: () => {} };
-  if (list.length === 1) return { signal: list[0], cleanup: () => {} };
+  if (list.length === 0) {
+    return { signal: undefined, cleanup: () => {} };
+  }
+  if (list.length === 1) {
+    return { signal: list[0], cleanup: () => {} };
+  }
 
   const controller = new AbortController();
   const cleanups: Array<() => void> = [];
@@ -103,7 +107,9 @@ function combineSignals(signals: Array<AbortSignal | undefined>): {
   return {
     signal: controller.signal,
     cleanup: () => {
-      for (const fn of cleanups) fn();
+      for (const fn of cleanups) {
+        fn();
+      }
     },
   };
 }
@@ -121,7 +127,9 @@ export class Transport {
     private readonly token: string,
     options: TransportOptions = {}
   ) {
-    if (!token) throw new TelegramBotError("A bot token is required", { code: "EPARAM" });
+    if (!token) {
+      throw new TelegramBotError("A bot token is required", { code: "EPARAM" });
+    }
     // Empty/whitespace apiRoot falls back to the default; `??` would keep "".
     const root = options.apiRoot?.trim();
     this.apiRoot = (root ? root : DEFAULT_API_ROOT).replace(/\/+$/, "");
@@ -134,7 +142,9 @@ export class Transport {
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.retryBackoffMs = options.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF;
     this.maxRetryAfterMs = options.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER;
-    if (options.rateLimit) this.limiter = new RateLimiter(options.rateLimit);
+    if (options.rateLimit) {
+      this.limiter = new RateLimiter(options.rateLimit);
+    }
   }
 
   /** For long polling the client timeout must outlast the server-side wait. */
@@ -188,7 +198,9 @@ export class Transport {
     // termination condition.
     for (let attempt = 0; attempt <= ctx.maxRetries; attempt++) {
       const outcome = await this.attempt<R>(ctx, attempt);
-      if (!outcome.retry) return outcome.result;
+      if (!outcome.retry) {
+        return outcome.result;
+      }
       await delay(outcome.waitMs, signal);
     }
 
@@ -224,14 +236,17 @@ export class Transport {
     ctx: RequestContext,
     attempt: number
   ): AttemptOutcome<R> {
-    if (ctx.signal?.aborted) throw err; // caller cancelled - propagate verbatim
+    if (ctx.signal?.aborted) {
+      throw err; // caller cancelled - propagate verbatim
+    }
     if (attempt < ctx.maxRetries) {
       const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
       log("%s transient error; retry %d/%d in %dms", ctx.method, attempt + 1, ctx.maxRetries, wait);
       return { retry: true, waitMs: wait };
     }
-    if (isAbortError(err))
+    if (isAbortError(err)) {
       throw new TimeoutError(`Request timed out: ${ctx.method}`, { cause: err });
+    }
     throw new NetworkError(`Network request failed: ${ctx.method}`, { cause: err });
   }
 
@@ -243,7 +258,9 @@ export class Transport {
     text: string
   ): AttemptOutcome<R> {
     // Server-side 5xx is transient: retry without parsing the body.
-    if (response.status >= 500) return this.onServerError<R>(ctx, attempt, response, text);
+    if (response.status >= 500) {
+      return this.onServerError<R>(ctx, attempt, response, text);
+    }
 
     const json = parseJson<R>(text, ctx.method);
     if (json.ok) {
@@ -319,7 +336,9 @@ function buildInit(
   // The fetch spec (and undici) require `duplex: "half"` to send a stream body;
   // set it only then so runtimes that reject the member for ordinary bodies are
   // unaffected.
-  if (body instanceof ReadableStream) init.duplex = "half";
+  if (body instanceof ReadableStream) {
+    init.duplex = "half";
+  }
   return init;
 }
 

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -214,10 +214,8 @@ export class Transport {
   private async attempt<R>(ctx: RequestContext, attempt: number): Promise<AttemptOutcome<R>> {
     const timeoutSignal = ctx.timeoutMs > 0 ? AbortSignal.timeout(ctx.timeoutMs) : undefined;
     const { signal: composed, cleanup } = combineSignals([ctx.signal, timeoutSignal]);
-    // Build the body/init BEFORE the try: a synchronous failure while creating
-    // the body (e.g. re-streaming a multipart source) must surface raw and
-    // unretried, exactly as it did before this was extracted - not get caught
-    // and reclassified as a transient transport error.
+    // Build body/init outside the try so a synchronous body-build failure
+    // surfaces raw and unretried, not caught and retried as a transport error.
     const init = buildInit(ctx.makeBody(), ctx.headers, composed);
     let response: Response;
     let text: string;

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -100,7 +100,7 @@ export class Transport {
 
   constructor(
     private readonly token: string,
-    options: TransportOptions = {},
+    options: TransportOptions = {}
   ) {
     if (!token) throw new TelegramBotError("A bot token is required", { code: "EPARAM" });
     // Empty/whitespace apiRoot falls back to the default; `??` would keep "".
@@ -120,13 +120,22 @@ export class Transport {
 
   /** For long polling the client timeout must outlast the server-side wait. */
   private effectiveTimeout(method: string, params?: Record<string, WireValue>): number {
-    if (method === "getUpdates" && params && typeof params.timeout === "number" && params.timeout > 0) {
+    if (
+      method === "getUpdates" &&
+      params &&
+      typeof params.timeout === "number" &&
+      params.timeout > 0
+    ) {
       return params.timeout * 1000 + 10_000;
     }
     return this.timeoutMs;
   }
 
-  async request<R>(method: string, params?: Record<string, WireValue>, signal?: AbortSignal): Promise<R> {
+  async request<R>(
+    method: string,
+    params?: Record<string, WireValue>,
+    signal?: AbortSignal
+  ): Promise<R> {
     const url = `${this.apiRoot}/bot${this.token}/${method}`;
     const timeoutMs = this.effectiveTimeout(method, params);
     log("-> %s", method);
@@ -157,7 +166,12 @@ export class Transport {
       // The fetch spec (and undici) require `duplex: "half"` to send a stream
       // body; set it only then so runtimes that reject the member for ordinary
       // bodies are unaffected.
-      const init: RequestInit & { duplex?: "half" } = { method: "POST", body, headers, signal: composed };
+      const init: RequestInit & { duplex?: "half" } = {
+        method: "POST",
+        body,
+        headers,
+        signal: composed,
+      };
       if (body instanceof ReadableStream) init.duplex = "half";
 
       let response: Response;
@@ -177,7 +191,8 @@ export class Transport {
           await delay(wait, signal);
           continue;
         }
-        if (isAbortError(err)) throw new TimeoutError(`Request timed out: ${method}`, { cause: err });
+        if (isAbortError(err))
+          throw new TimeoutError(`Request timed out: ${method}`, { cause: err });
         throw new NetworkError(`Network request failed: ${method}`, { cause: err });
       } finally {
         cleanup();
@@ -187,14 +202,25 @@ export class Transport {
       if (response.status >= 500) {
         if (attempt < maxRetries) {
           const wait = backoff(attempt + 1, this.retryBackoffMs, MAX_BACKOFF);
-          log("%s HTTP %d; retry %d/%d in %dms", method, response.status, attempt + 1, maxRetries, wait);
+          log(
+            "%s HTTP %d; retry %d/%d in %dms",
+            method,
+            response.status,
+            attempt + 1,
+            maxRetries,
+            wait
+          );
           await delay(wait, signal);
           continue;
         }
         // Exhausted: prefer the `{ ok: false }` envelope when the body is one.
         const envelope = parseEnvelope<R>(text);
         if (envelope && !envelope.ok) {
-          throw new TelegramApiError(envelope.error_code, envelope.description, envelope.parameters);
+          throw new TelegramApiError(
+            envelope.error_code,
+            envelope.description,
+            envelope.parameters
+          );
         }
         throw new NetworkError(`Server error ${response.status} on ${method}`);
       }
@@ -228,7 +254,7 @@ export class Transport {
           "%s 429; retry_after %ds exceeds maxRetryAfterMs (%dms) - surfacing",
           method,
           retryAfter,
-          this.maxRetryAfterMs,
+          this.maxRetryAfterMs
         );
       }
 

--- a/src/core/webhook.ts
+++ b/src/core/webhook.ts
@@ -97,7 +97,10 @@ export function safeEqual(a: string, b: string): boolean {
   return diff === 0;
 }
 
-export function webhookCallback(bot: Bot, options: WebhookOptions = {}): (request: Request) => Promise<Response> {
+export function webhookCallback(
+  bot: Bot,
+  options: WebhookOptions = {}
+): (request: Request) => Promise<Response> {
   const { secretToken, allowUnauthenticated, fastAck, waitUntil } = options;
 
   // Secure by default: a webhook callback requires a secret token. The only way
@@ -108,13 +111,13 @@ export function webhookCallback(bot: Bot, options: WebhookOptions = {}): (reques
       throw new TelegramBotError(
         "webhookCallback requires `secretToken` (matching setWebhook's secret_token). " +
           "Set it, or pass `allowUnauthenticated: true` if auth is enforced at another layer.",
-        { code: "EPARAM" },
+        { code: "EPARAM" }
       );
     }
   } else if (!SECRET_TOKEN_RE.test(secretToken)) {
     throw new TelegramBotError(
       "Invalid `secretToken`: must be 1-256 characters of A-Z, a-z, 0-9, _ or - (per setWebhook).",
-      { code: "EPARAM" },
+      { code: "EPARAM" }
     );
   }
 

--- a/src/core/webhook.ts
+++ b/src/core/webhook.ts
@@ -124,9 +124,13 @@ function rejectBadMethod(request: Request): Response | null {
  * (compare against ""), to avoid an early-out path that leaks header presence.
  */
 function rejectBadSecret(request: Request, secretToken: string | undefined): Response | null {
-  if (secretToken === undefined) return null;
+  if (secretToken === undefined) {
+    return null;
+  }
   const got = request.headers.get("X-Telegram-Bot-Api-Secret-Token") ?? "";
-  if (safeEqual(got, secretToken)) return null;
+  if (safeEqual(got, secretToken)) {
+    return null;
+  }
   log("rejected POST: bad secret token");
   return new Response("Unauthorized", { status: 401 });
 }
@@ -160,7 +164,9 @@ function dispatchInBackground(
   const work = Promise.resolve(bot.handleUpdate(update)).catch((err: unknown) => {
     log("background handleUpdate failed for update %d: %s", update.update_id, formatError(err));
   });
-  if (waitUntil !== undefined) waitUntil(work);
+  if (waitUntil !== undefined) {
+    waitUntil(work);
+  }
   log("update %d: acked 200, handling in background", update.update_id);
   return new Response(null, { status: 200 });
 }
@@ -212,10 +218,14 @@ export function webhookCallback(
 
   return async function handle(request: Request): Promise<Response> {
     const rejected = rejectBadMethod(request) ?? rejectBadSecret(request, secretToken);
-    if (rejected !== null) return rejected;
+    if (rejected !== null) {
+      return rejected;
+    }
 
     const update = await readUpdate(request);
-    if (update === null) return new Response("Bad Request", { status: 400 });
+    if (update === null) {
+      return new Response("Bad Request", { status: 400 });
+    }
     log("update %d", update.update_id);
 
     return earlyAck ? dispatchInBackground(bot, update, waitUntil) : dispatchAwaiting(bot, update);

--- a/src/core/webhook.ts
+++ b/src/core/webhook.ts
@@ -97,6 +97,92 @@ export function safeEqual(a: string, b: string): boolean {
   return diff === 0;
 }
 
+/**
+ * Render an error for a log line. Done explicitly because `%o` would
+ * JSON-stringify an `Error` to `{}` (Errors carry their fields on non-enumerable
+ * properties); prefer the stack, falling back to the message or a `String()`.
+ */
+function formatError(err: unknown): string {
+  return err instanceof Error ? (err.stack ?? err.message) : String(err);
+}
+
+/**
+ * Reject anything but POST. Returns the short-circuit `Response`, or `null` when
+ * the method is allowed and the callback should continue.
+ */
+function rejectBadMethod(request: Request): Response | null {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  return null;
+}
+
+/**
+ * Verify the secret-token header when a `secretToken` is configured. Returns the
+ * 401 `Response` on mismatch, or `null` to continue (no token configured, or a
+ * match). Always runs the constant-time compare, even when the header is missing
+ * (compare against ""), to avoid an early-out path that leaks header presence.
+ */
+function rejectBadSecret(request: Request, secretToken: string | undefined): Response | null {
+  if (secretToken === undefined) return null;
+  const got = request.headers.get("X-Telegram-Bot-Api-Secret-Token") ?? "";
+  if (safeEqual(got, secretToken)) return null;
+  log("rejected POST: bad secret token");
+  return new Response("Unauthorized", { status: 401 });
+}
+
+/**
+ * Parse the request body as an `Update`. Returns `null` (and logs) on invalid
+ * JSON so the caller can respond 400.
+ */
+async function readUpdate(request: Request): Promise<Update | null> {
+  try {
+    return (await request.json()) as Update;
+  } catch {
+    log("rejected POST: invalid JSON body");
+    return null;
+  }
+}
+
+/**
+ * Early-ACK dispatch: kick off `handleUpdate` and return 200 now. `handleUpdate`
+ * rejects only when a user-installed `bot.catch()` boundary throws (the default
+ * boundary logs and consumes); the 200 is already sent, so that rejection can
+ * never reach the caller - `.catch` keeps it from surfacing as an unhandled
+ * rejection, and logs it (message + stack) so the fail-loud opt-in stays
+ * debuggable in fastAck mode.
+ */
+function dispatchInBackground(
+  bot: Bot,
+  update: Update,
+  waitUntil: WebhookOptions["waitUntil"]
+): Response {
+  const work = Promise.resolve(bot.handleUpdate(update)).catch((err: unknown) => {
+    log("background handleUpdate failed for update %d: %s", update.update_id, formatError(err));
+  });
+  if (waitUntil !== undefined) waitUntil(work);
+  log("update %d: acked 200, handling in background", update.update_id);
+  return new Response(null, { status: 200 });
+}
+
+/**
+ * Awaiting dispatch: run `handleUpdate` and respond 200. `handleUpdate` rejects
+ * only when a user-installed `bot.catch()` boundary throws (the default boundary
+ * logs and consumes the update). Honor that fail-loud opt-in with an explicit
+ * 500 - deterministic across runtimes, where an escaping rejection is handled
+ * differently by each (Bun.serve, Workers, the node:http adapters) - so Telegram
+ * redelivers the update.
+ */
+async function dispatchAwaiting(bot: Bot, update: Update): Promise<Response> {
+  try {
+    await bot.handleUpdate(update);
+  } catch (err) {
+    log("handleUpdate failed for update %d: %s", update.update_id, formatError(err));
+    return new Response("Internal Server Error", { status: 500 });
+  }
+  return new Response(null, { status: 200 });
+}
+
 export function webhookCallback(
   bot: Bot,
   options: WebhookOptions = {}
@@ -125,59 +211,13 @@ export function webhookCallback(
   const earlyAck = fastAck === true || waitUntil !== undefined;
 
   return async function handle(request: Request): Promise<Response> {
-    if (request.method !== "POST") {
-      return new Response("Method Not Allowed", { status: 405 });
-    }
+    const rejected = rejectBadMethod(request) ?? rejectBadSecret(request, secretToken);
+    if (rejected !== null) return rejected;
 
-    if (secretToken !== undefined) {
-      // Always run the constant-time compare, even when the header is missing
-      // (compare against ""), to avoid an early-out path that leaks header presence.
-      const got = request.headers.get("X-Telegram-Bot-Api-Secret-Token") ?? "";
-      if (!safeEqual(got, secretToken)) {
-        log("rejected POST: bad secret token");
-        return new Response("Unauthorized", { status: 401 });
-      }
-    }
-
-    let update: Update;
-    try {
-      update = (await request.json()) as Update;
-    } catch {
-      log("rejected POST: invalid JSON body");
-      return new Response("Bad Request", { status: 400 });
-    }
+    const update = await readUpdate(request);
+    if (update === null) return new Response("Bad Request", { status: 400 });
     log("update %d", update.update_id);
 
-    if (earlyAck) {
-      // Validate, kick off the handler, and ACK now. `handleUpdate` rejects only
-      // when a user-installed `bot.catch()` boundary throws (the default boundary
-      // logs and consumes); the 200 is already sent, so that rejection can never
-      // reach the caller - `.catch` keeps it from surfacing as an unhandled
-      // rejection, and logs it (message + stack) so the fail-loud opt-in stays
-      // debuggable in fastAck mode. The error is rendered explicitly because
-      // `%o` would JSON-stringify an `Error` to `{}` (Errors carry their fields
-      // on non-enumerable properties).
-      const work = Promise.resolve(bot.handleUpdate(update)).catch((err: unknown) => {
-        const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
-        log("background handleUpdate failed for update %d: %s", update.update_id, detail);
-      });
-      if (waitUntil !== undefined) waitUntil(work);
-      log("update %d: acked 200, handling in background", update.update_id);
-      return new Response(null, { status: 200 });
-    }
-
-    // `handleUpdate` rejects only when a user-installed `bot.catch()` boundary
-    // throws (the default boundary logs and consumes the update). Honor that
-    // fail-loud opt-in with an explicit 500 - deterministic across runtimes,
-    // where an escaping rejection is handled differently by each (Bun.serve,
-    // Workers, the node:http adapters) - so Telegram redelivers the update.
-    try {
-      await bot.handleUpdate(update);
-    } catch (err) {
-      const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
-      log("handleUpdate failed for update %d: %s", update.update_id, detail);
-      return new Response("Internal Server Error", { status: 500 });
-    }
-    return new Response(null, { status: 200 });
+    return earlyAck ? dispatchInBackground(bot, update, waitUntil) : dispatchAwaiting(bot, update);
   };
 }

--- a/src/no-nullish-assign.grit
+++ b/src/no-nullish-assign.grit
@@ -1,0 +1,10 @@
+language js
+
+// Ban the logical-nullish-assignment operator (??=). Prefer an explicit
+// `if (x === undefined) x = y;` which is clearer and easier to step through.
+// Matches the assignment node's source text, so `??=` inside a string literal
+// on the right-hand side is a (rare) false positive.
+assignment_expression() as $a where {
+  $a <: r".*\?\?=.*",
+  register_diagnostic(span=$a, message="Avoid ??=; use an explicit `if (x === undefined) x = y;` instead.", severity="error")
+}

--- a/src/no-nullish-assign.grit
+++ b/src/no-nullish-assign.grit
@@ -2,9 +2,9 @@ language js
 
 // Ban the logical-nullish-assignment operator (??=). Prefer an explicit
 // `if (x === undefined) x = y;` which is clearer and easier to step through.
-// Matches the assignment node's source text, so `??=` inside a string literal
-// on the right-hand side is a (rare) false positive.
+// Matches the ??= token structurally (via `contains`), so a ??= inside a
+// string literal is not a false positive.
 assignment_expression() as $a where {
-  $a <: r".*\?\?=.*",
+  $a <: contains `??=`,
   register_diagnostic(span=$a, message="Avoid ??=; use an explicit `if (x === undefined) x = y;` instead.", severity="error")
 }

--- a/src/node/debug.ts
+++ b/src/node/debug.ts
@@ -21,8 +21,11 @@ export function compileDebugFilter(env: string): (namespace: string) => boolean 
   const names: RegExp[] = [];
   const skips: RegExp[] = [];
   for (const token of env.split(/[\s,]+/).filter(Boolean)) {
-    if (token.startsWith("-")) skips.push(toRegExp(token.slice(1)));
-    else names.push(toRegExp(token));
+    if (token.startsWith("-")) {
+      skips.push(toRegExp(token.slice(1)));
+    } else {
+      names.push(toRegExp(token));
+    }
   }
   return (namespace) =>
     names.some((re) => re.test(namespace)) && !skips.some((re) => re.test(namespace));

--- a/src/node/debug.ts
+++ b/src/node/debug.ts
@@ -24,7 +24,8 @@ export function compileDebugFilter(env: string): (namespace: string) => boolean 
     if (token.startsWith("-")) skips.push(toRegExp(token.slice(1)));
     else names.push(toRegExp(token));
   }
-  return (namespace) => names.some((re) => re.test(namespace)) && !skips.some((re) => re.test(namespace));
+  return (namespace) =>
+    names.some((re) => re.test(namespace)) && !skips.some((re) => re.test(namespace));
 }
 
 /** Turn one pattern (with `*` wildcards) into an anchored RegExp. */

--- a/src/node/file-session-storage.ts
+++ b/src/node/file-session-storage.ts
@@ -57,7 +57,9 @@ export class FileSessionStorage implements SessionStore {
     try {
       return await readFile(this.fileFor(key), "utf8");
     } catch (err) {
-      if ((err as { code?: string }).code === "ENOENT") return undefined;
+      if ((err as { code?: string }).code === "ENOENT") {
+        return undefined;
+      }
       throw err;
     }
   }
@@ -74,7 +76,9 @@ export class FileSessionStorage implements SessionStore {
     try {
       await unlink(this.fileFor(key));
     } catch (err) {
-      if ((err as { code?: string }).code !== "ENOENT") throw err;
+      if ((err as { code?: string }).code !== "ENOENT") {
+        throw err;
+      }
     }
   }
 }

--- a/src/node/from-path.ts
+++ b/src/node/from-path.ts
@@ -23,7 +23,10 @@ import { InputFile } from "../core/files.js";
  * the file for each transport retry. The default filename is the path's
  * basename; pass `meta.filename` / `meta.contentType` to override.
  */
-export async function fromPath(path: string, meta?: { filename?: string; contentType?: string }): Promise<InputFile> {
+export async function fromPath(
+  path: string,
+  meta?: { filename?: string; contentType?: string }
+): Promise<InputFile> {
   await stat(path); // surface a missing/unreadable path here, not mid-request
   const open = () => Readable.toWeb(createReadStream(path)) as ReadableStream<Uint8Array>;
   return new InputFile(open, {

--- a/src/node/run.ts
+++ b/src/node/run.ts
@@ -55,7 +55,7 @@ export async function run(bot: Bot, options: RunOptions = {}): Promise<void> {
   try {
     return await withShutdownSignals(
       () => bot.stop(),
-      () => bot.startPolling(undefined, pollOptions),
+      () => bot.startPolling(undefined, pollOptions)
     );
   } catch (err) {
     // Only the call that owns the pump reports and acts on the stop; a call that
@@ -64,7 +64,9 @@ export async function run(bot: Bot, options: RunOptions = {}): Promise<void> {
     if (owned) {
       failed = true;
       // Await the flush so the exit below can't truncate this diagnostic.
-      await writeStderr(`node-telegram-bot-api: polling stopped on a fatal error: ${String(err)}\n`);
+      await writeStderr(
+        `node-telegram-bot-api: polling stopped on a fatal error: ${String(err)}\n`
+      );
     }
     throw err;
   } finally {

--- a/src/node/run.ts
+++ b/src/node/run.ts
@@ -71,12 +71,16 @@ export async function run(bot: Bot, options: RunOptions = {}): Promise<void> {
     throw err;
   } finally {
     try {
-      if (owned) await bot.close();
+      if (owned) {
+        await bot.close();
+      }
     } finally {
       // Nested so it runs even when teardown throws: `exitOnError` must not be
       // defeated by the very stuck resource it exists to escape. Gated on
       // `failed` (which implies `owned`), so a losing double-run never exits.
-      if (failed && exitOnError) process.exit(1);
+      if (failed && exitOnError) {
+        process.exit(1);
+      }
     }
   }
 }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -138,7 +138,9 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
   let forceTimer: ReturnType<typeof setTimeout> | undefined;
   let shuttingDown = false;
   const stop = (): void => {
-    if (shuttingDown) return; // idempotent: a repeat signal must not schedule a second timer
+    if (shuttingDown) {
+      return; // idempotent: a repeat signal must not schedule a second timer
+    }
     shuttingDown = true;
     forceTimer = gracefulClose(server, shutdownTimeoutMs);
   };
@@ -152,6 +154,8 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
         })
     );
   } finally {
-    if (forceTimer) clearTimeout(forceTimer);
+    if (forceTimer) {
+      clearTimeout(forceTimer);
+    }
   }
 }

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -10,7 +10,11 @@
  */
 
 import http from "node:http";
-import { type NodeLikeRequest, type NodeLikeResponse, nodeFrameworkWebhook } from "../core/adapters.js";
+import {
+  type NodeLikeRequest,
+  type NodeLikeResponse,
+  nodeFrameworkWebhook,
+} from "../core/adapters.js";
 import type { Bot } from "../core/bot.js";
 import { debug } from "../core/debug.js";
 import type { WebhookOptions } from "../core/webhook.js";
@@ -47,21 +51,23 @@ export function createWebhookServer(bot: Bot, options: WebhookServerOptions = {}
     }
     // node:http's IncomingMessage / ServerResponse structurally satisfy the
     // core's NodeLike shapes.
-    handler(req as unknown as NodeLikeRequest, res as unknown as NodeLikeResponse).catch((err: unknown) => {
-      // Expected during a forced shutdown: `closeAllConnections()` destroys a
-      // socket whose request body was still arriving, so `readBody` rejects
-      // (ECONNRESET). Swallow it - an unhandled rejection here could crash the
-      // process mid-shutdown - and try a 500 while the socket is still writable.
-      log("handler error: %s", String(err));
-      if (!res.headersSent && res.writable) {
-        try {
-          res.statusCode = 500;
-          res.end();
-        } catch {
-          // socket already gone - nothing to send
+    handler(req as unknown as NodeLikeRequest, res as unknown as NodeLikeResponse).catch(
+      (err: unknown) => {
+        // Expected during a forced shutdown: `closeAllConnections()` destroys a
+        // socket whose request body was still arriving, so `readBody` rejects
+        // (ECONNRESET). Swallow it - an unhandled rejection here could crash the
+        // process mid-shutdown - and try a 500 while the socket is still writable.
+        log("handler error: %s", String(err));
+        if (!res.headersSent && res.writable) {
+          try {
+            res.statusCode = 500;
+            res.end();
+          } catch {
+            // socket already gone - nothing to send
+          }
         }
       }
-    });
+    );
   });
 }
 
@@ -83,7 +89,10 @@ const DEFAULT_SHUTDOWN_TIMEOUT = 10_000; // 10s, then force-close whatever is le
  * cancel it once `close` completes on its own. The connection helpers need Node
  * 18.2+ and are optional-chained so a non-Node runtime is a safe no-op.
  */
-export function gracefulClose(server: http.Server, timeoutMs: number): ReturnType<typeof setTimeout> {
+export function gracefulClose(
+  server: http.Server,
+  timeoutMs: number
+): ReturnType<typeof setTimeout> {
   server.close(); // stop accepting; resolves once existing connections end
   server.closeIdleConnections?.(); // drop idle keep-alive sockets now
   const forceTimer = setTimeout(() => server.closeAllConnections?.(), timeoutMs);
@@ -140,7 +149,7 @@ export async function startWebhook(bot: Bot, options: StartWebhookOptions): Prom
         new Promise<void>((resolve, reject) => {
           server.once("error", reject);
           server.once("close", () => resolve());
-        }),
+        })
     );
   } finally {
     if (forceTimer) clearTimeout(forceTimer);

--- a/src/node/signals.ts
+++ b/src/node/signals.ts
@@ -15,10 +15,14 @@ const SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM"] as const;
  * whether `body` resolves or throws.
  */
 export async function withShutdownSignals<T>(stop: () => void, body: () => Promise<T>): Promise<T> {
-  for (const sig of SHUTDOWN_SIGNALS) process.on(sig, stop);
+  for (const sig of SHUTDOWN_SIGNALS) {
+    process.on(sig, stop);
+  }
   try {
     return await body();
   } finally {
-    for (const sig of SHUTDOWN_SIGNALS) process.off(sig, stop);
+    for (const sig of SHUTDOWN_SIGNALS) {
+      process.off(sig, stop);
+    }
   }
 }

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -79,6 +79,23 @@ describe("webhookCallback", () => {
     assert.strictEqual(received.length, 0);
   });
 
+  test("valid JSON `null` body -> 400, handleUpdate not invoked", async () => {
+    const { bot, received } = fakeBot();
+    const handle = webhookCallback(bot, { secretToken: "s" });
+    const res = await handle(
+      new Request("https://h/hook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "s",
+        },
+        body: "null",
+      }),
+    );
+    assert.strictEqual(res.status, 400);
+    assert.strictEqual(received.length, 0);
+  });
+
   test("rejecting handleUpdate (a bot.catch() rethrow) -> explicit 500", async () => {
     // handleUpdate rejects only when the user's boundary rethrows (fail-loud
     // opt-in); the callback must answer 500 itself - Telegram then redelivers -


### PR DESCRIPTION
Sets up biome as a CI gate and brings `./src` into compliance.

## Changes

**1. Formatting gate** (`d1aafb5`)
- New read-only `lint:format` script + a "Formatting is clean" step in the Typecheck CI job. Also wired into `npm run check`.
- Formatter tightened: line width 120 -> 100, es5 trailing commas. `./src` reformatted to match (formatting-only).

**2. Config consolidation + `??=` ban** (`afeb90c`)
- Moved formatter config into a nested (`root:false`) `src/biome.json` that biome auto-discovers; `lint:format` simplified to `biome check ./src`.
- `src/no-nullish-assign.grit` GritQL plugin bans the `??=` operator in favor of an explicit `if (x === undefined) x = y;`.

**3. Cognitive-complexity rule + refactors** (`7db9e03`)
- Enabled `complexity/noExcessiveCognitiveComplexity` (max 15).
- Refactored the 5 functions that exceeded it into private helpers, no behavior change:

| Function | Before | After |
|---|---|---|
| `transport.ts` `request()` | 41 | 6 |
| `webhook.ts` `handle()` | 21 | ~4 |
| `bot.ts` `hears()` | 16 | <15 |
| `multipart.ts` `pieceChunks()` | 16 | ~3 |
| `ratelimiter.ts` `acquire()` | 16 | <15 |

Each refactor was checked behavior-preserving by an independent review pass (retry/backoff/error-type semantics, webhook status codes + secret compare, hears match-value semantics, multipart mid-flight cancel/teardown, ratelimiter LRU eviction).

## Verification

`npm run check` green: typecheck (x4), lint:core, lint:bun-isolation, check:edge, lint:format (format + complexity + `??=` ban), 248/248 unit tests.

## Note

One benign, non-blocking divergence in webhook: a request body of the literal JSON `null` now returns a clean 400 instead of a 500 (unreachable from Telegram; strictly more graceful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)